### PR TITLE
fix(companion): prevent writer teardown race during client eviction

### DIFF
--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -787,16 +787,18 @@ class CompanionFrameServer:
                 self.port,
             )
             old_writer = self._client_writer
+            old_writer_task = self._writer_task
             # Cancel and await the old writer task so it's fully gone before we replace
             # the queue and create a new task (avoids the new task being mistaken for
             # a failed writer when the old task had already exited).
-            if self._writer_task is not None:
-                self._writer_task.cancel()
+            if old_writer_task is not None:
+                old_writer_task.cancel()
                 try:
-                    await self._writer_task
+                    await old_writer_task
                 except asyncio.CancelledError:
                     pass
-                self._writer_task = None
+                if self._writer_task is old_writer_task:
+                    self._writer_task = None
             try:
                 old_writer.close()
                 await old_writer.wait_closed()
@@ -806,11 +808,13 @@ class CompanionFrameServer:
         self._client_reader = reader
         self._client_writer = writer
         self._configure_socket(writer)
-        self._write_queue = asyncio.Queue(maxsize=self._WRITE_QUEUE_MAXSIZE)
+        local_write_queue: asyncio.Queue = asyncio.Queue(maxsize=self._WRITE_QUEUE_MAXSIZE)
+        self._write_queue = local_write_queue
         self._setup_push_callbacks()
         logger.info("Companion client connected (port=%s)", self.port)
 
-        self._writer_task = asyncio.create_task(self._writer_loop(writer))
+        local_writer_task = asyncio.create_task(self._writer_loop(writer))
+        self._writer_task = local_writer_task
         disconnect_reason: Optional[str] = None
         try:
             while True:
@@ -835,11 +839,10 @@ class CompanionFrameServer:
                     break
                 payload = await reader.readexactly(frame_len)
                 await self._handle_cmd(payload)
-                writer_task = self._writer_task
-                if writer_task is None or writer_task.done():
+                if local_writer_task.done():
                     disconnect_reason = "writer_failed"
-                    if writer_task is not None and writer_task.done():
-                        exc = writer_task.exception()
+                    if not local_writer_task.cancelled():
+                        exc = local_writer_task.exception()
                         if exc is not None:
                             logger.error(
                                 "Writer task failed (port=%s): %s",
@@ -856,19 +859,30 @@ class CompanionFrameServer:
             disconnect_reason = f"other: {type(e).__name__}: {e}"
             logger.error("Client handler error: %s", e, exc_info=True)
         finally:
-            if self._write_queue is not None:
+            if self._write_queue is local_write_queue:
                 try:
-                    self._write_queue.put_nowait(None)  # Sentinel
+                    local_write_queue.put_nowait(None)  # Sentinel
                 except asyncio.QueueFull:
                     pass
-            if self._writer_task is not None:
-                self._writer_task.cancel()
+            else:
+                logger.debug(
+                    "Skipping stale queue cleanup for disconnected client (port=%s)",
+                    self.port,
+                )
+            if self._writer_task is local_writer_task:
+                local_writer_task.cancel()
                 try:
-                    await self._writer_task
+                    await local_writer_task
                 except asyncio.CancelledError:
                     pass
                 self._writer_task = None
-            self._write_queue = None
+            else:
+                logger.debug(
+                    "Skipping stale writer cleanup for disconnected client (port=%s)",
+                    self.port,
+                )
+            if self._write_queue is local_write_queue:
+                self._write_queue = None
             if self._client_writer is writer:
                 self._client_writer = None
                 self._client_reader = None

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1,6 +1,7 @@
 """Tests for CompanionFrameServer and advert push frame construction."""
 
 import asyncio
+import logging
 import struct
 from unittest.mock import AsyncMock, Mock
 
@@ -553,3 +554,142 @@ async def test_cmd_send_telemetry_req_failure_no_empty_push():
 
     assert any(f[0] == RESP_CODE_SENT for f in frames)
     assert not any(f[0] == PUSH_CODE_TELEMETRY_RESPONSE for f in frames)
+
+
+class _BlockingReader:
+    """Reader that blocks until released, then returns EOF."""
+
+    def __init__(self, release_event: asyncio.Event):
+        self._release_event = release_event
+
+    async def read(self, _n: int) -> bytes:
+        await self._release_event.wait()
+        return b""
+
+    async def readexactly(self, n: int) -> bytes:
+        raise asyncio.IncompleteReadError(partial=b"", expected=n)
+
+
+class _NeverReader:
+    """Reader that never returns (for idle-timeout path)."""
+
+    async def read(self, _n: int) -> bytes:
+        await asyncio.sleep(3600)
+        return b""
+
+    async def readexactly(self, n: int) -> bytes:
+        raise asyncio.IncompleteReadError(partial=b"", expected=n)
+
+
+class _RaisingReader:
+    """Reader that raises a socket-style exception on read()."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    async def read(self, _n: int) -> bytes:
+        raise self._exc
+
+    async def readexactly(self, n: int) -> bytes:
+        raise self._exc
+
+
+class _DummyWriter:
+    """Minimal writer for _handle_client tests."""
+
+    def __init__(self):
+        self.closed = False
+
+    def get_extra_info(self, _name):
+        return None
+
+    def write(self, _data: bytes) -> None:
+        return None
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+
+@pytest.mark.asyncio
+async def test_evicted_handler_cleanup_does_not_cancel_new_writer_task():
+    """Old handler finally block must not tear down new client writer state."""
+    bridge = Mock()
+    bridge.get_time = Mock(return_value=0)
+    server = CompanionFrameServer(bridge, "hash", port=0, client_idle_timeout_sec=None)
+
+    first_release = asyncio.Event()
+    second_release = asyncio.Event()
+    reader1 = _BlockingReader(first_release)
+    reader2 = _BlockingReader(second_release)
+    writer1 = _DummyWriter()
+    writer2 = _DummyWriter()
+
+    task1 = asyncio.create_task(server._handle_client(reader1, writer1))
+    for _ in range(50):
+        if server._client_writer is writer1 and server._writer_task is not None:
+            break
+        await asyncio.sleep(0)
+    assert server._client_writer is writer1
+
+    task2 = asyncio.create_task(server._handle_client(reader2, writer2))
+    for _ in range(50):
+        if server._client_writer is writer2 and server._writer_task is not None:
+            break
+        await asyncio.sleep(0)
+    assert server._client_writer is writer2
+
+    writer2_task = server._writer_task
+    assert writer2_task is not None
+    assert not writer2_task.done()
+
+    # Release old handler; its finally should not cancel the new handler writer task.
+    first_release.set()
+    await task1
+
+    assert server._writer_task is writer2_task
+    assert not writer2_task.done()
+
+    # Cleanly exit task2.
+    second_release.set()
+    await task2
+
+
+@pytest.mark.asyncio
+async def test_handle_client_idle_timeout_disconnects_cleanly(caplog):
+    """Idle timeout disconnect path leaves no active client state."""
+    caplog.set_level(logging.INFO, logger="CompanionFrameServer")
+    bridge = Mock()
+    bridge.get_time = Mock(return_value=0)
+    server = CompanionFrameServer(bridge, "hash", port=0, client_idle_timeout_sec=0.01)
+
+    await server._handle_client(_NeverReader(), _DummyWriter())
+
+    assert server._client_writer is None
+    assert server._client_reader is None
+    assert server._writer_task is None
+    assert any("idle_timeout" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_client_connection_reset_disconnects_cleanly(caplog):
+    """ConnectionResetError path leaves no active client state."""
+    caplog.set_level(logging.INFO, logger="CompanionFrameServer")
+    bridge = Mock()
+    bridge.get_time = Mock(return_value=0)
+    server = CompanionFrameServer(bridge, "hash", port=0, client_idle_timeout_sec=None)
+
+    await server._handle_client(_RaisingReader(ConnectionResetError("boom")), _DummyWriter())
+
+    assert server._client_writer is None
+    assert server._client_reader is None
+    assert server._writer_task is None
+    assert any("ConnectionResetError" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Guard frame-server cleanup by connection ownership so an evicted client handler cannot cancel or clear the newly connected client’s writer queue/task. Add regression and disconnect-path tests to verify eviction churn, idle timeout, and connection reset remain stable.