### PR TITLE
Add support for Femtofox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 radio = ["pyserial>=3.5"]
 hardware = [
     "python-periphery>=2.4.1",
+    "gpiod>=2.4.0",
     "spidev>=3.5",
     "pyserial>=3.5",
 ]


### PR DESCRIPTION
This change implements the following necessary to support the [Femtofox](https://github.com/femtofox/femtofox):

- Introduce gpiod as a GPIO_manager backend (The Femtofox runs on a rockchip linux 5.10 kernel with no GPIO CDEV V2 support)
- Implement IRQ pin polling (as yet again, the above)
- Introduce GPIO chip selection