### PR TITLE
fix(companion): extend client idle timeout for CompanionFrameServer

### DIFF
--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -187,7 +187,7 @@ class CompanionFrameServer:
         stats_getter: Optional[Callable] = None,
         control_handler: Optional[Any] = None,
         heartbeat_interval: int = 15,
-        client_idle_timeout_sec: Optional[int] = 120,
+        client_idle_timeout_sec: Optional[int] = 8 * 60 * 60,
     ):
         self.bridge = bridge
         self.companion_hash = companion_hash


### PR DESCRIPTION
- Updated the client_idle_timeout_sec parameter from 120 seconds to 8 hours (28800 seconds) to accommodate longer idle periods without disconnecting clients.
- This change aims to improve user experience by allowing more flexibility in client connections.