### PR TITLE
Adjust periphery implementation to not set GPIO V2 real-time flag

### DIFF
--- a/src/pymc_core/hardware/gpio_manager.py
+++ b/src/pymc_core/hardware/gpio_manager.py
@@ -14,6 +14,9 @@ from typing import Callable, Dict, Optional
 
 try:
     from periphery import GPIO, EdgeEvent
+    # We don't need the realtime event clock for our use case and it breaks support on older kernels, so disable it if present
+    import periphery.gpio_cdev2 as _cdev
+    _cdev.Cdev2GPIO._GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME = 0
     PERIPHERY_AVAILABLE = True
 except ImportError:
     # Mock GPIO classes for testing/non-hardware environments


### PR DESCRIPTION
After further digging at the core issue with older kernels I discovered that the root cause relates to GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME being set when edge detection is used

https://github.com/vsergeev/python-periphery/blob/master/periphery/gpio_cdev2.py#L261C13-L261C19

GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME seems to have been added into the linux kernel in 5.16 or so. A lot of Rockchip boards still use 5.10.~

Given we do not seem to need timestamps for the interrupts its not necessary to have this flag set. And given that python-periphery is not actively maintained (it seems) it is easier to make the change here for our use case, but i'll update an existing issue upstream to see if there is a way they can implement a fix.

I expect that after some longer testing, we may be able to remove the gpiod implementation I added previously as this will allow luckfox and other rockchip devices to just use python-periphery