### PR TITLE
feat(radio): Add use_dio2_rf parameter for RF switch control

### DIFF
--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -48,6 +48,7 @@ class SX1262Radio(LoRaRadio):
         is_waveshare: bool = False,
         use_dio3_tcxo: bool = False,
         dio3_tcxo_voltage: float = 1.8,
+        use_dio2_rf: bool = False,
     ):
         """
         Initialize SX1262 radio
@@ -73,6 +74,7 @@ class SX1262Radio(LoRaRadio):
             is_waveshare: Use alternate initialization needed for Waveshare HAT
             use_dio3_tcxo: Enable DIO3 TCXO control (default: False)
             dio3_tcxo_voltage: TCXO reference voltage in volts (default: 1.8)
+            use_dio2_rf: Enable DIO2 as RF switch control (default: False)
         """
         # Check if there's already an active instance and clean it up
         if SX1262Radio._active_instance is not None:
@@ -105,6 +107,7 @@ class SX1262Radio(LoRaRadio):
         self.is_waveshare = is_waveshare
         self.use_dio3_tcxo = use_dio3_tcxo
         self.dio3_tcxo_voltage = dio3_tcxo_voltage
+        self.use_dio2_rf = use_dio2_rf
 
         # State variables
         self.lora: Optional[SX126x] = None
@@ -634,7 +637,9 @@ class SX1262Radio(LoRaRadio):
 
                 self.lora.setRegulatorMode(self.lora.REGULATOR_DC_DC)
                 self.lora.calibrate(0x7F)
-                self.lora.setDio2RfSwitch(False)
+                self.lora.setDio2RfSwitch(self.use_dio2_rf)
+                if self.use_dio2_rf:
+                    logger.info("DIO2 RF switch control enabled")
 
                 # Set packet type and frequency
                 rfFreq = int(self.frequency * 33554432 / 32000000)


### PR DESCRIPTION
## Summary
Add configurable DIO2 RF switch control to SX1262Radio class.

Some modules (e.g., certain E22 variants) require DIO2 to control the RF switch for TX/RX switching, independent of the DIO3 TCXO setting.

## Changes
- Add `use_dio2_rf` parameter to `__init__` (default: `False`)
- Wire through to `setDio2RfSwitch()` in `begin()`
- Add logging when DIO2 RF switch is enabled

## Usage
```python
radio = SX1262Radio(
    use_dio3_tcxo=True,   # Independent TCXO control
    use_dio2_rf=True,     # Enable DIO2 RF switch
    # ... other params
)
```

## Related
- pyMC_Repeater PR for config support (pending)

Co-Authored-By: Warp <agent@warp.dev>