### PR TITLE
protocol: add PAYLOAD_VER_3 and PAYLOAD_VER_4 constants for upstream parity

### DIFF
--- a/src/pymc_core/protocol/constants.py
+++ b/src/pymc_core/protocol/constants.py
@@ -40,6 +40,8 @@ PAYLOAD_TYPE_RAW_CUSTOM = 0x0F
 # ---------------------------------------------------------------------------
 PAYLOAD_VER_1 = 0x00  # Currently supported
 PAYLOAD_VER_2 = 0x01  # Reserved for future use
+PAYLOAD_VER_3 = 0x02  # Reserved for future use
+PAYLOAD_VER_4 = 0x03  # Reserved for future use
 MAX_SUPPORTED_PAYLOAD_VERSION = PAYLOAD_VER_2  # Accept versions 0-1
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Upstream [meshcore-dev/MeshCore](https://github.com/meshcore-dev/meshcore) `src/Packet.h` defines four payload-version constants:

```c
#define PAYLOAD_VER_1       0x00   // 1-byte src/dest hashes, 2-byte MAC
#define PAYLOAD_VER_2       0x01   // FUTURE (eg. 2-byte hashes, 4-byte MAC ??)
#define PAYLOAD_VER_3       0x02   // FUTURE
#define PAYLOAD_VER_4       0x03   // FUTURE
```

`src/pymc_core/protocol/constants.py` currently only exposes the first two. Downstream tooling that diffs the `PH_*` / `PAYLOAD_VER_*` sets against a pinned `Packet.h` flags the missing entries as upstream-only:

```
info: pymc_core PH_* / PAYLOAD_VER_* set differs from upstream (informational, not a blocker).
  upstream-only: PAYLOAD_VER_3=0x02
  upstream-only: PAYLOAD_VER_4=0x03
```

## Change

Add `PAYLOAD_VER_3 = 0x02` and `PAYLOAD_VER_4 = 0x03` directly after `PAYLOAD_VER_2`, with the same `# Reserved for future use` comment style already used for `PAYLOAD_VER_2`. They are treated exactly like `PAYLOAD_VER_2`: defined as named constants, not exported in `protocol/__init__.py` (which already omits `PAYLOAD_VER_2`), and not added to `MAX_SUPPORTED_PAYLOAD_VERSION`.

```diff
 PAYLOAD_VER_1 = 0x00  # Currently supported
 PAYLOAD_VER_2 = 0x01  # Reserved for future use
+PAYLOAD_VER_3 = 0x02  # Reserved for future use
+PAYLOAD_VER_4 = 0x03  # Reserved for future use
 MAX_SUPPORTED_PAYLOAD_VERSION = PAYLOAD_VER_2  # Accept versions 0-1
```

## Behavior

No runtime change. `MAX_SUPPORTED_PAYLOAD_VERSION` is unchanged, so `Packet.read_from()` continues to reject versions > 1 (`raise ValueError("Unsupported packet version: ...")` in `src/pymc_core/protocol/packet.py`). The new constants only provide stable names for the version values that upstream already reserves.

## Scope

Single file, two lines added, additive only. No test changes required (these constants have no behavior of their own and existing tests cover the unchanged `MAX_SUPPORTED_PAYLOAD_VERSION` boundary).

---

Co-Authored-By: Oz <oz-agent@warp.dev>
Generated with [Warp](https://app.warp.dev/conversation/a56af1a5-e7d2-40f3-bb50-8ca2dab0bdf4)