### PR TITLE
Bug: Revert core back to FIRMWARE_VER_CODE = 10

### DIFF
--- a/src/pymc_core/companion/constants.py
+++ b/src/pymc_core/companion/constants.py
@@ -98,7 +98,7 @@ MAX_PENDING_ACK_CRCS = 64
 # CMD_SEND_ANON_REQ (owner requests, etc.) is supported.
 # 10+ provides support for multi-byte path lengths.
 # 11+ adds channel binary datagrams and default flood scope commands.
-FIRMWARE_VER_CODE = 11
+FIRMWARE_VER_CODE = 10
 
 # ---------------------------------------------------------------------------
 # Commands (app -> radio)


### PR DESCRIPTION
The change with the additions highlighted with figuring out the MeshMapper bugs introduced a bug. To be fair both Claude and @agessaman did warn about this being a possibility.

On Version 11 the app assumes there is default region support, we don't have default region support so it's breaking the Experimental Settings page - which means users can't set 2 byte paths on companions from the app.

This PR reverts that. Experimental Settings works again, 2 byte paths can be set and MeshMapper remains unaffected.