### PR TITLE
fix(companion): ensure auto-added chat contacts do not inherit wire advert flags

### DIFF
--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -1719,6 +1719,11 @@ class CompanionBase(ABC):
                 # -> one store update and at most one advert_received (Bridge and Radio).
                 now = int(time.time())
                 contact = Contact.from_dict(data, now=now)
+                # Wire advert flags (ADVERT_FLAG_IS_CHAT_NODE=0x01, etc.) must not
+                # be stored as local contact flags (bit 0 = favourite).  For new
+                # contacts the flags start at 0; for existing contacts
+                # _apply_advert_to_stores restores the persisted value (line 708).
+                contact.flags = 0
                 raw_blob = data.get("raw_advert_packet")
                 if isinstance(raw_blob, (bytes, bytearray)) and len(raw_blob) > 0:
                     contact.last_advert_packet = bytes(raw_blob)

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -405,6 +405,36 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         assert len(advert_received_calls) == 1
         assert advert_received_calls[0].name == "SinglePathNode"
 
+    async def test_auto_add_chat_contact_does_not_inherit_wire_flags(self):
+        """Wire protocol advert flags (ADVERT_FLAG_IS_CHAT_NODE=0x01) must not be
+        stored as local contact flags (bit 0 = favourite).  Regression test for the
+        bug where auto-added chat companions appeared as favourites."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        peer = LocalIdentity()
+        # Simulate the real event_data produced by advert.py, which includes the
+        # raw wire flags byte (0x81 = IS_CHAT_NODE | HAS_NAME).
+        event_data = {
+            "public_key": peer.get_public_key().hex(),
+            "name": "ChatNode",
+            "contact_type": ADV_TYPE_CHAT,
+            "flags": 0x81,  # ADVERT_FLAG_IS_CHAT_NODE | ADVERT_FLAG_HAS_NAME
+            "lat": 0.0,
+            "lon": 0.0,
+            "advert_timestamp": 1000,
+            "timestamp": 1001,
+            "snr": 0.0,
+            "rssi": 0,
+        }
+        await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
+        contact = bridge.contacts.get_by_key(peer.get_public_key())
+        assert contact is not None
+        assert contact.flags == 0, (
+            f"Auto-added contact should have flags=0, got {contact.flags:#x}. "
+            "Wire protocol flags must not bleed into local contact flags."
+        )
+        assert (contact.flags & 0x01) == 0, "Contact must not be marked as favourite after auto-add"
+
     async def test_path_packet_updates_contact_path_and_fires_contact_path_updated_once(self):
         """PATH packet that decrypts updates contact out_path and fires contact_path_updated."""
         injector = MockPacketInjector()


### PR DESCRIPTION
- Updated the CompanionBase class to reset contact flags to 0 for new contacts, preventing wire protocol advert flags from being stored as local contact flags.
- Added a regression test to verify that auto-added chat contacts do not appear as favourites due to inherited flags.

(Yes, I'll use your fancy spelling.)