### PR TITLE
fix(companion): improve error handling for channel message sending

### DIFF
--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -1097,12 +1097,13 @@ class CompanionFrameServer:
         if self.bridge.get_channel(channel_idx) is None:
             self._write_err(ERR_CODE_NOT_FOUND)
             return
+        self._write_ok()
         ok = await self.bridge.send_channel_message(channel_idx, text)
-        if ok:
-            self._write_ok()
-        else:
-            # Firmware uses ERR_CODE_NOT_FOUND for both bad channel and sendGroupMessage failure
-            self._write_err(ERR_CODE_NOT_FOUND)
+        if not ok:
+            logger.warning(
+                "Channel message send failed for channel %d after OK response was already sent",
+                channel_idx,
+            )
 
     async def _cmd_send_binary_req(self, data: bytes) -> None:
         if len(data) < 33:


### PR DESCRIPTION
- Added a confirmation response before sending a channel message to ensure the client is aware of the operation's status.
- Implemented a warning log for failed message sends after an OK response

This fixes the issue raised by Xplore here: https://discord.com/channels/1489331292309946508/1489606341025599701/1492122274525089945