### PR TITLE
Improve writer task management and update ProtocolRequestHandler

### DIFF
--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -764,6 +764,16 @@ class CompanionFrameServer:
                 self.port,
             )
             old_writer = self._client_writer
+            # Cancel and await the old writer task so it's fully gone before we replace
+            # the queue and create a new task (avoids the new task being mistaken for
+            # a failed writer when the old task had already exited).
+            if self._writer_task is not None:
+                self._writer_task.cancel()
+                try:
+                    await self._writer_task
+                except asyncio.CancelledError:
+                    pass
+                self._writer_task = None
             try:
                 old_writer.close()
                 await old_writer.wait_closed()
@@ -802,8 +812,17 @@ class CompanionFrameServer:
                     break
                 payload = await reader.readexactly(frame_len)
                 await self._handle_cmd(payload)
-                if self._writer_task.done():
+                if self._writer_task is None or self._writer_task.done():
                     disconnect_reason = "writer_failed"
+                    if self._writer_task is not None and self._writer_task.done():
+                        exc = self._writer_task.exception()
+                        if exc is not None:
+                            logger.error(
+                                "Writer task failed (port=%s): %s",
+                                self.port,
+                                exc,
+                                exc_info=True,
+                            )
                     break
         except asyncio.IncompleteReadError:
             disconnect_reason = "incomplete_read"

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -812,10 +812,11 @@ class CompanionFrameServer:
                     break
                 payload = await reader.readexactly(frame_len)
                 await self._handle_cmd(payload)
-                if self._writer_task is None or self._writer_task.done():
+                writer_task = self._writer_task
+                if writer_task is None or writer_task.done():
                     disconnect_reason = "writer_failed"
-                    if self._writer_task is not None and self._writer_task.done():
-                        exc = self._writer_task.exception()
+                    if writer_task is not None and writer_task.done():
+                        exc = writer_task.exception()
                         if exc is not None:
                             logger.error(
                                 "Writer task failed (port=%s): %s",

--- a/src/pymc_core/node/handlers/__init__.py
+++ b/src/pymc_core/node/handlers/__init__.py
@@ -9,6 +9,7 @@ from .control import ControlHandler
 from .group_text import GroupTextHandler
 from .login_response import AnonReqResponseHandler, LoginResponseHandler
 from .path import PathHandler
+from .protocol_request import ProtocolRequestHandler
 from .protocol_response import ProtocolResponseHandler
 from .registry import CoreHandlers, create_core_handlers
 from .text import TextMessageHandler
@@ -22,6 +23,7 @@ __all__ = [
     "PathHandler",
     "GroupTextHandler",
     "LoginResponseHandler",
+    "ProtocolRequestHandler",
     "ProtocolResponseHandler",
     "AnonReqResponseHandler",
     "TraceHandler",

--- a/src/pymc_core/node/handlers/protocol_request.py
+++ b/src/pymc_core/node/handlers/protocol_request.py
@@ -205,14 +205,8 @@ class ProtocolRequestHandler:
         """
         Build RESPONSE packet to send back to client.
 
-        Args:
-            original_packet: Original REQ packet
-            client: Client info
-            response_data: Response payload (includes timestamp)
-            shared_secret: Encryption secret
-
-        Returns:
-            Packet: RESPONSE packet ready to send
+        Matches simple_repeater firmware: REQ via flood → path-return PATH via flood;
+        REQ via direct → RESPONSE via direct (if client out_path) else RESPONSE via flood.
         """
         try:
             # Get client identity
@@ -228,12 +222,51 @@ class ProtocolRequestHandler:
                 )
                 client_identity = Identity(pk)
 
-            # Decide routing based on out_path_len if available
-            route_type = "direct"
-            if hasattr(client, "out_path_len") and client.out_path_len < 0:
-                route_type = "flood"
+            client_hash = client_identity.get_public_key()[0]
+            our_hash = self.local_identity.get_public_key()[0]
 
-            # Create RESPONSE datagram
+            # REQ via flood → path-return PATH (firmware: createPathReturn + sendFlood)
+            if getattr(original_packet, "is_route_flood", lambda: False)():
+                path_len_byte = getattr(original_packet, "path_len", 0)
+                path_byte_len = (
+                    PathUtils.get_path_byte_len(path_len_byte)
+                    if PathUtils.is_valid_path_len(path_len_byte)
+                    else 0
+                )
+                raw_path = getattr(original_packet, "path", None) or b""
+                path_list = list(raw_path[:path_byte_len]) if path_byte_len else []
+                reply_packet = PacketBuilder.create_path_return(
+                    dest_hash=client_hash,
+                    src_hash=our_hash,
+                    secret=shared_secret,
+                    path=path_list,
+                    extra_type=PAYLOAD_TYPE_RESPONSE,
+                    extra=response_data,
+                )
+                hash_size = (
+                    PathUtils.get_path_hash_size(path_len_byte)
+                    if PathUtils.is_valid_path_len(path_len_byte)
+                    else 1
+                )
+                reply_packet.apply_path_hash_mode(hash_size - 1)
+                self.log(f"PATH (path-return) built for 0x{client_hash:02X} via FLOOD")
+                return reply_packet
+
+            # REQ via direct: use client out_path if set, else flood
+            route_type = "flood"
+            path_bytes = None
+            path_len_encoded = None
+            if (
+                hasattr(client, "out_path_len")
+                and client.out_path_len >= 0
+                and hasattr(client, "out_path")
+                and len(client.out_path) > 0
+                and PathUtils.is_valid_path_len(client.out_path_len)
+            ):
+                route_type = "direct"
+                path_bytes = client.out_path[:MAX_PATH_SIZE]
+                path_len_encoded = client.out_path_len
+
             reply_packet = PacketBuilder.create_datagram(
                 ptype=PAYLOAD_TYPE_RESPONSE,
                 dest=client_identity,
@@ -242,22 +275,10 @@ class ProtocolRequestHandler:
                 plaintext=response_data,
                 route_type=route_type,
             )
+            if path_bytes is not None and path_len_encoded is not None:
+                reply_packet.set_path(path_bytes, path_len_encoded)
 
-            # Add path for direct routing if available
-            if hasattr(client, "out_path_len") and hasattr(client, "out_path"):
-                if client.out_path_len >= 0 and len(client.out_path) > 0:
-                    reply_packet.set_path(
-                        client.out_path[:MAX_PATH_SIZE],
-                        client.out_path_len
-                        if PathUtils.is_valid_path_len(client.out_path_len)
-                        else None,
-                    )
-
-            self.log(
-                f"RESPONSE built for 0x{client_identity.get_public_key()[0]:02X} "
-                f"via {route_type.upper()}"
-            )
-
+            self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")
             return reply_packet
 
         except Exception as e:

--- a/src/pymc_core/protocol/packet.py
+++ b/src/pymc_core/protocol/packet.py
@@ -115,6 +115,7 @@ class Packet:
         "drop_reason",
         "_tx_metadata",
         "_path_hash_mode_applied",
+        "_injected_for_tx",
     )
 
     def __init__(self):
@@ -138,6 +139,7 @@ class Packet:
         self._do_not_retransmit = False
         self.drop_reason = None  # Optional: reason for dropping packet
         self._path_hash_mode_applied = False
+        self._injected_for_tx = False  # Set by repeater inject path; skip engine on route
 
     def get_route_type(self) -> int:
         """

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -10,6 +10,7 @@ from pymc_core.node.handlers import (
     GroupTextHandler,
     LoginResponseHandler,
     PathHandler,
+    ProtocolRequestHandler,
     ProtocolResponseHandler,
     TextMessageHandler,
     TraceHandler,
@@ -21,10 +22,13 @@ from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_ANON_REQ,
     PAYLOAD_TYPE_GRP_TXT,
     PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_REQ,
     PAYLOAD_TYPE_RESPONSE,
     PAYLOAD_TYPE_TRACE,
     PAYLOAD_TYPE_TXT_MSG,
     PUB_KEY_SIZE,
+    ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
     SIGNATURE_SIZE,
     TIMESTAMP_SIZE,
 )
@@ -496,6 +500,121 @@ class TestProtocolResponseHandler:
         assert callback_calls[0][0] == peer_pubkey
         assert callback_calls[0][1] == path_len_byte  # encoded byte, not raw count
         assert callback_calls[0][2] == path_bytes  # all 4 bytes of path data
+
+
+class TestProtocolRequestHandler:
+    """Tests for ProtocolRequestHandler._build_response (firmware-consistent)."""
+
+    def setup_method(self):
+        self.local_identity = LocalIdentity()
+        self.contacts = MockContactBook()
+        self.log_fn = MagicMock()
+        self.handler = ProtocolRequestHandler(
+            self.local_identity, self.contacts, log_fn=self.log_fn
+        )
+
+    def _client_with_key(self, pubkey_bytes: bytes):
+        """Return a minimal client object with public_key (no .id to use public_key path)."""
+
+        class Client:
+            pass
+
+        c = Client()
+        c.public_key = pubkey_bytes
+        c.out_path = b""
+        c.out_path_len = -1
+        return c
+
+    def test_flood_req_returns_path_packet(self):
+        """REQ via flood → path-return PATH packet (firmware createPathReturn + sendFlood)."""
+        peer_identity = LocalIdentity()
+        client = self._client_with_key(peer_identity.get_public_key())
+        client_hash = peer_identity.get_public_key()[0]
+        our_hash = self.local_identity.get_public_key()[0]
+
+        # Incoming REQ via flood with 1-hop path
+        original = Packet()
+        original.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        original.path_len = 1
+        original.path = bytearray([0xAA])
+        assert original.is_route_flood()
+
+        response_data = b"\x39\x30\x00\x00\x00"  # timestamp LE + req_type 0
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
+
+        result = self.handler._build_response(original, client, response_data, shared_secret)
+
+        assert result is not None
+        assert result.get_payload_type() == PAYLOAD_TYPE_PATH
+        assert result.is_route_flood()
+        assert result.payload[0] == client_hash
+        assert result.payload[1] == our_hash
+
+    def test_flood_req_applies_path_hash_mode(self):
+        """Path-return packet preserves incoming path hash size (2-byte hashes)."""
+        from pymc_core.protocol.packet_utils import PathUtils
+
+        peer_identity = LocalIdentity()
+        client = self._client_with_key(peer_identity.get_public_key())
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
+
+        original = Packet()
+        original.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        # 2 hops × 2-byte hashes → encoded path_len
+        original.path_len = PathUtils.encode_path_len(2, 2)
+        original.path = bytearray([0x01, 0x02, 0x03, 0x04])
+        response_data = b"\x00\x00\x00\x00\x00"
+
+        result = self.handler._build_response(original, client, response_data, shared_secret)
+
+        assert result is not None
+        assert result.get_payload_type() == PAYLOAD_TYPE_PATH
+        # path_len high bits = (2-1)<<6 = 0x40 for 2-byte hash size, 0 hops
+        assert result.path_len == 0x40
+
+    def test_direct_req_no_out_path_returns_response_flood(self):
+        """Direct REQ and no client out_path → RESPONSE via flood (no reversed path)."""
+        peer_identity = LocalIdentity()
+        client = self._client_with_key(peer_identity.get_public_key())
+        client.out_path = b""
+        client.out_path_len = -1
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
+
+        original = Packet()
+        original.header = (ROUTE_TYPE_DIRECT & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        original.path_len = 1
+        original.path = bytearray([0xBB])
+        assert not original.is_route_flood()
+
+        response_data = b"\x01\x00\x00\x00\x00"
+        result = self.handler._build_response(original, client, response_data, shared_secret)
+
+        assert result is not None
+        assert result.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert result.is_route_flood()
+        assert result.path_len == 0
+
+    def test_direct_req_with_out_path_returns_response_direct(self):
+        """Direct REQ and client has out_path → RESPONSE via direct with that path."""
+        peer_identity = LocalIdentity()
+        client = self._client_with_key(peer_identity.get_public_key())
+        client.out_path = bytes([0x01, 0x02])
+        client.out_path_len = 2
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
+
+        original = Packet()
+        original.header = (ROUTE_TYPE_DIRECT & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        original.path_len = 0
+        original.path = bytearray()
+
+        response_data = b"\x02\x00\x00\x00\x00"
+        result = self.handler._build_response(original, client, response_data, shared_secret)
+
+        assert result is not None
+        assert result.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert result.is_route_direct()
+        assert result.path_len == 2
+        assert bytes(result.path) == b"\x01\x02"
 
 
 class TestTraceHandler:


### PR DESCRIPTION
 - Updated ProtocolRequestHandler to support PATH responses for flood request packets, consistent with the firmware. This returns the same data, but also gives the client a out_path to the repeater for subsequent requests to use DIRECT.
 - Improved the task writer management to [resolve issue #131 over on pyMC_repeater](https://github.com/rightup/pyMC_Repeater/issues/131#issuecomment-4027337526). 
 - Added some tests to ensure we get the proper PATH vs. RESPONSE packets in various scenarios.