### PR TITLE
Bugfix/initial rx en pin state

### DIFF
--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -537,6 +537,11 @@ class SX1262Radio(LoRaRadio):
                 else:
                     logger.warning(f"Could not setup RXEN pin {self.rxen_pin}")
 
+            # Ensure TX/RX pins are in default state (RX mode)
+            if self.txen_pin != -1 or self.rxen_pin != -1:
+                self._control_tx_rx_pins(tx_mode=False)
+                logger.debug("TX/RX control pins set to RX mode")
+
             # Setup LED pins if specified
             if self.txled_pin != -1 and not self._txled_pin_setup:
                 if self._gpio_manager.setup_output_pin(self.txled_pin, initial_value=False):


### PR DESCRIPTION
Without this fix, both rx_en and tx_en pins will be driven low when they are initialized as outputs.
This means the RF switch is in TX mode, while rx_en needs to be high to be in RX mode.
The situation resolves itself after the first time the radio sends something, however until then the RF switch sits in TX mode, while it should be RX.