### PR TITLE
Fix MAX_ADVERT_DATA_SIZE and MAX_PACKET_PAYLOAD

### DIFF
--- a/src/pymc_core/protocol/constants.py
+++ b/src/pymc_core/protocol/constants.py
@@ -45,13 +45,13 @@ MAX_SUPPORTED_PAYLOAD_VERSION = PAYLOAD_VER_2  # Accept versions 0-1
 # ---------------------------------------------------------------------------
 # Misc sizes
 # ---------------------------------------------------------------------------
-MAX_ADVERT_DATA_SIZE = 96
+MAX_ADVERT_DATA_SIZE = 32
 PUB_KEY_SIZE = 32
 SIGNATURE_SIZE = 64
 PATH_HASH_SIZE = 1
 CIPHER_MAC_SIZE = 32  # SHA‑256 HMAC
 CIPHER_BLOCK_SIZE = 16
-MAX_PACKET_PAYLOAD = 256  # firmware's default
+MAX_PACKET_PAYLOAD = 184  # firmware's default
 
 MAX_PATH_SIZE = 64
 MAX_PACKET_PAYLOAD = 256

--- a/src/pymc_core/protocol/constants.py
+++ b/src/pymc_core/protocol/constants.py
@@ -54,7 +54,6 @@ CIPHER_BLOCK_SIZE = 16
 MAX_PACKET_PAYLOAD = 184  # firmware's default
 
 MAX_PATH_SIZE = 64
-MAX_PACKET_PAYLOAD = 256
 MAX_HASH_SIZE = 32  # SHA-256 truncated
 
 NAME_MAX_LEN = 16  # Max length of a contact name


### PR DESCRIPTION
MAX_PACKET_PAYLOAD must be 184, see (https://github.com/meshcore-dev/MeshCore/blob/main/docs/packet_structure.md).

MAX_ADVERT_DATA_SIZE must be 32. Even though the protocol isn't clear (https://github.com/meshcore-dev/MeshCore/blob/main/docs/payloads.md), Meshcore imposes a limit of 32 bytes (https://github.com/meshcore-dev/MeshCore/blob/main/src/MeshCore.h).

This fixes pyMC_core sending adverts longer than 32 bytes which get silently (!) dropped by other repeaters, the Companion App or Letsmesh.
With the current limits, the following situations will lead to this event:
- A node name longer than 23 characters with GPS location included
- A node name longer than 31 characters without GPS location