### PR TITLE
feat(companion, dispatcher): implement path hash mode for flood packets

### DIFF
--- a/docs/docs/api/node.md
+++ b/docs/docs/api/node.md
@@ -2,6 +2,34 @@
 
 This section documents the node management classes and functions in pyMC_Core.
 
+## Dispatcher default path hash mode
+
+The dispatcher can apply a **default path hash mode** to flood packets with 0 hops
+that have not already had path hash mode set by the companion. This allows
+packets built without the companion (e.g. ``PacketBuilder.create_flood_advert()``
+and ``send_packet()``) to use 2- or 3-byte path hashes when the host sets a default.
+
+- **``path_hash_mode``**: ``Optional[int] = None`` — 0=1-byte, 1=2-byte, 2=3-byte; ``None`` disables.
+- **``set_default_path_hash_mode(mode)``**: Set or clear the default; ``mode`` must be ``None``, 0, 1, or 2.
+
+The default is applied only to flood-routed packets with 0 hops. Packets that
+already have path hash mode applied by the companion (marked with
+``_path_hash_mode_applied``) are never overwritten.
+
+**TRACE and flood:** The TRACE payload type is only sent via direct routing in the
+firmware (path/SNR in payload, ``path_len = 0``). Flood TRACE is explicitly
+unsupported. If ``send_packet()`` is called with a packet that is both
+flood-routed and TRACE payload type, the dispatcher does not transmit and
+returns ``False``.
+
+**Repeater forwarding:** When implementing repeater-style forwarding of packets as
+flood (e.g. path-return or reply floods), preserve the incoming packet's path
+hash size on the outgoing packet so repeaters use the same 1-, 2-, or 3-byte
+path hashes. For example: use ``incoming.get_path_hash_size()`` and call
+``outgoing.apply_path_hash_mode(size - 1)`` when building the reply (mode 0=1-byte,
+1=2-byte, 2=3-byte). This matches firmware behavior where
+``sendFlood(..., packet->getPathHashSize())`` is used when forwarding.
+
 ## MeshNode
 
 ::: pymc_core.node.node.MeshNode

--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -282,6 +282,12 @@ companion.set_radio_params(915_000_000, 250_000, 10, 5)  # freq, bw, SF, CR
 companion.set_tx_power(22)                                # dBm
 companion.set_tuning_params(rx_delay=0.0, airtime_factor=0.0)
 
+# Path hash mode for flood packets: 0=1-byte, 1=2-byte, 2=3-byte per hop (repeaters
+# use this to decide how many bytes to append when forwarding). Applied to all
+# companion-originated flood packets with 0 hops. Set via CMD_SET_PATH_HASH_MODE on
+# the frame server.
+companion.set_path_hash_mode(1)   # use 2-byte path hashes
+
 # Fetch current radio configuration (frequency, bandwidth, SF, CR, TX power, tuning)
 radio_params = companion.get_radio_params()
 # {'frequency_hz': 915000000, 'bandwidth_hz': 250000, 'spreading_factor': 10, ...}
@@ -309,6 +315,13 @@ companion.set_other_params(
 
 prefs = companion.get_self_info()   # -> NodePrefs (copy)
 ```
+
+Originated flood packets (including adverts) set the high bits of the packet's
+``path_len`` byte so repeaters know how many bytes to append when forwarding
+(1-, 2-, or 3-byte path hashes). The companion applies its ``path_hash_mode``
+preference to all such packets with zero hops via ``set_path_hash_mode()``;
+the frame server exposes this as CMD_SET_PATH_HASH_MODE and reports it in
+device info (byte 81).
 
 ### Flood Scope (Regions)
 
@@ -365,6 +378,7 @@ stats = companion.get_stats(STATS_TYPE_PACKETS)
 | `set_advert_name()` | Updates `prefs.node_name` | Also syncs `node.node_name` |
 | `set_flood_scope()` | Stores transport key | Also syncs to `node.dispatcher` |
 | `set_flood_region()` | Derives key from name | Also syncs to `node.dispatcher` |
+| `set_path_hash_mode()` | Updates `prefs.path_hash_mode` | Also syncs to `node.dispatcher.set_default_path_hash_mode()` |
 
 ---
 
@@ -904,7 +918,10 @@ class NodePrefs:
     rx_delay_base: float = 0.0
     airtime_factor: float = 0.0
     client_repeat: int = 0   # reported in CMD_DEVICE_QUERY device info frame (byte 80)
+    path_hash_mode: int = 0   # 0=1-byte, 1=2-byte, 2=3-byte path hashes for flood packets (byte 81)
 ```
+
+---
 
 ### SentResult
 

--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -557,11 +557,11 @@ CompanionFrameServer(
     stats_getter: Callable | None = None,
     control_handler: Any | None = None,
     heartbeat_interval: int = 15,      # seconds between keepalive frames
-    client_idle_timeout_sec: int = 120,  # no data from client → disconnect and free slot
+    client_idle_timeout_sec: int | None = 120,  # no data from client → disconnect; None = no timeout (firmware behaviour)
 )
 ```
 
-**Connection management:** Only one client is allowed at a time. If a new connection arrives while one is already active, the server closes the existing connection and accepts the new one (same as firmware). If the client disappears without closing (e.g. kill, network drop), the slot is freed after no data is received for `client_idle_timeout_sec` seconds (default 120). Operators can tune this timeout to avoid dropping slow but live clients.
+**Connection management:** Only one client is allowed at a time. If a new connection arrives while one is already active, the server closes the existing connection and accepts the new one (same as firmware). If the client disappears without closing (e.g. kill, network drop), the slot is freed after no data is received for `client_idle_timeout_sec` seconds (default 120). Pass `None` to disable the idle timeout (no disconnect on idle, matching firmware). Operators can tune this timeout to avoid dropping slow but live clients.
 
 ### Supported Commands
 

--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -29,7 +29,6 @@ from ..protocol.constants import (
     MAX_PACKET_PAYLOAD,
     MAX_PATH_SIZE,
     PAYLOAD_TYPE_CONTROL,
-    PAYLOAD_TYPE_TRACE,
     REQ_TYPE_GET_STATUS,
     REQ_TYPE_GET_TELEMETRY_DATA,
     ROUTE_TYPE_FLOOD,
@@ -584,15 +583,9 @@ class CompanionBase(ABC):
         Packets with existing hops (stored contact paths) are untouched.
         Trace packets are excluded because the repeater's trace handler uses
         ``path``/``path_len`` to store SNR values, not routing hashes.
-
-        Mirrors firmware ``sendFlood(pkt, delay, _prefs.path_hash_mode + 1)``
-        which calls ``pkt->setPathHashSizeAndCount(hash_size, 0)``.
+        Sets ``_path_hash_mode_applied`` so the dispatcher does not overwrite.
         """
-        if pkt.get_payload_type() == PAYLOAD_TYPE_TRACE:
-            return
-        if pkt.get_path_hash_count() == 0:
-            hash_size = self.prefs.path_hash_mode + 1
-            pkt.path_len = PathUtils.encode_path_len(hash_size, 0)
+        pkt.apply_path_hash_mode(self.prefs.path_hash_mode, mark_applied=True)
 
     # -------------------------------------------------------------------------
     # Statistics (subclasses may override _get_radio_stats for STATS_TYPE_RADIO)

--- a/src/pymc_core/companion/companion_radio.py
+++ b/src/pymc_core/companion/companion_radio.py
@@ -125,6 +125,7 @@ class CompanionRadio(CompanionBase):
             logger.warning("CompanionRadio already running")
             return
         self._running = True
+        self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
         self._dispatcher_task = asyncio.create_task(self.node.start())
         logger.info(
             f"CompanionRadio started: name={self.prefs.node_name}, "
@@ -164,6 +165,11 @@ class CompanionRadio(CompanionBase):
         """Set flood region and propagate to the dispatcher."""
         super().set_flood_region(region_name)
         self.node.dispatcher.flood_transport_key = self._flood_transport_key
+
+    def set_path_hash_mode(self, mode: int) -> None:
+        """Set path hash mode and sync to dispatcher default."""
+        super().set_path_hash_mode(mode)
+        self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
 
     # -------------------------------------------------------------------------
     # Device Configuration (overrides for radio hardware)

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -166,8 +166,10 @@ class CompanionFrameServer:
 
     One client per companion at a time.  If a new connection arrives while
     one is already active, the existing connection is closed and the new
-    one is accepted (eviction). An idle read timeout (client_idle_timeout_sec)
-    frees the slot when no data is received. Persistence is handled through
+    one is accepted (eviction). An optional idle read timeout
+    (client_idle_timeout_sec) frees the slot when no data is received; pass
+    None to disable (no disconnect on idle, matching firmware behaviour).
+    Persistence is handled through
     overridable hook methods; the base class works with in-memory stores only.
     """
 
@@ -185,7 +187,7 @@ class CompanionFrameServer:
         stats_getter: Optional[Callable] = None,
         control_handler: Optional[Any] = None,
         heartbeat_interval: int = 15,
-        client_idle_timeout_sec: int = 120,
+        client_idle_timeout_sec: Optional[int] = 120,
     ):
         self.bridge = bridge
         self.companion_hash = companion_hash
@@ -840,6 +842,7 @@ class CompanionFrameServer:
     async def _handle_cmd(self, payload: bytes) -> None:
         """Dispatch command to handler."""
         if not payload:
+            self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
         cmd = payload[0]
         data = payload[1:]
@@ -1569,6 +1572,9 @@ class CompanionFrameServer:
                 ch = self.bridge.get_channel(idx)
                 frame = _channel_info_frame(idx, ch)
                 self._write_frame(frame)
+            if max_channels_val == 0:
+                # Send at least one frame so client always gets a response per command
+                self._write_frame(_channel_info_frame(0, None))
             return
 
         if channel_idx < 0 or channel_idx >= max_channels_val:

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -657,7 +657,9 @@ class CompanionFrameServer:
     # Must exceed DEFAULT_MAX_CONTACTS (+2 for START/END) so that
     # _cmd_get_contacts can enqueue the full contact dump without drops.
     _WRITE_QUEUE_MAXSIZE = 2048
-    _DRAIN_BATCH = 10
+    # Drain after every frame so clients that count one TCP receive per response
+    # (e.g. _receive_count per data_received()) stay in sync with sends.
+    _DRAIN_BATCH = 1
 
     async def _writer_loop(self, writer: asyncio.StreamWriter) -> None:
         """Single writer task: pull frames from the queue, write to the
@@ -1039,7 +1041,8 @@ class CompanionFrameServer:
         if ok:
             self._write_ok()
         else:
-            self._write_err(ERR_CODE_BAD_STATE)
+            # Firmware uses ERR_CODE_NOT_FOUND for both bad channel and sendGroupMessage failure
+            self._write_err(ERR_CODE_NOT_FOUND)
 
     async def _cmd_send_binary_req(self, data: bytes) -> None:
         if len(data) < 33:

--- a/src/pymc_core/node/dispatcher.py
+++ b/src/pymc_core/node/dispatcher.py
@@ -9,6 +9,7 @@ from ..protocol import Packet
 from ..protocol.constants import (  # Payload types
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
+    PAYLOAD_TYPE_TRACE,
     PH_TYPE_SHIFT,
     ROUTE_TYPE_FLOOD,
     ROUTE_TYPE_TRANSPORT_FLOOD,
@@ -94,6 +95,11 @@ class Dispatcher:
         # When set, flood packets are tagged with a transport code and sent
         # as ROUTE_TYPE_TRANSPORT_FLOOD.  Set via companion set_flood_scope().
         self.flood_transport_key: Optional[bytes] = None
+
+        # Default path hash mode for flood packets with 0 hops that have not
+        # had path hash mode set by the companion. 0=1-byte, 1=2-byte, 2=3-byte.
+        # When None, no default is applied.
+        self.path_hash_mode: Optional[int] = None
 
         self._logger = logging.getLogger("Dispatcher")
         self._current_expected_crc: Optional[int] = None
@@ -464,6 +470,33 @@ class Dispatcher:
         pkt.transport_codes[1] = 0  # reserved for home region
         pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD
 
+    def set_default_path_hash_mode(self, mode: Optional[int]) -> None:
+        """Set or clear the default path hash mode for flood packets with 0 hops.
+
+        When set, packets sent via send_packet() that have not already had path
+        hash mode applied (e.g. by the companion) will get path_len bits 6-7
+        set from this mode. Companion-originated packets are never overwritten.
+
+        Args:
+            mode: 0=1-byte, 1=2-byte, 2=3-byte per hop; None to disable.
+        """
+        if mode is not None and mode not in (0, 1, 2):
+            raise ValueError(f"path_hash_mode must be None, 0, 1, or 2, got {mode}")
+        self.path_hash_mode = mode
+
+    def _apply_default_path_hash_mode(self, pkt: Packet) -> None:
+        """Apply dispatcher default path hash mode if set and packet is eligible."""
+        if self.path_hash_mode is None:
+            return
+        route_type = pkt.get_route_type()
+        if route_type not in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD):
+            return
+        if pkt.get_path_hash_count() != 0:
+            return
+        if getattr(pkt, "_path_hash_mode_applied", False):
+            return
+        pkt.apply_path_hash_mode(self.path_hash_mode, mark_applied=False)
+
     async def send_packet(
         self,
         packet: Packet,
@@ -480,7 +513,14 @@ class Dispatcher:
             expected_crc: The expected CRC for ACK matching.
                 If None, will be calculated from packet.
         """
+        # TRACE is only sent via sendDirect() in firmware; flood TRACE is unsupported.
+        route_type = packet.get_route_type()
+        if route_type in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD):
+            if packet.get_payload_type() == PAYLOAD_TYPE_TRACE:
+                self._log("TRACE not supported for flood; dropping")
+                return False
         self._apply_flood_scope(packet)
+        self._apply_default_path_hash_mode(packet)
         async with self._tx_lock:  # Wait our turn
             return await self._send_packet_immediate(packet, wait_for_ack, expected_crc)
 

--- a/src/pymc_core/protocol/packet.py
+++ b/src/pymc_core/protocol/packet.py
@@ -2,6 +2,7 @@ from typing import ByteString, Optional
 
 from .constants import (
     MAX_SUPPORTED_PAYLOAD_VERSION,
+    PAYLOAD_TYPE_TRACE,
     PH_ROUTE_MASK,
     PH_TYPE_MASK,
     PH_TYPE_SHIFT,
@@ -113,6 +114,7 @@ class Packet:
         "_do_not_retransmit",
         "drop_reason",
         "_tx_metadata",
+        "_path_hash_mode_applied",
     )
 
     def __init__(self):
@@ -135,6 +137,7 @@ class Packet:
         # Repeater flag to prevent retransmission and log drop reason
         self._do_not_retransmit = False
         self.drop_reason = None  # Optional: reason for dropping packet
+        self._path_hash_mode_applied = False
 
     def get_route_type(self) -> int:
         """
@@ -217,6 +220,36 @@ class Packet:
     def get_path_byte_len(self) -> int:
         """Calculate actual path byte length from the encoded path_len byte."""
         return PathUtils.get_path_byte_len(self.path_len)
+
+    def apply_path_hash_mode(
+        self,
+        mode: int,
+        *,
+        mark_applied: bool = False,
+    ) -> None:
+        """Set path_len bits 6-7 from path_hash_mode for 0-hop packets (skip TRACE).
+
+        Used by companion and dispatcher so the rule lives in one place. TRACE
+        packets are excluded because the repeater's trace handler uses path/path_len
+        for SNR values, not routing hashes.
+
+        Args:
+            mode: Path hash mode: 0=1-byte, 1=2-byte, 2=3-byte per hop.
+            mark_applied: If True, set _path_hash_mode_applied so dispatcher
+                does not overwrite (used when companion applies its preference).
+
+        Raises:
+            ValueError: If mode not in (0, 1, 2).
+        """
+        if mode not in (0, 1, 2):
+            raise ValueError(f"path_hash_mode must be 0, 1, or 2, got {mode}")
+        if self.get_payload_type() == PAYLOAD_TYPE_TRACE:
+            return
+        if self.get_path_hash_count() != 0:
+            return
+        self.path_len = PathUtils.encode_path_len(mode + 1, 0)
+        if mark_applied:
+            self._path_hash_mode_applied = True
 
     def get_path_hashes(self) -> list:
         """Return path as a list of per-hop hash entries (1, 2, or 3 bytes each).

--- a/src/pymc_core/protocol/utils.py
+++ b/src/pymc_core/protocol/utils.py
@@ -10,6 +10,7 @@ from .constants import (
     ADVERT_FLAG_IS_CHAT_NODE,
     ADVERT_FLAG_IS_REPEATER,
     ADVERT_FLAG_IS_ROOM_SERVER,
+    ADVERT_FLAG_IS_SENSOR,
     PUB_KEY_SIZE,
     SIGNATURE_SIZE,
     TIMESTAMP_SIZE,
@@ -65,6 +66,8 @@ def describe_advert_flags(flags: int) -> str:
         labels.append("is repeater")
     if flags & ADVERT_FLAG_IS_ROOM_SERVER:
         labels.append("is room server")
+    if flags & ADVERT_FLAG_IS_SENSOR:
+        labels.append("is sensor")
     if flags & ADVERT_FLAG_HAS_LOCATION:
         labels.append("has location")
     if flags & ADVERT_FLAG_HAS_FEATURE1:
@@ -148,21 +151,22 @@ def determine_contact_type_from_flags(flags: int) -> int:
         ADVERT_FLAG_IS_CHAT_NODE,
         ADVERT_FLAG_IS_REPEATER,
         ADVERT_FLAG_IS_ROOM_SERVER,
+        ADVERT_FLAG_IS_SENSOR,
     )
 
     # Extract node type from bits 0-3 (mask with 0x0F)
     node_type = flags & 0x0F
 
     if node_type == ADVERT_FLAG_IS_ROOM_SERVER:  # 0x03
-        return 3  # CONTACT_TYPE_ROOM_SERVER
+        return 3  # ADV_TYPE_ROOM
     elif node_type == ADVERT_FLAG_IS_REPEATER:  # 0x02
-        return 2  # CONTACT_TYPE_REPEATER
+        return 2  # ADV_TYPE_REPEATER
     elif node_type == ADVERT_FLAG_IS_CHAT_NODE:  # 0x01
-        return 1  # CONTACT_TYPE_CHAT_NODE
-    elif node_type == 0x04:  # Sensor (if defined)
-        return 5  # CONTACT_TYPE_SENSOR (you may need to add this constant)
+        return 1  # ADV_TYPE_CHAT
+    elif node_type == ADVERT_FLAG_IS_SENSOR:  # 0x04
+        return 4  # ADV_TYPE_SENSOR
     else:
-        return 0  # CONTACT_TYPE_UNKNOWN
+        return 0  # unknown
 
 
 def get_contact_type_name(contact_type: int) -> str:

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -19,6 +19,7 @@ from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_TRACE,
     ROUTE_TYPE_DIRECT,
 )
+from pymc_core.protocol.utils import determine_contact_type_from_flags, get_contact_type_name
 
 # ---------------------------------------------------------------------------
 # ResponseWaiter
@@ -79,6 +80,25 @@ class TestAdvTypeToFlags:
     def test_unknown_defaults_to_chat(self):
         assert adv_type_to_flags(99) == ADVERT_FLAG_IS_CHAT_NODE
         assert adv_type_to_flags(0) == ADVERT_FLAG_IS_CHAT_NODE
+
+
+class TestDetermineContactTypeFromFlags:
+    """Wire advert flags (low nibble) map to ADV_TYPE_* (1=chat, 2=repeater, 3=room, 4=sensor)."""
+
+    def test_sensor_flags_map_to_adv_type_sensor(self):
+        assert determine_contact_type_from_flags(0x04) == ADV_TYPE_SENSOR
+        assert determine_contact_type_from_flags(0x14) == ADV_TYPE_SENSOR  # with HAS_LOCATION
+        assert get_contact_type_name(4) == "Sensor"
+
+    def test_all_node_types(self):
+        assert determine_contact_type_from_flags(0x01) == ADV_TYPE_CHAT
+        assert determine_contact_type_from_flags(0x02) == ADV_TYPE_REPEATER
+        assert determine_contact_type_from_flags(0x03) == ADV_TYPE_ROOM
+        assert determine_contact_type_from_flags(0x04) == ADV_TYPE_SENSOR
+
+    def test_unknown(self):
+        assert determine_contact_type_from_flags(0x05) == 0
+        assert determine_contact_type_from_flags(0) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -175,3 +195,17 @@ class TestApplyPathHashMode:
         assert pkt.path_len == 0
         assert pkt.get_path_hash_size() == 1
         assert pkt.get_path_hash_count() == 0
+
+    def test_sets_path_hash_mode_applied_marker(self):
+        """Companion sets _path_hash_mode_applied so dispatcher does not overwrite."""
+        bridge = _make_bridge(path_hash_mode=1)
+        pkt = Packet()
+        pkt.header = 0x06
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"x")
+        pkt.payload_len = 1
+
+        bridge._apply_path_hash_mode(pkt)
+
+        assert getattr(pkt, "_path_hash_mode_applied", False) is True

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -5,7 +5,14 @@ import pytest
 
 from pymc_core.node.dispatcher import Dispatcher, DispatcherState
 from pymc_core.protocol import Packet
-from pymc_core.protocol.constants import PAYLOAD_TYPE_ACK, PAYLOAD_TYPE_ADVERT, PAYLOAD_TYPE_TXT_MSG
+from pymc_core.protocol.constants import (
+    PAYLOAD_TYPE_ACK,
+    PAYLOAD_TYPE_ADVERT,
+    PAYLOAD_TYPE_TRACE,
+    PAYLOAD_TYPE_TXT_MSG,
+    ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
+)
 from pymc_core.protocol.packet_filter import PacketFilter
 from pymc_core.protocol.packet_utils import PathUtils
 
@@ -355,6 +362,93 @@ class TestDispatcherSendPacket:
 
         assert result is True
         dispatcher.radio.transmit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_path_hash_mode_applied_to_flood_packet(self, dispatcher):
+        """When path_hash_mode is set, flood packets with 0 hops get path_len bits 6-7 set."""
+        from pymc_core.protocol.constants import PH_TYPE_SHIFT
+
+        dispatcher.set_default_path_hash_mode(1)  # 2-byte hashes
+        pkt = Packet()
+        pkt.header = (1 << 6) | (PAYLOAD_TYPE_ADVERT << PH_TYPE_SHIFT) | ROUTE_TYPE_FLOOD
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"advert_payload")
+        pkt.payload_len = len(pkt.payload)
+
+        await dispatcher.send_packet(pkt)
+
+        raw = dispatcher.radio.tx_data
+        assert raw is not None
+        path_len_byte = raw[1]
+        assert path_len_byte == 0x40
+
+    @pytest.mark.asyncio
+    async def test_path_hash_mode_not_overwritten_when_companion_applied(self, dispatcher):
+        """Packet with _path_hash_mode_applied is not overwritten by dispatcher default."""
+        from pymc_core.protocol.constants import PH_TYPE_SHIFT
+
+        dispatcher.set_default_path_hash_mode(2)  # 3-byte
+        pkt = Packet()
+        pkt.header = (1 << 6) | (PAYLOAD_TYPE_ADVERT << PH_TYPE_SHIFT) | ROUTE_TYPE_FLOOD
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"x")
+        pkt.payload_len = 1
+        pkt.apply_path_hash_mode(1, mark_applied=True)
+
+        await dispatcher.send_packet(pkt)
+
+        raw = dispatcher.radio.tx_data
+        assert raw is not None
+        path_len_byte = raw[1]
+        assert path_len_byte == 0x40
+
+    @pytest.mark.asyncio
+    async def test_trace_flood_rejected(self, dispatcher):
+        """TRACE payload with flood route is rejected; send_packet returns False and no TX."""
+        from pymc_core.protocol.constants import PH_TYPE_SHIFT
+
+        pkt = Packet()
+        pkt.header = (1 << 6) | (PAYLOAD_TYPE_TRACE << PH_TYPE_SHIFT) | ROUTE_TYPE_FLOOD
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00")  # tag, auth, flags
+        pkt.payload_len = len(pkt.payload)
+
+        result = await dispatcher.send_packet(pkt)
+
+        assert result is False
+        assert dispatcher.radio.tx_data is None
+
+    @pytest.mark.asyncio
+    async def test_trace_direct_still_sends(self, dispatcher):
+        """TRACE with direct route is still sent (no regression)."""
+        from pymc_core.protocol.constants import PH_TYPE_SHIFT
+
+        pkt = Packet()
+        pkt.header = (1 << 6) | (PAYLOAD_TYPE_TRACE << PH_TYPE_SHIFT) | ROUTE_TYPE_DIRECT
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+        pkt.payload_len = len(pkt.payload)
+
+        result = await dispatcher.send_packet(pkt, wait_for_ack=False)
+
+        assert result is True
+        assert dispatcher.radio.tx_data is not None
+
+    def test_set_default_path_hash_mode_validates(self, dispatcher):
+        """set_default_path_hash_mode accepts None, 0, 1, 2 and rejects other values."""
+        dispatcher.set_default_path_hash_mode(None)
+        assert dispatcher.path_hash_mode is None
+        for mode in (0, 1, 2):
+            dispatcher.set_default_path_hash_mode(mode)
+            assert dispatcher.path_hash_mode == mode
+        with pytest.raises(ValueError, match="path_hash_mode must be None, 0, 1, or 2"):
+            dispatcher.set_default_path_hash_mode(3)
+        with pytest.raises(ValueError, match="path_hash_mode must be None, 0, 1, or 2"):
+            dispatcher.set_default_path_hash_mode(-1)
 
     @pytest.mark.asyncio
     async def test_send_packet_failure(self, dispatcher):


### PR DESCRIPTION
- Added `set_path_hash_mode` method to CompanionBase and CompanionRadio to configure path hash mode for flood packets.
- Introduced default path hash mode in Dispatcher for flood packets with 0 hops, allowing compatibility with packets built without the companion.
- Updated Packet class to apply path hash mode and prevent overwriting when already set by the companion.
- Enhanced tests to validate path hash mode functionality and ensure correct behavior for flood packets and TRACE payloads.