### PR TITLE
Add CH341 USB-SPI bridge support (MeshToad V3)

### DIFF
--- a/src/pymc_core/hardware/gpio_manager.py
+++ b/src/pymc_core/hardware/gpio_manager.py
@@ -233,14 +233,31 @@ class GPIOPinManager:
             # Determine bias setting
             bias = "pull_up" if pull_up else "default"
 
-            # Open GPIO pin as input with edge detection on rising edge
-            gpio = GPIO(self._gpio_chip, pin_number, "in", bias=bias, edge="rising")
+            # Try hardware edge detection first, fall back to polling
+            # (CH341 and some other USB GPIO chips don't support kernel edge IRQ)
+            try:
+                gpio = GPIO(self._gpio_chip, pin_number, "in", bias=bias, edge="rising")
+                use_polling = False
+            except OSError as edge_err:
+                if edge_err.errno == 22:  # EINVAL - edge detection not supported
+                    logger.warning(
+                        f"Pin {pin_number}: edge detection not supported by GPIO chip "
+                        f"(errno 22), falling back to polling mode"
+                    )
+                    gpio = GPIO(self._gpio_chip, pin_number, "in", bias=bias)
+                    use_polling = True
+                else:
+                    raise
+
             self._pins[pin_number] = gpio
 
-            # Setup callback with async edge monitoring
+            # Setup callback with edge monitoring or polling fallback
             if callback:
                 self._input_callbacks[pin_number] = callback
-                self._start_edge_detection(pin_number)
+                if use_polling:
+                    self._start_polling_detection(pin_number)
+                else:
+                    self._start_edge_detection(pin_number)
 
             logger.debug(
                 f"Interrupt pin {pin_number} configured "
@@ -288,6 +305,51 @@ class GPIOPinManager:
         thread.start()
         self._edge_threads[pin_number] = thread
         logger.debug(f"Edge detection thread started for pin {pin_number}")
+
+    def _start_polling_detection(self, pin_number: int) -> None:
+        """Start polling-based edge detection for chips that don't support kernel IRQ"""
+        stop_event = threading.Event()
+        self._edge_stop_events[pin_number] = stop_event
+
+        thread = threading.Thread(
+            target=self._monitor_polling,
+            args=(pin_number, stop_event),
+            daemon=True,
+            name=f"GPIO-Poll-{pin_number}",
+        )
+        thread.start()
+        self._edge_threads[pin_number] = thread
+        logger.debug(f"Polling detection thread started for pin {pin_number}")
+
+    def _monitor_polling(self, pin_number: int, stop_event: threading.Event) -> None:
+        """Poll GPIO pin to simulate rising edge detection"""
+        last_value = False
+        poll_interval = 0.005  # 5ms polling = ~200Hz, sufficient for SX1262 DIO1
+
+        try:
+            while not stop_event.is_set() and pin_number in self._pins:
+                try:
+                    gpio = self._pins.get(pin_number)
+                    if not gpio:
+                        break
+
+                    current_value = gpio.read()
+
+                    # Detect rising edge (low -> high transition)
+                    if current_value and not last_value:
+                        callback = self._input_callbacks.get(pin_number)
+                        if callback:
+                            callback()
+
+                    last_value = current_value
+                    time.sleep(poll_interval)
+
+                except Exception:
+                    if not stop_event.is_set():
+                        time.sleep(0.1)
+
+        except Exception as e:
+            logger.error(f"Polling detection error for pin {pin_number}: {e}")
 
     def _monitor_edge_events(self, pin_number: int, stop_event: threading.Event) -> None:
         """Monitor hardware edge events using poll() for interrupts"""

--- a/src/pymc_core/hardware/lora/LoRaRF/SX126x.py
+++ b/src/pymc_core/hardware/lora/LoRaRF/SX126x.py
@@ -401,8 +401,9 @@ class SX126x(BaseLoRa):
             return True  # Continue if reset pin unavailable
 
         reset_pin.write(False)  # periphery: write(False) = LOW
-        time.sleep(0.001)
+        time.sleep(0.010)       # 10ms pulse (was 1ms, too short for USB GPIO)
         reset_pin.write(True)   # periphery: write(True) = HIGH
+        time.sleep(0.150)       # 150ms for SX1262 boot via USB GPIO (was none)
         return not self.busyCheck()
 
     def sleep(self, option=SLEEP_WARM_START):
@@ -498,7 +499,9 @@ class SX126x(BaseLoRa):
         # periphery pins are initialized on first use by _get_output/_get_input
         _get_output(reset)
         _get_input(busy)
-        _get_output(self._cs_define)
+        # Only setup CS GPIO if not using hardware SPI CS (-1 = hardware CS)
+        if self._cs_define != -1:
+            _get_output(self._cs_define)
         # IRQ pin managed externally by sx1262_wrapper.py via gpio_manager
         # Do NOT initialize it here to avoid double allocation
         if txen != -1:
@@ -1482,7 +1485,13 @@ class SX126x(BaseLoRa):
             return
 
         # Adaptive CS control based on CS pin type
-        if self._cs_define != 8:  # Manual CS pin (like Waveshare GPIO 21)
+        if self._cs_define == -1:  # Hardware SPI CS (e.g. CH341 USB SPI, kernel spidev CS)
+            # SPI controller handles CS automatically - just do the transfer
+            buf = [opCode]
+            for i in range(nBytes):
+                buf.append(data[i])
+            spi.xfer2(buf)
+        elif self._cs_define != 8:  # Manual CS pin (like Waveshare GPIO 21)
             # Simple CS control for manual pins
             _get_output(self._cs_define).write(False)
             buf = [opCode]
@@ -1507,7 +1516,15 @@ class SX126x(BaseLoRa):
             return ()
 
         # Adaptive CS control based on CS pin type
-        if self._cs_define != 8:  # Manual CS pin (like Waveshare GPIO 21)
+        if self._cs_define == -1:  # Hardware SPI CS (e.g. CH341 USB SPI, kernel spidev CS)
+            # SPI controller handles CS automatically - just do the transfer
+            buf = [opCode]
+            for i in range(nAddress):
+                buf.append(address[i])
+            for i in range(nBytes):
+                buf.append(0x00)
+            feedback = spi.xfer2(buf)
+        elif self._cs_define != 8:  # Manual CS pin (like Waveshare GPIO 21)
             # Simple CS control for manual pins
             _get_output(self._cs_define).write(False)
             buf = [opCode]

--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -49,6 +49,7 @@ class SX1262Radio(LoRaRadio):
         use_dio3_tcxo: bool = False,
         dio3_tcxo_voltage: float = 1.8,
         use_dio2_rf: bool = False,
+        gpio_chip: str = "/dev/gpiochip0",
     ):
         """
         Initialize SX1262 radio
@@ -75,6 +76,8 @@ class SX1262Radio(LoRaRadio):
             use_dio3_tcxo: Enable DIO3 TCXO control (default: False)
             dio3_tcxo_voltage: TCXO reference voltage in volts (default: 1.8)
             use_dio2_rf: Enable DIO2 as RF switch control (default: False)
+            gpio_chip: GPIO chip device path (default: /dev/gpiochip0)
+                       Set to e.g. /dev/gpiochip2 for USB GPIO adapters (CH341)
         """
         # Check if there's already an active instance and clean it up
         if SX1262Radio._active_instance is not None:
@@ -108,6 +111,7 @@ class SX1262Radio(LoRaRadio):
         self.use_dio3_tcxo = use_dio3_tcxo
         self.dio3_tcxo_voltage = dio3_tcxo_voltage
         self.use_dio2_rf = use_dio2_rf
+        self.gpio_chip = gpio_chip
 
         # State variables
         self.lora: Optional[SX126x] = None
@@ -119,7 +123,7 @@ class SX1262Radio(LoRaRadio):
         self._tx_lock = asyncio.Lock()
 
         # GPIO management
-        self._gpio_manager = GPIOPinManager()
+        self._gpio_manager = GPIOPinManager(gpio_chip=gpio_chip)
         self._interrupt_setup = False
         self._txen_pin_setup = False
         self._txled_pin_setup = False
@@ -214,9 +218,9 @@ class SX1262Radio(LoRaRadio):
     def _basic_radio_setup(self, use_busy_check: bool = False) -> bool:
         """Common radio setup: reset, standby, and LoRa packet type"""
         self.lora.reset()
-        time.sleep(0.01)  # Give hardware time to complete reset
+        time.sleep(0.20)  # Give hardware time to complete reset (USB GPIO needs longer)
         self.lora.setStandby(self.lora.STANDBY_RC)
-        time.sleep(0.01)  # Give hardware time to enter standby mode
+        time.sleep(0.05)  # Give hardware time to enter standby mode
 
         # Check if standby mode was set correctly (different methods for different boards)
         if use_busy_check:
@@ -519,6 +523,9 @@ class SX1262Radio(LoRaRadio):
             if self.cs_pin != -1:
                 # Override CS pin for special boards (e.g., Waveshare HAT)
                 self.lora.setManualCsPin(self.cs_pin)
+            else:
+                # Use hardware SPI CS - disable GPIO CS in low-level driver
+                self.lora._cs_define = -1
 
             self.lora._reset = self.reset_pin
             self.lora._busy = self.busy_pin


### PR DESCRIPTION
## Summary

Adds support for CH341 USB-SPI bridge devices as LoRa radio interfaces,
specifically tested with the NULLHOP MeshToad V3 — a 1W USB-C LoRa radio
built around a CH341 USB-SPI bridge, SX1262, and E22-900M30S PA.

This allows pyMC_Repeater to run as a MeshCore repeater on any Linux
computer (Raspberry Pi, x86, etc.) using only a USB connection to the
radio — no GPIO header required.

## Problem

CH341 USB-SPI bridges expose SPI via `spidev` and GPIO via a `gpiochip`
device, but differ from native GPIO HATs in three ways that caused failures:

1. **Wrong GPIO chip** — `GPIOPinManager` defaulted to `/dev/gpiochip0`
   (the Pi's BCM GPIO chip), but CH341 GPIO lives on a different chip
   (e.g. `/dev/gpiochip2`). All GPIO operations silently targeted the
   wrong chip.

2. **No kernel edge IRQ support** — CH341 GPIO lines return `EINVAL` when
   opened with `edge="rising"`, causing a fatal crash on IRQ pin setup.

3. **Hardware CS not supported** — `SX126x` always tried to set up and
   toggle a GPIO CS pin, but with `cs_pin=-1` (hardware SPI CS) this
   caused a `KeyError: -1` crash on every SPI transaction, and a fatal
   error trying to open pin 21 (the Waveshare default) on the CH341's
   gpiochip.

4. **USB GPIO latency** — Reset pulse (1ms) and post-reset boot wait
   (0ms) were too tight for USB GPIO round-trip latency, causing the
   busy check to fail and `setStandby` to report an error.

## Changes

### `gpio_manager.py`
- `setup_interrupt_pin`: catches `OSError(EINVAL)` from `edge="rising"`
  and falls back to a 5ms polling thread (`_monitor_polling`) that
  simulates rising-edge detection. Hardware edge detection is still used
  when supported. 5ms poll interval is sufficient for SX1262 DIO1 pulses.

### `sx1262_wrapper.py`
- Adds `gpio_chip: str = "/dev/gpiochip0"` parameter to `SX1262Radio.__init__`
  and passes it through to `GPIOPinManager`, allowing the correct chip
  to be specified per-board in config.
- When `cs_pin == -1`, explicitly sets `lora._cs_define = -1` after
  `setSpi()` to signal that the SPI controller handles CS natively.
- Increases `_basic_radio_setup` post-reset sleep from 10ms to 200ms
  and post-standby sleep from 10ms to 50ms to accommodate USB GPIO latency.

### `SX126x.py`
- `reset()`: increases reset pulse from 1ms to 10ms, adds 150ms
  post-boot wait before `busyCheck()` — both necessary for USB GPIO
  round-trip latency.
- `setPins()`: guards `_get_output(self._cs_define)` with a
  `_cs_define != -1` check to skip GPIO CS setup when using hardware CS.
- `_writeBytes()` / `_readBytes()`: adds `_cs_define == -1` branch that
  calls `spi.xfer2()` directly without any GPIO CS toggling, letting the
  SPI controller handle CS automatically. Existing GPIO CS branches
  (manual pin and kernel pin) are unchanged.

## Backward Compatibility

All changes are backward compatible:
- `gpio_chip` defaults to `/dev/gpiochip0`, preserving existing behavior
  for all current hardware profiles
- Hardware edge detection is still attempted first; polling only activates
  on `EINVAL`
- The `_cs_define == -1` path is only taken when explicitly set via the
  new `cs_pin=-1` + `setSpi()` flow
- Reset timing increases are within SX1262 spec and have no negative
  effect on native GPIO hardware

## Tested On

- NULLHOP MeshToad V3 (muzi.works) — CH341 + SX1262 + E22-900M30S 1W PA
- Raspberry Pi 4B, Raspberry Pi OS Bookworm 64-bit
- Kernel 6.12.75+rpt-rpi-v8
- frank-zago/ch341-i2c-spi-gpio driver
- pyMC_Repeater running as a live MeshCore repeater

## References

- MeshToad hardware design: https://oshwlab.com/mtnmesh/meshtoad-v1-2
- MeshToad pin mapping source: meshtastic/firmware#6339
- CH341 kernel driver: https://github.com/frank-zago/ch341-i2c-spi-gpio
- pyMC_Repeater companion PR: (link once opened)