### PR TITLE
fix(companion): refactor push_trace_data to synchronous method and add async wrapper

### DIFF
--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -639,8 +639,13 @@ The frame server sends unsolicited push frames to the companion app when events 
 The frame server exposes methods for the host application to push data to the connected companion app:
 
 ```python
-# Push trace data from the repeater (await for backpressure)
-await server.push_trace_data(
+# Push trace data from the repeater (sync; enqueues like push_rx_raw)
+server.push_trace_data(
+    path_len=3, flags=0, tag=42, auth_code=0,
+    path_hashes=b"...", path_snrs=b"...", final_snr_byte=0
+)
+# Optional async wrapper if you must await a coroutine:
+await server.push_trace_data_async(
     path_len=3, flags=0, tag=42, auth_code=0,
     path_hashes=b"...", path_snrs=b"...", final_snr_byte=0
 )

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -518,7 +518,7 @@ class CompanionFrameServer:
     # Public push methods (called directly by host application)
     # -------------------------------------------------------------------------
 
-    async def push_trace_data(
+    def push_trace_data(
         self,
         path_len: int,
         flags: int,
@@ -531,8 +531,8 @@ class CompanionFrameServer:
         """Push PUSH_CODE_TRACE_DATA (0x89) to client.  Matches firmware
         ``onTraceRecv()`` frame format.
 
-        Kept as ``async def`` for backward-compatible call sites that
-        ``await`` it, but the body is synchronous (just enqueues).
+        Sync, non-blocking.  Safe to call from any context (async or sync),
+        like :pymethod:`push_rx_raw`.
         """
         if self._write_queue is None:
             return
@@ -553,6 +553,29 @@ class CompanionFrameServer:
             + bytes([final_snr_byte & 0xFF])
         )
         self._enqueue_frame(data)
+
+    async def push_trace_data_async(
+        self,
+        path_len: int,
+        flags: int,
+        tag: int,
+        auth_code: int,
+        path_hashes: bytes,
+        path_snrs: bytes,
+        final_snr_byte: int,
+    ) -> None:
+        """Async wrapper for code that must ``await`` a coroutine (same as
+        :pymethod:`push_trace_data`).
+        """
+        self.push_trace_data(
+            path_len,
+            flags,
+            tag,
+            auth_code,
+            path_hashes,
+            path_snrs,
+            final_snr_byte,
+        )
 
     def push_rx_raw(self, snr: float, rssi: int, raw: bytes) -> None:
         """Push raw RX packet to client (PUSH_CODE_LOG_RX_DATA 0x88).
@@ -1209,7 +1232,7 @@ class CompanionFrameServer:
             snr_len = path_len >> path_sz
             path_snrs = bytes(snr_len)
             final_snr_byte = 0
-            await self.push_trace_data(
+            self.push_trace_data(
                 path_len,
                 flags,
                 tag,
@@ -1317,12 +1340,12 @@ class CompanionFrameServer:
         self._write_frame(bytes([RESP_CODE_SENT, 0]) + struct.pack("<II", 0, 15000))
         result = await self.bridge.send_status_request(pubkey)
         if not result.get("success"):
-            self._write_frame(bytes([PUSH_CODE_STATUS_RESPONSE, 0]) + pubkey[:6])
+            logger.debug("Status request failed for %s; no push sent)", pubkey[:6].hex())
             return
         stats_data = result.get("stats", {})
         raw_bytes = stats_data.get("raw_bytes", b"")
         if not raw_bytes:
-            self._write_frame(bytes([PUSH_CODE_STATUS_RESPONSE, 0]) + pubkey[:6])
+            logger.debug("Status response had no raw_bytes for %s; no push sent", pubkey[:6].hex())
             return
         self._write_frame(bytes([PUSH_CODE_STATUS_RESPONSE, 0]) + pubkey[:6] + raw_bytes)
 
@@ -1345,12 +1368,14 @@ class CompanionFrameServer:
             want_environment=want_environment,
         )
         if not result.get("success"):
-            self._write_frame(bytes([PUSH_CODE_TELEMETRY_RESPONSE, 0]) + pubkey[:6])
+            logger.debug("Telemetry request failed for %s; no push sent", pubkey[:6].hex())
             return
         telem_data = result.get("telemetry_data", {})
         raw_bytes = telem_data.get("raw_bytes", b"")
         if not raw_bytes:
-            self._write_frame(bytes([PUSH_CODE_TELEMETRY_RESPONSE, 0]) + pubkey[:6])
+            logger.debug(
+                "Telemetry response had no raw_bytes for %s; no push sent", pubkey[:6].hex()
+            )
             return
         self._write_frame(bytes([PUSH_CODE_TELEMETRY_RESPONSE, 0]) + pubkey[:6] + raw_bytes)
         logger.info("Telemetry push sent to client: %d bytes LPP", len(raw_bytes))

--- a/src/pymc_core/node/handlers/trace.py
+++ b/src/pymc_core/node/handlers/trace.py
@@ -5,10 +5,11 @@ for network diagnostics and analysis.
 """
 
 import struct
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ...protocol import Packet
 from ...protocol.constants import PAYLOAD_TYPE_TRACE
+from ...protocol.packet_utils import PathUtils
 
 
 class TraceHandler:
@@ -56,15 +57,15 @@ class TraceHandler:
                 f"[TraceHandler] Parsed trace: tag=0x{parsed_data.get('tag', 0):08X}, "
                 f"auth=0x{parsed_data.get('auth_code', 0):08X}, "
                 f"flags=0x{parsed_data.get('flags', 0):02X}, "
-                f"path_length={parsed_data.get('path_length', 0)}"
+                f"path_hops={parsed_data.get('path_hop_count', 0)}"
             )
 
-            # Extract source hash from trace data if available
+            # Callback key: last byte of final hop hash (legacy single-byte contact id)
             src_hash = None
-            trace_path = parsed_data.get("trace_path", [])
-            if trace_path:
-                # Usually the source is the last node in the trace path
-                src_hash = trace_path[-1] if trace_path else None
+            trace_hops: List[bytes] = parsed_data.get("trace_hops") or []
+            if trace_hops:
+                last = trace_hops[-1]
+                src_hash = last[-1] if last else None
 
             # If we have a callback waiting for this source, call it
             if src_hash and src_hash in self._response_callbacks:
@@ -106,7 +107,8 @@ class TraceHandler:
     def _parse_trace_payload(self, payload: bytes) -> Dict[str, Any]:
         """Parse trace packet payload.
 
-        Expected format: tag(4) + auth_code(4) + flags(1) + trace_path_bytes...
+        Format: tag(4) + auth_code(4) + flags(1) + concatenated per-hop path hashes.
+        Hash width is ``1 << (flags & 0x03)`` bytes per hop (MeshCore TRACE).
         """
         try:
             if len(payload) < 9:
@@ -115,16 +117,33 @@ class TraceHandler:
             # Unpack the fixed fields (little-endian)
             tag, auth_code, flags = struct.unpack("<IIB", payload[:9])
 
-            # Extract trace path bytes (remaining payload)
-            trace_path_bytes = payload[9:]
-            trace_path = list(trace_path_bytes) if trace_path_bytes else []
+            trace_path_bytes = bytes(payload[9:])
+            path_hash_width = PathUtils.trace_payload_hash_width(flags)
+            trace_hops: List[bytes] = []
+            remainder = (
+                len(trace_path_bytes) % path_hash_width
+                if path_hash_width
+                else len(trace_path_bytes)
+            )
+            if path_hash_width and len(trace_path_bytes) >= path_hash_width:
+                end = len(trace_path_bytes) - remainder
+                for i in range(0, end, path_hash_width):
+                    trace_hops.append(trace_path_bytes[i : i + path_hash_width])
+
+            # Legacy: one int per hop (first byte only), for older callers
+            trace_path = [h[0] for h in trace_hops] if trace_hops else []
 
             return {
                 "tag": tag,
                 "auth_code": auth_code,
                 "flags": flags,
+                "trace_path_bytes": trace_path_bytes,
+                "path_hash_width": path_hash_width,
+                "trace_hops": trace_hops,
                 "trace_path": trace_path,
-                "path_length": len(trace_path),
+                "path_length": len(trace_path_bytes),
+                "path_hop_count": len(trace_hops),
+                "trace_path_remainder": remainder if remainder else 0,
                 "raw_payload": payload.hex(),
                 "valid": True,
             }
@@ -144,7 +163,7 @@ class TraceHandler:
         tag = parsed_data.get("tag", 0)
         auth_code = parsed_data.get("auth_code", 0)
         flags = parsed_data.get("flags", 0)
-        trace_path = parsed_data.get("trace_path", [])
+        trace_hops: List[bytes] = parsed_data.get("trace_hops") or []
 
         response_parts = [
             f"TRACE_RESPONSE tag=0x{tag:08X}",
@@ -152,8 +171,8 @@ class TraceHandler:
             f"flags=0x{flags:02X}",
         ]
 
-        if trace_path:
-            path_str = " -> ".join(f"0x{hop:02X}" for hop in trace_path)
+        if trace_hops:
+            path_str = " -> ".join(f"0x{h.hex()}" for h in trace_hops)
             response_parts.append(f"path=[{path_str}]")
 
         # Add signal strength information

--- a/src/pymc_core/protocol/packet_utils.py
+++ b/src/pymc_core/protocol/packet_utils.py
@@ -175,6 +175,17 @@ class PathUtils:
         max_hops = min(PATH_HASH_COUNT_MASK, MAX_PATH_SIZE // hash_size)
         return hash_count >= max_hops
 
+    @staticmethod
+    def trace_payload_hash_width(flags: int) -> int:
+        """Per-hop path hash size inside TRACE payload (Mesh.cpp ``PAYLOAD_TYPE_TRACE``).
+
+        Lower two bits of ``flags`` select width as ``1 << (flags & 0x03)`` bytes per hop
+        (1, 2, 4, or 8). This matches companion_radio / ``isHashMatch(..., 1 << path_sz)``.
+        It is not the same encoding as ``get_path_hash_size`` for the packet ``path``
+        field (1–3 bytes via bits 6–7 of ``path_len``).
+        """
+        return 1 << (int(flags) & 0x03)
+
 
 class PacketDataUtils:
     """Centralized data packing and unpacking utilities."""

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -226,7 +226,7 @@ async def test_push_trace_data_enqueues_frame():
     server = CompanionFrameServer(bridge, "hash", port=0)
     server._write_queue = asyncio.Queue(maxsize=256)
 
-    await server.push_trace_data(
+    server.push_trace_data(
         path_len=1,
         flags=0,
         tag=1,
@@ -276,6 +276,24 @@ def test_push_rx_raw_sync_enqueues_immediately():
     server._write_queue = asyncio.Queue(maxsize=256)
 
     server.push_rx_raw(snr=-5.0, rssi=-100, raw=b"abc")
+    assert server._write_queue.qsize() == 1
+
+
+def test_push_trace_data_sync_enqueues_immediately():
+    """Sync push_trace_data() enqueues immediately with no event loop scheduling."""
+    bridge = _MockBridgeSendRawDirect()
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+
+    server.push_trace_data(
+        path_len=1,
+        flags=0,
+        tag=1,
+        auth_code=0,
+        path_hashes=b"\x00",
+        path_snrs=b"\x00",
+        final_snr_byte=0,
+    )
     assert server._write_queue.qsize() == 1
 
 
@@ -406,3 +424,91 @@ async def test_device_info_includes_path_hash_mode():
     assert frame[0] == RESP_CODE_DEVICE_INFO
     assert len(frame) == 82  # 81 bytes (old) + 1 byte path_hash_mode
     assert frame[81] == 2  # path_hash_mode at last byte
+
+
+# ---------------------------------------------------------------------------
+# CMD_SEND_STATUS_REQ / CMD_SEND_TELEMETRY_REQ — no empty push on failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_status_req_failure_no_empty_push():
+    """Failed status request must NOT send PUSH_CODE_STATUS_RESPONSE (matches firmware)."""
+    from pymc_core.companion.constants import PUSH_CODE_STATUS_RESPONSE, RESP_CODE_SENT
+
+    bridge = Mock()
+    bridge.send_status_request = AsyncMock(return_value={"success": False, "reason": "timeout"})
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+
+    pubkey = bytes(range(32))
+    await server._cmd_send_status_req(pubkey)
+
+    # Should have sent RESP_CODE_SENT but NOT PUSH_CODE_STATUS_RESPONSE
+    assert any(f[0] == RESP_CODE_SENT for f in frames)
+    assert not any(f[0] == PUSH_CODE_STATUS_RESPONSE for f in frames)
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_status_req_empty_raw_bytes_no_push():
+    """Status response with empty raw_bytes must NOT send PUSH_CODE_STATUS_RESPONSE."""
+    from pymc_core.companion.constants import PUSH_CODE_STATUS_RESPONSE, RESP_CODE_SENT
+
+    bridge = Mock()
+    bridge.send_status_request = AsyncMock(
+        return_value={"success": True, "stats": {"raw_bytes": b""}}
+    )
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+
+    pubkey = bytes(range(32))
+    await server._cmd_send_status_req(pubkey)
+
+    assert any(f[0] == RESP_CODE_SENT for f in frames)
+    assert not any(f[0] == PUSH_CODE_STATUS_RESPONSE for f in frames)
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_status_req_success_sends_push_with_data():
+    """Successful status request with data sends PUSH_CODE_STATUS_RESPONSE with raw_bytes."""
+    from pymc_core.companion.constants import PUSH_CODE_STATUS_RESPONSE
+
+    raw = b"\x01" * 56
+    bridge = Mock()
+    bridge.send_status_request = AsyncMock(
+        return_value={"success": True, "stats": {"raw_bytes": raw}}
+    )
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+
+    pubkey = bytes(range(32))
+    await server._cmd_send_status_req(pubkey)
+
+    status_frames = [f for f in frames if f[0] == PUSH_CODE_STATUS_RESPONSE]
+    assert len(status_frames) == 1
+    # Frame: cmd(1) + reserved(1) + pubkey_prefix(6) + raw_bytes(56) = 64
+    assert len(status_frames[0]) == 64
+    assert status_frames[0][8:] == raw
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_telemetry_req_failure_no_empty_push():
+    """Failed telemetry request must NOT send PUSH_CODE_TELEMETRY_RESPONSE."""
+    from pymc_core.companion.constants import PUSH_CODE_TELEMETRY_RESPONSE, RESP_CODE_SENT
+
+    bridge = Mock()
+    bridge.send_telemetry_request = AsyncMock(return_value={"success": False})
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+
+    # CMD_SEND_TELEMETRY_REQ expects 3 reserved bytes + 32-byte pubkey
+    pubkey = bytes(range(32))
+    data = bytes(3) + pubkey
+    await server._cmd_send_telemetry_req(data)
+
+    assert any(f[0] == RESP_CODE_SENT for f in frames)
+    assert not any(f[0] == PUSH_CODE_TELEMETRY_RESPONSE for f in frames)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,3 +1,4 @@
+import struct
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -630,6 +631,41 @@ class TestTraceHandler:
     def test_trace_handler_initialization(self):
         """Test trace handler initialization."""
         assert self.handler._log == self.log_fn
+
+    def test_parse_trace_payload_one_byte_hashes(self):
+        """flags=0: 1 byte per hop; path 0x01 0x02 = two hops."""
+        payload = struct.pack("<IIB", 0x11111111, 0x22222222, 0x00) + bytes([0x01, 0x02])
+        r = self.handler._parse_trace_payload(payload)
+        assert r["valid"]
+        assert r["path_hash_width"] == 1
+        assert r["path_hop_count"] == 2
+        assert r["trace_hops"] == [b"\x01", b"\x02"]
+        assert r["trace_path_bytes"] == b"\x01\x02"
+        assert r["trace_path"] == [0x01, 0x02]
+
+    def test_parse_trace_payload_two_byte_hashes(self):
+        """flags=0x01: 2 bytes per hop; 0x01 0x02 = one hop 0x0102."""
+        payload = struct.pack("<IIB", 1, 2, 0x01) + bytes([0x01, 0x02])
+        r = self.handler._parse_trace_payload(payload)
+        assert r["valid"]
+        assert r["path_hash_width"] == 2
+        assert r["path_hop_count"] == 1
+        assert r["trace_hops"] == [b"\x01\x02"]
+        assert r["trace_path"] == [0x01]
+
+    def test_format_trace_response_multibyte_hops(self):
+        parsed = {
+            "valid": True,
+            "tag": 0xC88E314F,
+            "auth_code": 0,
+            "flags": 1,
+            "trace_hops": [b"\x01\x02"],
+            "snr": 11.8,
+            "rssi": -45,
+        }
+        s = self.handler._format_trace_response(parsed)
+        assert "0x0102" in s
+        assert "path=[0x0102]" in s
 
 
 # Integration Tests

--- a/tests/test_packet_utils.py
+++ b/tests/test_packet_utils.py
@@ -337,3 +337,13 @@ class TestPathUtils:
         # 3-byte hashes: max 21 hops (63 bytes)
         assert PathUtils.is_path_at_max_hops(PathUtils.encode_path_len(3, 20)) is False
         assert PathUtils.is_path_at_max_hops(PathUtils.encode_path_len(3, 21)) is True
+
+    # --- TRACE payload (Mesh.cpp flags & 0x03) ---
+
+    def test_trace_payload_hash_width(self):
+        """TRACE uses 1 << (flags & 3) bytes per hop, not Packet path_len encoding."""
+        assert PathUtils.trace_payload_hash_width(0) == 1
+        assert PathUtils.trace_payload_hash_width(1) == 2
+        assert PathUtils.trace_payload_hash_width(2) == 4
+        assert PathUtils.trace_payload_hash_width(3) == 8
+        assert PathUtils.trace_payload_hash_width(0xFF) == 8


### PR DESCRIPTION
- Changed push_trace_data from async to sync for immediate enqueueing, aligning with usage patterns.
- Introduced push_trace_data_async as an optional async wrapper for compatibility with existing async call sites.
- Updated documentation and tests to reflect changes in trace data handling and ensure correct functionality.