### PR TITLE
Fix CMD_ADD_UPDATE_CONTACT and CMD_SHARE_CONTACT behaviors

### DIFF
--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -179,6 +179,8 @@ await companion.advertise(flood=True)       # broadcast presence
 await companion.share_contact(pub_key)      # share a contact via direct advert
 ```
 
+**Share contact (firmware parity):** MeshCore replays the **last received raw ADVERT** for that contact (`getBlobByKey` + `sendZeroHop`), not a newly signed advert from the companion identity. pyMC_core stores the wire bytes on each contact when an advert is heard (`Contact.last_advert_packet`) and `share_contact()` returns `False` if no blob exists (e.g. contact was only added manually and never advertised on-air).
+
 ### Contact Management
 
 ```python

--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -28,9 +28,13 @@ from ..protocol.constants import (
     ADVERT_FLAG_IS_SENSOR,
     MAX_PACKET_PAYLOAD,
     MAX_PATH_SIZE,
+    PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_CONTROL,
+    PH_ROUTE_MASK,
+    PUB_KEY_SIZE,
     REQ_TYPE_GET_STATUS,
     REQ_TYPE_GET_TELEMETRY_DATA,
+    ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
     ROUTE_TYPE_TRANSPORT_FLOOD,
     TELEM_PERM_BASE,
@@ -703,6 +707,8 @@ class CompanionBase(ABC):
                 contact.out_path = existing.out_path
                 contact.flags = existing.flags
                 contact.sync_since = existing.sync_since
+                if contact.last_advert_packet is None:
+                    contact.last_advert_packet = existing.last_advert_packet
                 self.contacts.update(contact)
                 return contact
             if not self.should_auto_add_contact_type(contact.adv_type):
@@ -962,19 +968,38 @@ class CompanionBase(ABC):
         return success
 
     async def share_contact(self, pub_key: bytes) -> bool:
-        """Share a contact's advert to the mesh."""
+        """Share a contact's advert on zero hops (direct route, empty path).
+
+        Matches firmware ``BaseChatMesh::shareContactZeroHop``: replay the last stored
+        raw ADVERT wire bytes for this contact (see ``Contact.last_advert_packet``),
+        with ``Mesh::sendZeroHop``-style header/path normalization. Does not re-sign with
+        the companion identity. If no blob is stored (never heard an advert for this
+        contact), returns ``False``.
+        """
         contact = self.contacts.get_by_key(pub_key)
         if not contact:
             return False
+        blob = contact.last_advert_packet
+        if not blob:
+            return False
         try:
-            pkt = PacketBuilder.create_advert(
-                local_identity=self._identity,
-                name=contact.name,
-                flags=adv_type_to_flags(contact.adv_type) | ADVERT_FLAG_HAS_NAME,
-                route_type="direct",
-            )
-            self._apply_flood_scope(pkt)
-            self._apply_path_hash_mode(pkt)
+            pkt = Packet()
+            if not pkt.read_from(bytes(blob)):
+                return False
+            if pkt.get_payload_type() != PAYLOAD_TYPE_ADVERT:
+                return False
+            if len(pkt.payload) >= PUB_KEY_SIZE:
+                embedded = bytes(pkt.payload[:PUB_KEY_SIZE])
+                if embedded != pub_key:
+                    logger.warning(
+                        "Cached advert pubkey does not match contact key; refusing share"
+                    )
+                    return False
+            # Mesh::sendZeroHop (non-transport): direct route, path_len=0, empty path
+            pkt.header = (pkt.header & ~PH_ROUTE_MASK) | ROUTE_TYPE_DIRECT
+            pkt.transport_codes = [0, 0]
+            pkt.path_len = 0
+            pkt.path = bytearray()
             return await self._send_packet(pkt, wait_for_ack=False)
         except Exception as e:
             logger.error(f"Error sharing contact: {e}")
@@ -1694,6 +1719,9 @@ class CompanionBase(ABC):
                 # -> one store update and at most one advert_received (Bridge and Radio).
                 now = int(time.time())
                 contact = Contact.from_dict(data, now=now)
+                raw_blob = data.get("raw_advert_packet")
+                if isinstance(raw_blob, (bytes, bytearray)) and len(raw_blob) > 0:
+                    contact.last_advert_packet = bytes(raw_blob)
                 if len(contact.public_key) >= 7 and contact.name:
                     inbound_path = data.get("inbound_path")
                     path_len_encoded = data.get("path_len_encoded")

--- a/src/pymc_core/companion/contact_store.py
+++ b/src/pymc_core/companion/contact_store.py
@@ -199,7 +199,8 @@ class ContactStore:
 
         Each dict must have 'public_key' (hex string or bytes) and 'name' keys.
         Optional keys: 'adv_type', 'flags', 'out_path', 'out_path_len',
-        'last_advert_timestamp', 'lastmod', 'gps_lat', 'gps_lon', 'sync_since'.
+        'last_advert_timestamp', 'lastmod', 'gps_lat', 'gps_lon', 'sync_since',
+        'last_advert_packet' (hex string of raw ADVERT wire bytes for CMD_SHARE_CONTACT).
 
         Replaces all existing contacts.
         """
@@ -218,6 +219,16 @@ class ContactStore:
             elif isinstance(out_path, list):
                 out_path = bytes(out_path)
 
+            lap = rec.get("last_advert_packet")
+            if isinstance(lap, str) and lap:
+                try:
+                    last_advert_packet = bytes.fromhex(lap)
+                except ValueError:
+                    last_advert_packet = None
+            elif isinstance(lap, (bytes, bytearray)):
+                last_advert_packet = bytes(lap)
+            else:
+                last_advert_packet = None
             contact = Contact(
                 public_key=pub_key,
                 name=rec.get("name", ""),
@@ -232,6 +243,7 @@ class ContactStore:
                 gps_lat=rec.get("gps_lat", 0.0),
                 gps_lon=rec.get("gps_lon", 0.0),
                 sync_since=rec.get("sync_since", 0),
+                last_advert_packet=last_advert_packet,
             )
             self._contacts[pub_key] = contact
             self._proxies[pub_key] = ContactProxy(contact)
@@ -253,6 +265,9 @@ class ContactStore:
                     "gps_lat": c.gps_lat,
                     "gps_lon": c.gps_lon,
                     "sync_since": c.sync_since,
+                    "last_advert_packet": c.last_advert_packet.hex()
+                    if c.last_advert_packet
+                    else "",
                 }
             )
         return result

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -1443,27 +1443,9 @@ class CompanionFrameServer:
             gps_lon=gps_lon,
         )
         ok = self.bridge.add_update_contact(contact)
+        # Keep command/response parity: return a single frame for CMD_ADD_UPDATE_CONTACT.
+        # Sending an extra RESP_CODE_CONTACT frame can desync some companion clients.
         self._write_ok() if ok else self._write_err(ERR_CODE_TABLE_FULL)
-        if ok:
-            opl_byte = 0xFF if out_path_len < 0 or out_path_len > 255 else out_path_len
-            out_path_padded = (out_path[:MAX_PATH_SIZE] if out_path else b"").ljust(
-                MAX_PATH_SIZE, b"\x00"
-            )
-            name_padded = (name.encode("utf-8")[:32] if isinstance(name, str) else name[:32]).ljust(
-                32, b"\x00"
-            )
-            contact_frame = (
-                bytes([RESP_CODE_CONTACT])
-                + pubkey
-                + bytes([adv_type, flags, opl_byte])
-                + out_path_padded
-                + name_padded
-                + struct.pack("<I", last_advert)
-                + struct.pack("<i", int(gps_lat * 1e6))
-                + struct.pack("<i", int(gps_lon * 1e6))
-                + struct.pack("<I", lastmod)
-            )
-            self._write_frame(contact_frame)
         if ok:
             try:
                 await self._save_contacts()

--- a/src/pymc_core/companion/models.py
+++ b/src/pymc_core/companion/models.py
@@ -22,6 +22,9 @@ class Contact:
     gps_lat: float = 0.0  # degrees
     gps_lon: float = 0.0  # degrees
     sync_since: int = 0  # for filtered iteration
+    # Last on-wire ADVERT packet bytes (Packet.write_to),
+    # for CMD_SHARE_CONTACT replay (firmware blob).
+    last_advert_packet: Optional[bytes] = None
 
     @classmethod
     def from_dict(
@@ -80,6 +83,16 @@ class Contact:
         out_path_len_val = int(out_path_len_val) if out_path_len_val is not None else -1
         sync_since_val = d.get("sync_since", 0)
         sync_since_val = int(sync_since_val) if sync_since_val is not None else 0
+        lap = d.get("last_advert_packet")
+        if isinstance(lap, str) and lap:
+            try:
+                last_advert_packet = bytes.fromhex(lap)
+            except ValueError:
+                last_advert_packet = None
+        elif isinstance(lap, (bytes, bytearray)):
+            last_advert_packet = bytes(lap)
+        else:
+            last_advert_packet = None
         return cls(
             public_key=pub,
             name=name,
@@ -92,6 +105,7 @@ class Contact:
             gps_lat=gps_lat,
             gps_lon=gps_lon,
             sync_since=sync_since_val,
+            last_advert_packet=last_advert_packet,
         )
 
 

--- a/src/pymc_core/node/handlers/advert.py
+++ b/src/pymc_core/node/handlers/advert.py
@@ -142,10 +142,16 @@ class AdvertHandler(BaseHandler):
                     path = getattr(packet, "path", bytearray()) or bytearray()
                     path_byte_len = PathUtils.get_path_byte_len(path_len)
                     inbound_path = bytes(path[:path_byte_len]) if path_byte_len > 0 else b""
+                    # Wire bytes for CMD_SHARE_CONTACT replay (firmware getBlobByKey + sendZeroHop).
+                    try:
+                        raw_advert_packet = packet.write_to()
+                    except Exception:
+                        raw_advert_packet = None
                     event_data = {
                         "public_key": pubkey_hex,
                         "name": name,
                         "contact_type": contact_type_id,
+                        "flags": flags_int,
                         "lat": lat,
                         "lon": lon,
                         "advert_timestamp": advert_timestamp,
@@ -154,6 +160,7 @@ class AdvertHandler(BaseHandler):
                         "rssi": advert_data["rssi"],
                         "inbound_path": inbound_path,
                         "path_len_encoded": path_len,
+                        "raw_advert_packet": raw_advert_packet,
                     }
                     self.event_service.publish_sync(MeshEvents.NODE_DISCOVERED, event_data)
                 except Exception as e:

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -10,7 +10,8 @@ from pymc_core.companion.constants import (
     ADV_TYPE_ROOM,
     ADV_TYPE_SENSOR,
 )
-from pymc_core.protocol import LocalIdentity, Packet
+from pymc_core.companion.models import Contact
+from pymc_core.protocol import LocalIdentity, Packet, PacketBuilder
 from pymc_core.protocol.constants import (
     ADVERT_FLAG_IS_CHAT_NODE,
     ADVERT_FLAG_IS_REPEATER,
@@ -209,3 +210,54 @@ class TestApplyPathHashMode:
         bridge._apply_path_hash_mode(pkt)
 
         assert getattr(pkt, "_path_hash_mode_applied", False) is True
+
+
+# ---------------------------------------------------------------------------
+# share_contact — replay cached ADVERT blob (firmware shareContactZeroHop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_share_contact_returns_false_without_cached_blob():
+    """No last_advert_packet → cannot replay (matches firmware empty getBlobByKey)."""
+
+    async def _inj(pkt, wait_for_ack=False):
+        return True
+
+    bridge = CompanionBridge(LocalIdentity(), _inj)
+    key = bytes([0xAB] * 32)
+    bridge.contacts.add(Contact(public_key=key, name="OnlyManual", adv_type=1))
+    ok = await bridge.share_contact(key)
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_share_contact_replays_remote_pubkey_zero_hop():
+    """Replays stored wire bytes; payload pubkey stays the remote contact's, route=direct."""
+
+    remote = LocalIdentity()
+    sent = []
+
+    async def _capture(pkt, wait_for_ack=False):
+        sent.append(pkt)
+        return True
+
+    bridge = CompanionBridge(LocalIdentity(), _capture)
+    original = PacketBuilder.create_advert(remote, "RemoteName", route_type="flood")
+    blob = original.write_to()
+    bridge.contacts.add(
+        Contact(
+            public_key=remote.get_public_key(),
+            name="RemoteName",
+            adv_type=1,
+            last_advert_packet=blob,
+        )
+    )
+    ok = await bridge.share_contact(remote.get_public_key())
+    assert ok is True
+    assert len(sent) == 1
+    out = sent[0]
+    assert bytes(out.payload[:32]) == remote.get_public_key()
+    assert out.get_route_type() == ROUTE_TYPE_DIRECT
+    assert out.path_len == 0
+    assert len(out.path) == 0

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -8,7 +8,7 @@ from pymc_core.companion import CompanionBridge
 from pymc_core.companion.constants import ADV_TYPE_CHAT, AUTOADD_CHAT
 from pymc_core.companion.models import Contact
 from pymc_core.node.events import MeshEvents
-from pymc_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet
+from pymc_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, PacketBuilder
 from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
@@ -240,11 +240,17 @@ class TestCompanionBridgeSendAndShare:
     async def test_share_contact_success(self):
         injector = MockPacketInjector()
         bridge = CompanionBridge(LocalIdentity(), injector)
-        key = b"\x22" * 32
-        bridge.contacts.add(Contact(public_key=key, name="Bob"))
+        remote = LocalIdentity()
+        key = remote.get_public_key()
+        blob = PacketBuilder.create_advert(remote, "Bob", route_type="direct").write_to()
+        bridge.contacts.add(
+            Contact(public_key=key, name="Bob", adv_type=1, last_advert_packet=blob)
+        )
         result = await bridge.share_contact(key)
         assert result is True
         assert len(injector.calls) == 1
+        pkt, _ = injector.calls[0]
+        assert bytes(pkt.payload[:32]) == key
 
     async def test_send_raw_data_direct_injects_packet(self):
         """send_raw_data_direct builds RAW_CUSTOM packet and sends via injector."""

--- a/tests/test_companion_radio.py
+++ b/tests/test_companion_radio.py
@@ -5,7 +5,7 @@ import pytest
 from pymc_core.companion import CompanionRadio
 from pymc_core.companion.constants import ADV_TYPE_CHAT
 from pymc_core.companion.models import Contact
-from pymc_core.protocol import LocalIdentity, Packet
+from pymc_core.protocol import LocalIdentity, Packet, PacketBuilder
 from pymc_core.protocol.constants import PAYLOAD_TYPE_ACK
 
 
@@ -227,8 +227,10 @@ class TestCompanionRadioMisc:
     async def test_share_contact_success(self):
         radio = MockRadio()
         comp = CompanionRadio(radio, LocalIdentity())
-        key = b"\x22" * 32
-        comp.contacts.add(Contact(public_key=key, name="Bob"))
+        remote = LocalIdentity()
+        key = remote.get_public_key()
+        blob = PacketBuilder.create_advert(remote, "Bob", route_type="direct").write_to()
+        comp.contacts.add(Contact(public_key=key, name="Bob", adv_type=1, last_advert_packet=blob))
         result = await comp.share_contact(key)
         assert result is True
         assert len(radio.sent) == 1

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -13,6 +13,7 @@ from pymc_core.companion.constants import (
     PUB_KEY_SIZE,
     PUSH_CODE_ADVERT,
     PUSH_CODE_NEW_ADVERT,
+    RESP_CODE_OK,
 )
 from pymc_core.companion.frame_server import CompanionFrameServer, _build_advert_push_frames
 from pymc_core.companion.models import Contact, SentResult
@@ -135,6 +136,46 @@ async def test_cmd_send_raw_data_valid_writes_ok():
     assert path_len_enc == 1  # 1-byte hash, 1 hop
     server._write_ok.assert_called_once()
     server._write_err.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cmd_add_update_contact_writes_single_ok_response():
+    """CMD_ADD_UPDATE_CONTACT should emit one response frame (OK only)."""
+    bridge = Mock()
+    bridge.add_update_contact = Mock(return_value=True)
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._save_contacts = AsyncMock()
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+    server._write_err = Mock()
+
+    pubkey = bytes(range(32))
+    adv_type = 1
+    flags = 0x01
+    out_path_len = 0
+    out_path = b"\x00" * MAX_PATH_SIZE
+    name = b"Alice".ljust(32, b"\x00")
+    last_advert = struct.pack("<I", 123)
+    gps_lat = struct.pack("<i", int(52.5 * 1e6))
+    gps_lon = struct.pack("<i", int(-1.7 * 1e6))
+    lastmod = struct.pack("<I", 456)
+    data = (
+        pubkey
+        + bytes([adv_type, flags, out_path_len & 0xFF])
+        + out_path
+        + name
+        + last_advert
+        + gps_lat
+        + gps_lon
+        + lastmod
+    )
+
+    await server._cmd_add_update_contact(data)
+
+    bridge.add_update_contact.assert_called_once()
+    assert frames == [bytes([RESP_CODE_OK])]
+    server._write_err.assert_not_called()
+    server._save_contacts.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This fixes an error and possible disconnect on CMD_ADD_UPDATE_CONTACT.

This aligns CMD_SHARE_CONTACT behavior with the most recent advert blob for each contact so it can be replayed for zero-hop share.