### PR TITLE
refactor(dispatcher): improve packet processing with payload-based deduplication and raw hash blacklisting

### DIFF
--- a/src/pymc_core/node/dispatcher.py
+++ b/src/pymc_core/node/dispatcher.py
@@ -375,31 +375,21 @@ class Dispatcher:
             except Exception as e:
                 self._log(f"Raw RX subscriber error: {e}")
 
-        # Generate packet hash for deduplication and blacklist checking
-        packet_hash = self.packet_filter.generate_hash(data)
-
-        # Skip blacklisted packets (known malformed)
-        if self.packet_filter.is_blacklisted(packet_hash):
+        # Blacklist check uses raw-frame hash (catches known-bad bytes before parsing)
+        raw_hash = self.packet_filter.generate_hash(data)
+        if self.packet_filter.is_blacklisted(raw_hash):
             self._log("[RX DEBUG] Packet blacklisted, skipping")
             return
 
-        # Skip duplicate packets
-        if self.packet_filter.is_duplicate(packet_hash):
-            self._log(f"Duplicate packet ignored (hash: {packet_hash})")
-            return
-
-        # Update packet hash tracking
-        self.packet_filter.track_packet(packet_hash)
-
+        # Parse before dedup — calculate_packet_hash() needs a parsed packet
         pkt = Packet()
         try:
             pkt.read_from(data)
             self._log("[RX DEBUG] Packet parsed successfully")
         except Exception as err:
             self._log(f"Malformed packet: {err}")
-            # Blacklist this packet to avoid repeated parsing attempts
-            self.packet_filter.blacklist(packet_hash)
-            self._log(f"Blacklisted malformed packet (hash: {packet_hash})")
+            self.packet_filter.blacklist(raw_hash)
+            self._log(f"Blacklisted malformed packet (raw hash: {raw_hash})")
             return
 
         # Packets at max hops for their path encoding must not be retransmitted
@@ -426,6 +416,7 @@ class Dispatcher:
                 self._log(f"Error in packet analysis callback: {e}")
 
         # Notify raw packet subscribers (e.g. companion clients for PUSH_CODE_LOG_RX_DATA)
+        # This fires BEFORE dedup so the UI sees all path variants for logging
         analysis = {}
         for callback in self._raw_packet_subscribers:
             await self._invoke_enhanced_raw_callback(callback, pkt, data, analysis)
@@ -433,6 +424,14 @@ class Dispatcher:
             await self._invoke_enhanced_raw_callback(self.raw_packet_callback, pkt, data, {})
         if self._raw_packet_subscribers or self.raw_packet_callback:
             self._log("[RX DEBUG] Raw packet callback completed")
+
+        # Dedup uses payload-based hash (matches firmware), ignoring path differences
+        # Only blocks handler dispatch — UI/logging subscribers above still see all variants
+        packet_hash = pkt.calculate_packet_hash().hex()[:16]
+        if self.packet_filter.is_duplicate(packet_hash):
+            self._log(f"Duplicate packet ignored (hash: {packet_hash})")
+            return
+        self.packet_filter.track_packet(packet_hash)
 
         # Check if this is our own packet before processing handlers
         if self._is_own_packet(pkt):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -756,3 +756,68 @@ class TestDispatcherIntegration:
         """Test clearing packet filter."""
         dispatcher.clear_packet_filter()
         # Should not crash
+
+
+class TestDispatcherPayloadBasedDedup:
+    """Test that dedup uses payload-based hash (matching firmware), not raw-frame hash."""
+
+    @pytest.mark.asyncio
+    async def test_same_payload_different_paths_deduplicated(self, dispatcher):
+        """Packets with same payload but different paths are caught as duplicates."""
+        mock_handler = MockHandler(PAYLOAD_TYPE_TXT_MSG)
+        dispatcher.register_handler(PAYLOAD_TYPE_TXT_MSG, mock_handler)
+
+        # Packet 1: 1-byte hash mode, 0 hops
+        pkt1 = Packet()
+        pkt1.header = (1 << 6) | (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD
+        pkt1.path_len = PathUtils.encode_path_len(1, 0)
+        pkt1.path = bytearray()
+        pkt1.payload = bytearray(b"Hello mesh!")
+        pkt1.payload_len = len(pkt1.payload)
+        data1 = pkt1.write_to()
+
+        # Packet 2: same payload, 2 hops in path
+        pkt2 = Packet()
+        pkt2.header = (1 << 6) | (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD
+        pkt2.path_len = PathUtils.encode_path_len(1, 2)
+        pkt2.path = bytearray(b"\xAA\xBB")
+        pkt2.payload = bytearray(b"Hello mesh!")
+        pkt2.payload_len = len(pkt2.payload)
+        data2 = pkt2.write_to()
+
+        # Raw bytes must differ (path is different)
+        assert data1 != data2
+
+        await dispatcher._process_received_packet(data1)
+        await dispatcher._process_received_packet(data2)
+
+        # Second packet should be deduplicated — handler called only once
+        assert mock_handler.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_different_payloads_not_deduplicated(self, dispatcher):
+        """Packets with different payloads are processed independently."""
+        mock_handler = MockHandler(PAYLOAD_TYPE_TXT_MSG)
+        dispatcher.register_handler(PAYLOAD_TYPE_TXT_MSG, mock_handler)
+
+        data1 = create_test_packet(PAYLOAD_TYPE_TXT_MSG, b"message_one")
+        data2 = create_test_packet(PAYLOAD_TYPE_TXT_MSG, b"message_two")
+
+        await dispatcher._process_received_packet(data1)
+        await dispatcher._process_received_packet(data2)
+
+        assert mock_handler.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_malformed_packet_blacklisted_by_raw_hash(self, dispatcher):
+        """Malformed packets are blacklisted by raw hash and rejected on repeat."""
+        bad_data = b"\xFF"
+
+        await dispatcher._process_received_packet(bad_data)
+
+        # Should be blacklisted by raw hash
+        raw_hash = dispatcher.packet_filter.generate_hash(bad_data)
+        assert dispatcher.packet_filter.is_blacklisted(raw_hash)
+
+        # Second attempt should be rejected at blacklist check (not re-parsed)
+        await dispatcher._process_received_packet(bad_data)


### PR DESCRIPTION
- Updated the Dispatcher class to use a raw-frame hash for blacklisting known malformed packets before parsing, enhancing error handling.
- Changed deduplication logic to utilize the standard payload-based hash, ensuring compatibility with firmware and improving packet processing accuracy.
- Added tests to verify that packets with the same payload but different paths are deduplicated correctly, while different payloads are processed independently.
- Ensured malformed packets are blacklisted by their raw hash to prevent repeated parsing attempts.