### PR TITLE
Add TCPLoRaRadio and USBLoRaRadio for pymc_usb firmware

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -39,9 +39,16 @@ def create_radio(
     """Create a radio instance with configuration for specified hardware.
 
     Args:
-        radio_type: Type of radio hardware ("waveshare", "uconsole", "meshadv-mini",
-                    "kiss-tnc", "kiss-modem", or "ch341")
-        serial_port: Serial port for KISS devices (only used with "kiss-tnc" or "kiss-modem")
+        radio_type: Type of radio hardware. Supported values:
+            "waveshare"     — Waveshare SX1262 HAT (SPI)
+            "uconsole"      — uConsole LoRa module (SPI)
+            "meshadv-mini"  — MeshAdv Mini (SPI)
+            "kiss-tnc"      — KISS TNC over serial
+            "kiss-modem"    — MeshCore KISS modem over serial
+            "ch341"         — SX1262 via CH341 USB-to-SPI adapter
+            "pymc_usb"      — pymc_usb firmware over USB-CDC
+            "pymc_tcp"      — pymc_usb firmware over Wi-Fi/TCP
+        serial_port: Serial port path. Used by "kiss-tnc", "kiss-modem", and "pymc_usb".
 
     Returns:
         Radio instance configured for the specified hardware
@@ -157,6 +164,73 @@ def create_radio(
             )
             return radio
 
+        # ── pymc_tcp (pymc_usb firmware over Wi-Fi/TCP) ─────────
+        if radio_type == "pymc_tcp":
+            from pymc_core.hardware.tcp_radio import TCPLoRaRadio
+
+            logger.debug("Using TCP LoRa Radio (pymc_usb firmware over Wi-Fi)")
+
+            tcp_config = {
+                "host": os.environ.get("PYMC_TCP_HOST", ""),
+                "port": int(os.environ.get("PYMC_TCP_PORT", 5055)),
+                "token": os.environ.get("PYMC_TCP_TOKEN", ""),
+                "connect_timeout": float(
+                    os.environ.get("PYMC_TCP_CONNECT_TIMEOUT", 5.0)
+                ),
+                "frequency": int(os.environ.get("LORA_FREQ", 869618000)),
+                "bandwidth": int(os.environ.get("LORA_BW", 62500)),
+                "spreading_factor": int(os.environ.get("LORA_SF", 8)),
+                "coding_rate": int(os.environ.get("LORA_CR", 8)),
+                "tx_power": int(os.environ.get("LORA_POWER", 22)),
+                "sync_word": int(os.environ.get("LORA_SYNCWORD", "0x12"), 0),
+                "preamble_length": int(os.environ.get("LORA_PREAMBLE", 16)),
+                "lbt_enabled": True,
+                "lbt_max_attempts": 5,
+            }
+
+            if not tcp_config["host"]:
+                raise ValueError(
+                    "pymc_tcp radio requires PYMC_TCP_HOST env var — "
+                    "modem hostname or LAN IP."
+                )
+
+            radio = TCPLoRaRadio(**tcp_config)
+            logger.info(
+                f"pymc_tcp radio created at {tcp_config['host']}:{tcp_config['port']}: "
+                f"{tcp_config['frequency']/1e6:.1f}MHz SF{tcp_config['spreading_factor']} "
+                f"BW{tcp_config['bandwidth']/1000:.0f}kHz {tcp_config['tx_power']}dBm"
+            )
+            return radio
+
+        # ── pymc_usb (pymc_usb firmware over USB-CDC) ───────────
+        if radio_type == "pymc_usb":
+            from pymc_core.hardware.usb_radio import USBLoRaRadio
+
+            logger.debug("Using USB LoRa Radio (pymc_usb firmware)")
+
+            # Default: EU/UK (Narrow), Switzerland preset
+            usb_config = {
+                "port": serial_port,          # e.g. /dev/ttyACM0
+                "baudrate": 921600,
+                "frequency": int(os.environ.get("LORA_FREQ", 869618000)),
+                "bandwidth": int(os.environ.get("LORA_BW", 62500)),
+                "spreading_factor": int(os.environ.get("LORA_SF", 8)),
+                "coding_rate": int(os.environ.get("LORA_CR", 8)),
+                "tx_power": int(os.environ.get("LORA_POWER", 22)),
+                "sync_word": int(os.environ.get("LORA_SYNCWORD", "0x12"), 0),
+                "preamble_length": int(os.environ.get("LORA_PREAMBLE", 16)),
+                "lbt_enabled": True,
+                "lbt_max_attempts": 5,
+            }
+
+            radio = USBLoRaRadio(**usb_config)
+            logger.info(
+                f"pymc_usb radio created on {serial_port}: "
+                f"{usb_config['frequency']/1e6:.1f}MHz SF{usb_config['spreading_factor']} "
+                f"BW{usb_config['bandwidth']/1000:.0f}kHz {usb_config['tx_power']}dBm"
+            )
+            return radio
+
         # Direct SX1262 radio for other types
         from pymc_core.hardware.sx1262_wrapper import SX1262Radio
 
@@ -218,7 +292,8 @@ def create_radio(
         if radio_type not in configs:
             raise ValueError(
                 f"Unknown radio type: {radio_type}. "
-                "Use 'waveshare', 'meshadv-mini', 'uconsole', 'kiss-tnc', 'kiss-modem', or 'ch341'"
+                "Use 'waveshare', 'meshadv-mini', 'uconsole', 'kiss-tnc', "
+                "'kiss-modem', 'ch341', 'pymc_usb', or 'pymc_tcp'"
             )
 
         radio_kwargs = configs[radio_type]
@@ -250,8 +325,9 @@ def create_mesh_node(
     Args:
         node_name: Name for the mesh node
         radio_type: Type of radio hardware ("waveshare", "uconsole", "meshadv-mini",
-                    "kiss-tnc", "kiss-modem", or "ch341")
-        serial_port: Serial port for KISS devices (only used with "kiss-tnc" or "kiss-modem")
+                    "kiss-tnc", "kiss-modem", "ch341", "pymc_usb", or "pymc_tcp")
+        serial_port: Serial port for KISS devices or pymc_usb
+                     (e.g. "/dev/ttyUSB0" for KISS, "/dev/ttyACM0" for pymc_usb)
         use_modem_identity: If True and radio_type is "kiss-modem", use the modem's
                            cryptographic identity instead of generating a local one.
                            This keeps the private key secure on the modem hardware.
@@ -301,10 +377,11 @@ def create_mesh_node(
             logger.info("CH341 radio initialized successfully")
             print("CH341 USB adapter radio initialized")
         else:
+            # waveshare/uconsole/meshadv-mini/pymc_usb/pymc_tcp all use begin()
             logger.debug("Calling radio.begin()...")
             ok = radio.begin()
             if ok is False:
-                raise RuntimeError("SX1262 radio begin() returned False")
+                raise RuntimeError("Radio begin() returned False")
             logger.info("Radio initialized successfully")
 
         # Create identity - use modem identity if requested and available

--- a/src/pymc_core/hardware/__init__.py
+++ b/src/pymc_core/hardware/__init__.py
@@ -40,6 +40,24 @@ except ImportError:
     _KISS_MODEM_AVAILABLE = False
     KissModemWrapper = None
 
+# Conditional import for USBLoRaRadio (requires pyserial)
+try:
+    from .usb_radio import USBLoRaRadio
+
+    _USB_AVAILABLE = True
+except ImportError:
+    _USB_AVAILABLE = False
+    USBLoRaRadio = None
+
+# Conditional import for TCPLoRaRadio (stdlib only — socket/threading/asyncio)
+try:
+    from .tcp_radio import TCPLoRaRadio
+
+    _TCP_AVAILABLE = True
+except ImportError:
+    _TCP_AVAILABLE = False
+    TCPLoRaRadio = None
+
 __all__ = ["LoRaRadio"]
 
 # Add WsRadio to exports if available
@@ -57,3 +75,11 @@ if _KISS_SERIAL_AVAILABLE:
 # Add KissModemWrapper to exports if available
 if _KISS_MODEM_AVAILABLE:
     __all__.append("KissModemWrapper")
+
+# Add USBLoRaRadio to exports if available
+if _USB_AVAILABLE:
+    __all__.append("USBLoRaRadio")
+
+# Add TCPLoRaRadio to exports if available
+if _TCP_AVAILABLE:
+    __all__.append("TCPLoRaRadio")

--- a/src/pymc_core/hardware/protocol_constants.py
+++ b/src/pymc_core/hardware/protocol_constants.py
@@ -1,0 +1,152 @@
+"""
+Wire-protocol constants and framing helpers shared by USBLoRaRadio and
+TCPLoRaRadio.
+
+Mirrors the on-the-wire format defined in the pymc_usb firmware
+(`firmware/include/protocol.h`). Keep this file and the firmware header
+in sync — every command code, struct layout, CRC vector and sync byte
+must match bit-for-bit, otherwise both drivers will silently lose frames.
+
+Frame format:
+
+    SYNC (0xAA) | CMD (1B) | LEN (2B LE) | PAYLOAD (0..N B) | CRC-16/CCITT (2B LE)
+
+CRC is computed over `CMD + LEN + PAYLOAD` (the SYNC byte is excluded);
+polynomial 0x1021, initial 0xFFFF, no reflect, no xor-out (CRC-16/CCITT-FALSE).
+"""
+
+import struct
+
+# ─── Framing ─────────────────────────────────────────────────────────
+PROTO_SYNC = 0xAA
+
+# Maximum LoRa payload size accepted by the firmware (single-byte LEN
+# optimisation in the modem's RX buffer). The wire LEN field itself is
+# u16, so the framing helpers below handle anything that fits in 65535 B.
+MAX_LORA_PAYLOAD = 255
+
+# ─── Host → Modem ────────────────────────────────────────────────────
+CMD_TX_REQUEST = 0x01
+CMD_SET_CONFIG = 0x10
+CMD_GET_CONFIG = 0x11
+CMD_STATUS_REQ = 0x20
+CMD_NOISE_REQ = 0x22
+CMD_CAD_REQUEST = 0x30
+CMD_RX_START = 0x31
+CMD_SET_CAD_PARAMS = 0x34  # v0.5.4
+CMD_SET_WIFI = 0x41  # v0.5
+CMD_AUTH = 0x50
+CMD_WIFI_RESET = 0x60
+CMD_GET_WIFI = 0x61  # v0.5
+CMD_GET_VERSION = 0x70  # v0.5.3
+CMD_PING = 0xFF
+
+# ─── Modem → Host ────────────────────────────────────────────────────
+CMD_TX_DONE = 0x02
+CMD_TX_FAIL = 0x03
+CMD_RX_PACKET = 0x04
+CMD_CONFIG_RESP = 0x12
+CMD_STATUS_RESP = 0x21
+CMD_NOISE_RESP = 0x23
+CMD_CAD_RESP = 0x32
+CMD_RX_STARTED = 0x33
+CMD_CAD_PARAMS_RESP = 0x35  # v0.5.4
+CMD_AUTH_OK = 0x51
+CMD_WIFI_STATUS = 0x62  # v0.5
+CMD_VERSION_RESP = 0x71  # v0.5.3
+CMD_ERROR = 0xFE
+CMD_PONG = 0xFF
+
+# ─── Error codes (CMD_ERROR payload[0]) ──────────────────────────────
+ERR_CRC_MISMATCH = 0x01
+ERR_INVALID_CMD = 0x02
+ERR_RADIO_BUSY = 0x03
+ERR_TX_TIMEOUT = 0x04
+ERR_PAYLOAD_TOO_BIG = 0x05
+ERR_INVALID_CONFIG = 0x06
+ERR_CAD_FAILED = 0x07
+ERR_RADIO_INIT = 0x08
+ERR_UNAUTHORIZED = 0x09
+
+# ─── WIFI_STATUS mode codes ──────────────────────────────────────────
+# Matches firmware main.cpp::buildWifiStatusPayload
+WIFI_MODE_OFFLINE = 0
+WIFI_MODE_STA_CONNECTING = 1
+WIFI_MODE_STA_CONNECTED = 2
+WIFI_MODE_AP_CONFIG = 3
+
+# ─── Packed struct layouts ───────────────────────────────────────────
+# RadioConfig (14 B): freq_hz(u32) | bandwidth_hz(u32) | sf(u8) | cr(u8)
+#                     | power_dbm(i8) | syncword(u16) | preamble_len(u8)
+RADIO_CONFIG_FMT = "<IIBBbHB"
+RADIO_CONFIG_SIZE = struct.calcsize(RADIO_CONFIG_FMT)
+
+# StatusResp (24 B): uptime | rx_count | tx_count | crc_errors
+#                    | last_rssi | snr×10 | noise×10 | temp_c | radio_state
+STATUS_RESP_FMT = "<IIIIhhhbB"
+STATUS_RESP_SIZE = struct.calcsize(STATUS_RESP_FMT)
+
+
+# ─── Framing helpers ─────────────────────────────────────────────────
+
+def crc16_ccitt(data: bytes) -> int:
+    """CRC-16/CCITT-FALSE. Matches the firmware reference implementation."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = (crc << 1) ^ 0x1021
+            else:
+                crc <<= 1
+            crc &= 0xFFFF
+    return crc
+
+
+def build_frame(cmd: int, payload: bytes = b"") -> bytes:
+    """Build a wire frame: SYNC | CMD | LEN | PAYLOAD | CRC.
+
+    Raises ValueError if the payload does not fit in the 16-bit LEN
+    field. The firmware caps individual LoRa payloads at
+    MAX_LORA_PAYLOAD, but the framing itself accepts anything up to
+    0xFFFF — exceeding that is a programming error in the caller.
+    """
+    length = len(payload)
+    if length > 0xFFFF:
+        raise ValueError(
+            f"payload length {length} exceeds 16-bit LEN field "
+            f"(max 65535; firmware caps at MAX_LORA_PAYLOAD={MAX_LORA_PAYLOAD})"
+        )
+    hdr = struct.pack("<BH", cmd, length)
+    crc = crc16_ccitt(hdr + payload)
+    return bytes([PROTO_SYNC]) + hdr + payload + struct.pack("<H", crc)
+
+
+__all__ = [
+    "PROTO_SYNC",
+    "MAX_LORA_PAYLOAD",
+    # Host → Modem
+    "CMD_TX_REQUEST", "CMD_SET_CONFIG", "CMD_GET_CONFIG",
+    "CMD_STATUS_REQ", "CMD_NOISE_REQ",
+    "CMD_CAD_REQUEST", "CMD_RX_START", "CMD_SET_CAD_PARAMS",
+    "CMD_SET_WIFI", "CMD_AUTH", "CMD_WIFI_RESET",
+    "CMD_GET_WIFI", "CMD_GET_VERSION", "CMD_PING",
+    # Modem → Host
+    "CMD_TX_DONE", "CMD_TX_FAIL", "CMD_RX_PACKET",
+    "CMD_CONFIG_RESP", "CMD_STATUS_RESP", "CMD_NOISE_RESP",
+    "CMD_CAD_RESP", "CMD_RX_STARTED", "CMD_CAD_PARAMS_RESP",
+    "CMD_AUTH_OK", "CMD_WIFI_STATUS", "CMD_VERSION_RESP",
+    "CMD_ERROR", "CMD_PONG",
+    # Errors
+    "ERR_CRC_MISMATCH", "ERR_INVALID_CMD", "ERR_RADIO_BUSY",
+    "ERR_TX_TIMEOUT", "ERR_PAYLOAD_TOO_BIG", "ERR_INVALID_CONFIG",
+    "ERR_CAD_FAILED", "ERR_RADIO_INIT", "ERR_UNAUTHORIZED",
+    # WIFI_STATUS modes
+    "WIFI_MODE_OFFLINE", "WIFI_MODE_STA_CONNECTING",
+    "WIFI_MODE_STA_CONNECTED", "WIFI_MODE_AP_CONFIG",
+    # Structs
+    "RADIO_CONFIG_FMT", "RADIO_CONFIG_SIZE",
+    "STATUS_RESP_FMT", "STATUS_RESP_SIZE",
+    # Framing
+    "crc16_ccitt", "build_frame",
+]

--- a/src/pymc_core/hardware/tcp_radio.py
+++ b/src/pymc_core/hardware/tcp_radio.py
@@ -1,0 +1,1060 @@
+"""
+TCP LoRa Radio Driver for pymc_core
+
+Implements the LoRaRadio interface using any board running the pymc_usb
+firmware in Wi-Fi/TCP mode. Same binary protocol as USBLoRaRadio — only
+the transport differs.
+
+Drop-in replacement for SX1262Radio in pymc_core's hardware layer.
+
+Default sync word is 0x12 (MeshCore private syncword), matching the
+firmware default — change only if the deployment uses a custom value.
+
+Usage:
+    from pymc_core.hardware.tcp_radio import TCPLoRaRadio
+
+    radio = TCPLoRaRadio(
+        host="192.168.1.50",
+        port=5055,
+        token="",                # empty = no auth (matches firmware NVS)
+        frequency=869618000,
+        bandwidth=62500,
+        spreading_factor=8,
+        coding_rate=8,
+        tx_power=22,
+        sync_word=0x12,
+        preamble_length=16,
+    )
+    radio.begin()
+    radio.set_rx_callback(my_callback)
+    await radio.send(packet_bytes)
+"""
+
+import asyncio
+import logging
+import random
+import socket
+import struct
+import threading
+import time
+from typing import Callable, Optional
+
+from .protocol_constants import (
+    PROTO_SYNC,
+    MAX_LORA_PAYLOAD,
+    CMD_TX_REQUEST, CMD_SET_CONFIG,
+    CMD_STATUS_REQ, CMD_NOISE_REQ,
+    CMD_CAD_REQUEST, CMD_RX_START, CMD_SET_CAD_PARAMS,
+    CMD_AUTH, CMD_PING,
+    CMD_TX_DONE, CMD_TX_FAIL, CMD_RX_PACKET,
+    CMD_CONFIG_RESP, CMD_STATUS_RESP, CMD_NOISE_RESP,
+    CMD_CAD_RESP, CMD_RX_STARTED, CMD_CAD_PARAMS_RESP,
+    CMD_AUTH_OK, CMD_ERROR, CMD_PONG,
+    ERR_UNAUTHORIZED,
+    RADIO_CONFIG_FMT,
+    STATUS_RESP_FMT, STATUS_RESP_SIZE,
+    crc16_ccitt, build_frame,
+)
+
+logger = logging.getLogger("TCPLoRaRadio")
+
+
+# Import LoRaRadio base conditionally — allows standalone testing
+try:
+    from pymc_core.hardware.base import LoRaRadio
+    _HAS_BASE = True
+except ImportError:
+    _HAS_BASE = False
+
+if _HAS_BASE:
+    class _RadioBase(LoRaRadio):
+        pass
+else:
+    class _RadioBase:
+        pass
+
+
+class TCPLoRaRadio(_RadioBase):
+    """TCP LoRa Radio — pymc_core LoRaRadio interface over Wi-Fi/TCP.
+
+    Communicates with any board running the pymc_usb firmware in Wi-Fi
+    STA mode. Provides the same interface as SX1262Radio and USBLoRaRadio
+    for transparent integration with pymc_core.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 5055,
+        token: str = "",
+        frequency: int = 869618000,
+        bandwidth: int = 62500,
+        spreading_factor: int = 8,
+        coding_rate: int = 8,
+        tx_power: int = 22,
+        sync_word: int = 0x12,
+        preamble_length: int = 16,
+        lbt_enabled: bool = True,
+        lbt_max_attempts: int = 5,
+        connect_timeout: float = 5.0,
+    ):
+        self.host = host
+        self.port = port
+        self.token = token or ""
+        self.connect_timeout = connect_timeout
+
+        # Radio config — matches SX1262Radio/USBLoRaRadio constructor params
+        self.frequency = frequency
+        self.bandwidth = bandwidth
+        self.spreading_factor = spreading_factor
+        self.coding_rate = coding_rate
+        self.tx_power = tx_power
+        self.sync_word = sync_word
+        self.preamble_length = preamble_length
+
+        # LBT (Listen Before Talk) via CAD
+        self.lbt_enabled = lbt_enabled
+        self.lbt_max_attempts = lbt_max_attempts
+
+        # State
+        self._sock: Optional[socket.socket] = None
+        self._sock_lock = threading.Lock()  # guards socket writes
+        self._initialized = False
+        self._rx_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
+        # or perform_cad(det_peak=..., det_min=...); read by _reopen_socket
+        # to re-push to the firmware after a reconnect, so they must exist
+        # from construction time even when never customised.
+        self._custom_cad_peak: Optional[int] = None
+        self._custom_cad_min: Optional[int] = None
+
+        # Signal metrics
+        self.last_rssi: int = -99
+        self.last_snr: float = 0.0
+        self.last_signal_rssi: int = -99
+        self._noise_floor: float = -99.0
+
+        # RX callback
+        self.rx_callback: Optional[Callable[[bytes], None]] = None
+
+        # Response synchronization
+        self._response_events: dict[int, asyncio.Event] = {}
+        self._response_data: dict[int, Optional[bytes]] = {}
+        self._response_lock = threading.Lock()
+
+        # TX lock
+        self._tx_lock = asyncio.Lock()
+
+        # Stats
+        self._tx_count = 0
+        self._rx_count = 0
+
+        logger.info(
+            f"TCPLoRaRadio configured: {host}:{port} "
+            f"(auth={'token' if self.token else 'open'}), "
+            f"freq={frequency/1e6:.1f}MHz, sf={spreading_factor}, "
+            f"bw={bandwidth/1000:.0f}kHz, power={tx_power}dBm, "
+            f"syncword=0x{sync_word:04X}"
+        )
+
+    # ══════════════════════════════════════════════════════════
+    # LoRaRadio interface
+    # ══════════════════════════════════════════════════════════
+
+    def begin(self) -> bool:
+        """Open TCP connection, authenticate (if token set), push config.
+
+        If the initial connect/handshake fails, the radio is still marked
+        initialised and the RX worker is started in deferred-connect mode —
+        it will keep retrying the connection with exponential backoff until
+        the modem appears. This lets the repeater's HTTP server / setup
+        wizard come up even when the modem is offline or its host has not
+        been set yet (e.g. placeholder hostname after a fresh install).
+        """
+        if self._initialized:
+            return True
+
+        connected = False
+        try:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.settimeout(self.connect_timeout)
+            self._sock.connect((self.host, self.port))
+            # TCP_NODELAY mirrors the firmware side and avoids Nagle delay
+            self._sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            logger.info(f"TCP connected to {self.host}:{self.port}")
+            connected = True
+
+            if self.token and not self._auth_sync(timeout=3.0):
+                logger.error("Modem rejected AUTH token — entering deferred mode")
+                self._close_sock()
+                connected = False
+            elif not self._ping_sync(timeout=3.0):
+                logger.error("Modem not responding to PING — entering deferred mode")
+                self._close_sock()
+                connected = False
+            elif not self._apply_config_sync():
+                logger.error("Failed to configure radio — entering deferred mode")
+                self._close_sock()
+                connected = False
+        except Exception as e:
+            logger.warning(
+                f"Could not reach modem at {self.host}:{self.port} ({e}); "
+                f"starting in deferred-connect mode — RX worker will keep retrying"
+            )
+            self._close_sock()
+            connected = False
+
+        # Always start the RX worker. When connected it processes traffic
+        # immediately; otherwise _reconnect_with_backoff drives reconnection
+        # so the repeater UI can stay up while the user sets pymc_tcp.host
+        # via /api/setup_wizard or /api/update_radio_config.
+        self._stop_event.clear()
+        self._rx_thread = threading.Thread(
+            target=self._rx_worker, daemon=True, name="tcp-lora-rx"
+        )
+        self._rx_thread.start()
+
+        self._initialized = True
+        if connected:
+            logger.info("TCPLoRaRadio initialized successfully")
+        else:
+            logger.info(
+                "TCPLoRaRadio initialised in deferred-connect mode "
+                "(no modem yet — radio commands will return None until reachable)"
+            )
+        return True
+
+    async def send(self, data: bytes) -> Optional[dict]:
+        """Send a LoRa packet asynchronously with LBT (CAD)."""
+        if not self._initialized:
+            logger.error("Radio not initialized")
+            return None
+
+        async with self._tx_lock:
+            lbt_backoff_delays: list[float] = []
+
+            if self.lbt_enabled:
+                for attempt in range(self.lbt_max_attempts):
+                    try:
+                        channel_busy = await self._perform_cad(timeout=1.0)
+                        if not channel_busy:
+                            logger.debug(
+                                f"CAD clear after {attempt + 1} attempt(s)"
+                            )
+                            break
+                        else:
+                            logger.debug("CAD busy — channel activity detected")
+                            if attempt < self.lbt_max_attempts - 1:
+                                base_delay = random.randint(50, 200)
+                                backoff_ms = min(
+                                    base_delay * (2 ** attempt), 5000
+                                )
+                                lbt_backoff_delays.append(float(backoff_ms))
+                                logger.debug(
+                                    f"CAD backoff {backoff_ms}ms "
+                                    f"(attempt {attempt+1}/{self.lbt_max_attempts})"
+                                )
+                                await asyncio.sleep(backoff_ms / 1000.0)
+                            else:
+                                logger.warning(
+                                    "CAD max attempts — transmitting anyway"
+                                )
+                    except Exception as e:
+                        logger.warning(f"CAD failed: {e}, proceeding with TX")
+                        break
+
+            try:
+                resp = await self._send_command(
+                    CMD_TX_REQUEST, data,
+                    expect_cmd=CMD_TX_DONE,
+                    timeout=10.0,
+                )
+
+                if resp is not None:
+                    self._tx_count += 1
+                    airtime_us = 0
+                    if len(resp) >= 4:
+                        airtime_us = struct.unpack("<I", resp[:4])[0]
+                    airtime_ms = airtime_us / 1000.0
+
+                    logger.debug(
+                        f"TX done: {len(data)}B, airtime={airtime_ms:.1f}ms"
+                    )
+
+                    await self._send_command(
+                        CMD_RX_START, b"",
+                        expect_cmd=CMD_RX_STARTED,
+                        timeout=2.0,
+                    )
+
+                    return {
+                        "airtime_ms": airtime_ms,
+                        "lbt_attempts": len(lbt_backoff_delays),
+                        "lbt_backoff_delays_ms": lbt_backoff_delays,
+                        "lbt_channel_busy": len(lbt_backoff_delays) > 0,
+                    }
+                else:
+                    logger.error("TX failed — no TX_DONE response")
+                    await self._send_command(
+                        CMD_RX_START, b"",
+                        expect_cmd=CMD_RX_STARTED,
+                        timeout=2.0,
+                    )
+                    return None
+
+            except Exception as e:
+                logger.error(f"TX error: {e}")
+                return None
+
+    async def wait_for_rx(self) -> bytes:
+        """Not used — packets arrive via set_rx_callback()."""
+        raise NotImplementedError(
+            "Use set_rx_callback(callback) to receive packets asynchronously."
+        )
+
+    def set_event_loop(self, loop) -> None:
+        # Called by repeater.main so radio can schedule live config pushes.
+        self._event_loop = loop
+
+    def set_rx_callback(self, callback: Callable[[bytes], None]):
+        """Set RX callback — called by Dispatcher."""
+        self.rx_callback = callback
+        logger.info("RX callback registered")
+        try:
+            self._event_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+
+    def sleep(self):
+        logger.debug("Sleep not applicable for TCP modem")
+
+    def get_last_rssi(self) -> int:
+        return self.last_rssi
+
+    def get_last_snr(self) -> float:
+        return self.last_snr
+
+    def get_last_signal_rssi(self) -> int:
+        return self.last_signal_rssi
+
+    # ══════════════════════════════════════════════════════════
+    # Extended interface
+    # ══════════════════════════════════════════════════════════
+
+    def check_radio_health(self) -> bool:
+        if not self._initialized:
+            return False
+
+        if self._rx_thread is None or not self._rx_thread.is_alive():
+            logger.warning("RX thread dead — restarting")
+            self._stop_event.clear()
+            self._rx_thread = threading.Thread(
+                target=self._rx_worker, daemon=True, name="tcp-lora-rx"
+            )
+            self._rx_thread.start()
+            return False
+
+        if self._event_loop:
+            self._event_loop.call_soon_threadsafe(
+                lambda: self._event_loop.create_task(self.refresh_noise_floor())
+            )
+        return True
+
+    def get_status(self) -> dict:
+        return {
+            "initialized": self._initialized,
+            "frequency": self.frequency,
+            "tx_power": self.tx_power,
+            "spreading_factor": self.spreading_factor,
+            "bandwidth": self.bandwidth,
+            "coding_rate": self.coding_rate,
+            "last_rssi": self.last_rssi,
+            "last_snr": self.last_snr,
+            "last_signal_rssi": self.last_signal_rssi,
+            "hardware_ready": self._initialized,
+            "driver": "pymc_tcp",
+            "host": self.host,
+            "port": self.port,
+            "tx_count": self._tx_count,
+            "rx_count": self._rx_count,
+        }
+
+    async def get_modem_status(self) -> Optional[dict]:
+        resp = await self._send_command(
+            CMD_STATUS_REQ, b"",
+            expect_cmd=CMD_STATUS_RESP,
+            timeout=2.0,
+        )
+        if resp and len(resp) >= STATUS_RESP_SIZE:
+            fields = struct.unpack(STATUS_RESP_FMT, resp[:STATUS_RESP_SIZE])
+            return {
+                "uptime_sec": fields[0],
+                "rx_count": fields[1],
+                "tx_count": fields[2],
+                "crc_errors": fields[3],
+                "last_rssi": fields[4],
+                "last_snr": fields[5] / 10.0,
+                "noise_floor": fields[6] / 10.0,
+                "temp_c": fields[7],
+                "radio_state": ["idle/rx", "tx", "error"][min(fields[8], 2)],
+            }
+        return None
+
+    def get_noise_floor(self) -> Optional[float]:
+        if not self._initialized:
+            return 0.0
+        if self._tx_lock.locked():
+            return 0.0
+        return self._noise_floor
+
+    async def refresh_noise_floor(self) -> Optional[float]:
+        resp = await self._send_command(
+            CMD_NOISE_REQ, b"",
+            expect_cmd=CMD_NOISE_RESP,
+            timeout=2.0,
+        )
+        if resp and len(resp) >= 2:
+            nf_x10 = struct.unpack("<h", resp[:2])[0]
+            self._noise_floor = nf_x10 / 10.0
+            logger.debug(f"Noise floor: {self._noise_floor:.1f} dBm")
+            return self._noise_floor
+        return None
+
+    async def perform_cad(
+        self,
+        det_peak: Optional[int] = None,
+        det_min: Optional[int] = None,
+        timeout: float = 1.0,
+        calibration: bool = False,
+    ) -> bool:
+        """Public CAD interface compatible with sx1262_wrapper.perform_cad().
+
+        When det_peak/det_min are supplied (e.g. by the repeater's CAD
+        calibration tool), program the chip with those thresholds via
+        CMD_SET_CAD_PARAMS before running the scan. Without this each
+        calibration sample would silently fall back to whatever thresholds
+        were last installed, defeating the sweep.
+        """
+        if det_peak is not None and det_min is not None:
+            new_peak = int(det_peak)
+            new_min = int(det_min)
+            # Skip the firmware roundtrip when thresholds haven't changed
+            # since the previous call. Saves ~50-80 ms per CAD during the
+            # repeated-sample phase of the calibration sweep.
+            if new_peak != self._custom_cad_peak or new_min != self._custom_cad_min:
+                payload = bytes([
+                    0x01,             # symNum: CAD_ON_2_SYMB
+                    new_peak & 0xFF,
+                    new_min & 0xFF,
+                    0x00,             # exitMode: STDBY
+                ])
+                await self._send_command(
+                    CMD_SET_CAD_PARAMS, payload,
+                    expect_cmd=CMD_CAD_PARAMS_RESP, timeout=2.0,
+                )
+                self._custom_cad_peak = new_peak
+                self._custom_cad_min = new_min
+
+        # Calibration engine passes 0.3s, which is tight for TCP transport
+        # with the firmware's CAD-prime delay; floor it so the sweep gets
+        # real samples instead of "no response → assumed clear".
+        effective = max(timeout, 0.6)
+        return await self._perform_cad(effective)
+
+    def cleanup(self):
+        self._initialized = False
+        self._stop_event.set()
+
+        if self._rx_thread and self._rx_thread.is_alive():
+            self._rx_thread.join(timeout=2.0)
+
+        self._close_sock()
+        logger.info("TCPLoRaRadio cleanup complete")
+
+    # ══════════════════════════════════════════════════════════
+    # Private — socket I/O
+    # ══════════════════════════════════════════════════════════
+
+    def _close_sock(self):
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+
+    def _sock_write(self, data: bytes):
+        """Thread-safe write to the TCP socket."""
+        if self._sock is None:
+            raise ConnectionError("socket not open")
+        with self._sock_lock:
+            self._sock.sendall(data)
+
+    def _auth_sync(self, timeout: float = 3.0) -> bool:
+        """Send CMD_AUTH with token payload, expect CMD_AUTH_OK."""
+        frame = build_frame(CMD_AUTH, self.token.encode("utf-8"))
+        self._sock_write(frame)
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            resp = self._read_frame_sync(timeout=max(0.1, deadline - time.time()))
+            if resp is None:
+                continue
+            cmd, payload = resp
+            if cmd == CMD_AUTH_OK:
+                logger.info("Modem accepted AUTH token")
+                return True
+            if cmd == CMD_ERROR:
+                err = payload[0] if payload else 0xFF
+                if err == ERR_UNAUTHORIZED:
+                    logger.error("AUTH rejected: ERR_UNAUTHORIZED")
+                    return False
+                logger.warning(f"Unexpected error during AUTH: 0x{err:02X}")
+            # Ignore other frames (e.g. broadcast RX) during auth handshake
+        return False
+
+    def _ping_sync(self, timeout: float = 3.0) -> bool:
+        frame = build_frame(CMD_PING)
+        self._sock_write(frame)
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            resp = self._read_frame_sync(timeout=max(0.1, deadline - time.time()))
+            if resp and resp[0] == CMD_PONG:
+                logger.info("Modem PONG received — alive")
+                return True
+        return False
+
+    def _apply_config_sync(self) -> bool:
+        payload = struct.pack(
+            RADIO_CONFIG_FMT,
+            self.frequency,
+            self.bandwidth,
+            self.spreading_factor,
+            self.coding_rate,
+            self.tx_power,
+            self.sync_word,
+            self.preamble_length,
+        )
+        frame = build_frame(CMD_SET_CONFIG, payload)
+        self._sock_write(frame)
+
+        # The firmware may emit RX_PACKET broadcasts concurrently; filter by cmd.
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            resp = self._read_frame_sync(timeout=max(0.1, deadline - time.time()))
+            if resp is None:
+                continue
+            cmd, payload = resp
+            if cmd == CMD_CONFIG_RESP:
+                logger.info(
+                    f"Radio configured: {self.frequency/1e6:.1f}MHz "
+                    f"SF{self.spreading_factor} BW{self.bandwidth/1000:.0f}kHz "
+                    f"{self.tx_power}dBm sync=0x{self.sync_word:04X} "
+                    f"pre={self.preamble_length}"
+                )
+                return True
+            if cmd == CMD_ERROR:
+                err = payload[0] if payload else 0xFF
+                logger.error(f"Config rejected by modem: error 0x{err:02X}")
+                return False
+            # Ignore RX_PACKET or other unrelated frames during config
+        logger.error("No config response from modem")
+        return False
+
+    def _read_frame_sync(self, timeout: float = 2.0) -> Optional[tuple]:
+        """Read one frame synchronously with a single timeout budget."""
+        if self._sock is None:
+            return None
+        try:
+            self._sock.settimeout(timeout)
+
+            # Look for SYNC byte
+            sync_found = False
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                b = self._sock.recv(1)
+                if not b:
+                    return None
+                if b[0] == PROTO_SYNC:
+                    sync_found = True
+                    break
+            if not sync_found:
+                return None
+
+            # Header (cmd + len)
+            hdr = b""
+            while len(hdr) < 3:
+                chunk = self._sock.recv(3 - len(hdr))
+                if not chunk:
+                    return None
+                hdr += chunk
+
+            cmd = hdr[0]
+            length = struct.unpack("<H", hdr[1:3])[0]
+
+            payload = b""
+            while len(payload) < length:
+                chunk = self._sock.recv(length - len(payload))
+                if not chunk:
+                    return None
+                payload += chunk
+
+            crc_bytes = b""
+            while len(crc_bytes) < 2:
+                chunk = self._sock.recv(2 - len(crc_bytes))
+                if not chunk:
+                    return None
+                crc_bytes += chunk
+
+            received_crc = struct.unpack("<H", crc_bytes)[0]
+            computed_crc = crc16_ccitt(hdr + payload)
+            if received_crc != computed_crc:
+                logger.warning(
+                    f"CRC mismatch: recv=0x{received_crc:04X} "
+                    f"comp=0x{computed_crc:04X}"
+                )
+                return None
+            return (cmd, payload)
+        except socket.timeout:
+            return None
+        except (OSError, ConnectionError) as e:
+            logger.warning(f"Socket read error: {e}")
+            return None
+
+    # ── RX background thread ─────────────────────────────────
+
+    def _reopen_socket(self) -> bool:
+        """Open a fresh TCP socket + auth + push config. Returns True on success.
+        Does NOT start a new RX worker (we are already in one); does NOT flip
+        self._initialized (the radio is still the same instance from the host's
+        point of view). Used by _reconnect_with_backoff after a dropped link."""
+        try:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.settimeout(self.connect_timeout)
+            self._sock.connect((self.host, self.port))
+            self._sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            logger.info(f"TCP re-connected to {self.host}:{self.port}")
+            if self.token and not self._auth_sync(timeout=3.0):
+                logger.error("Reconnect: AUTH rejected")
+                self._close_sock()
+                return False
+            if not self._ping_sync(timeout=3.0):
+                logger.error("Reconnect: PING failed")
+                self._close_sock()
+                return False
+            if not self._apply_config_sync():
+                logger.error("Reconnect: SET_CONFIG failed")
+                self._close_sock()
+                return False
+            # Re-apply custom CAD if host had programmed any.
+            if self._custom_cad_peak is not None and self._custom_cad_min is not None:
+                try:
+                    self.set_custom_cad_thresholds(peak=self._custom_cad_peak,
+                                                   min_val=self._custom_cad_min)
+                except Exception as e:
+                    logger.warning(f"Reconnect: re-push CAD failed: {e}")
+            return True
+        except Exception as e:
+            logger.error(f"Reconnect socket open failed: {e}")
+            self._close_sock()
+            return False
+
+    def _reconnect_with_backoff(self) -> bool:
+        """Exponential backoff (1, 2, 5, 10, 30 s) until socket is up or stop_event fires."""
+        for delay in (1.0, 2.0, 5.0, 10.0, 30.0):
+            if self._stop_event.is_set():
+                return False
+            logger.info(f"Reconnect attempt in {delay:.0f}s…")
+            if self._stop_event.wait(delay):
+                return False
+            if self._reopen_socket():
+                return True
+        # Last resort: keep trying at 30 s intervals forever.
+        while not self._stop_event.is_set():
+            if self._stop_event.wait(30.0):
+                return False
+            if self._reopen_socket():
+                return True
+        return False
+
+    def _rx_worker(self):
+        """Background thread: reads socket, dispatches RX packets and responses."""
+        logger.debug("RX worker thread started")
+        buf = bytearray()
+
+        while not self._stop_event.is_set():
+            try:
+                if self._sock is None:
+                    # Deferred-connect mode: begin() couldn't reach the
+                    # modem, so we drive the reconnect ourselves with the
+                    # same exponential backoff used after a runtime drop.
+                    # Returns False if stop_event fires while waiting.
+                    if not self._reconnect_with_backoff():
+                        return
+                    buf.clear()
+                    continue
+
+                # Short recv timeout so stop_event is honoured promptly
+                self._sock.settimeout(0.1)
+                try:
+                    chunk = self._sock.recv(4096)
+                except socket.timeout:
+                    continue
+                except (OSError, ConnectionError) as e:
+                    logger.error(f"Socket read error in RX worker: {e} — reconnecting")
+                    self._close_sock()
+                    buf.clear()
+                    if not self._reconnect_with_backoff():
+                        return
+                    continue
+
+                if not chunk:
+                    # Remote closed — try to reopen instead of dying; the
+                    # previous behaviour left tcp_radio permanently offline
+                    # until systemctl restart (known_issue_tcp_no_reconnect).
+                    logger.warning("TCP connection closed by peer — attempting reconnect")
+                    self._close_sock()
+                    buf.clear()
+                    if self._reconnect_with_backoff():
+                        continue
+                    return
+
+                buf.extend(chunk)
+
+                # Parse complete frames from buffer
+                while len(buf) >= 6:
+                    sync_idx = buf.find(PROTO_SYNC)
+                    if sync_idx < 0:
+                        buf.clear()
+                        break
+                    if sync_idx > 0:
+                        buf = buf[sync_idx:]
+
+                    if len(buf) < 4:
+                        break
+
+                    cmd = buf[1]
+                    length = buf[2] | (buf[3] << 8)
+                    # Sanity-cap the LEN field. The largest legitimate frame
+                    # is RX_PACKET (6 B header + MAX_LORA_PAYLOAD); anything
+                    # bigger means we're parsing garbage from a desync.
+                    # Drop the SYNC byte we just consumed and resync rather
+                    # than waiting indefinitely for a phantom 64 KB frame.
+                    if length > MAX_LORA_PAYLOAD + 32:
+                        logger.warning(
+                            f"RX frame LEN={length} exceeds sanity bound — "
+                            f"dropping SYNC byte and resyncing"
+                        )
+                        buf = buf[1:]
+                        continue
+                    frame_size = 1 + 1 + 2 + length + 2
+
+                    if len(buf) < frame_size:
+                        break
+
+                    hdr = bytes(buf[1:4])
+                    payload = bytes(buf[4 : 4 + length])
+                    crc_recv = buf[4 + length] | (buf[5 + length] << 8)
+                    crc_comp = crc16_ccitt(hdr + payload)
+
+                    buf = buf[frame_size:]
+
+                    if crc_recv != crc_comp:
+                        logger.warning(
+                            f"RX CRC mismatch, cmd=0x{cmd:02X}, dropping"
+                        )
+                        continue
+
+                    self._dispatch_frame(cmd, payload)
+
+            except Exception as e:
+                logger.error(f"RX worker error: {e}")
+                time.sleep(0.1)
+
+        logger.debug("RX worker thread exiting")
+
+    def _dispatch_frame(self, cmd: int, payload: bytes):
+        """Route a received frame."""
+
+        if cmd == CMD_RX_PACKET:
+            if len(payload) < 6:
+                logger.warning(f"RX_PACKET too short: {len(payload)}B")
+                return
+
+            rssi = struct.unpack("<h", payload[0:2])[0]
+            snr_x10 = struct.unpack("<h", payload[2:4])[0]
+            signal_rssi = struct.unpack("<h", payload[4:6])[0]
+            lora_data = payload[6:]
+
+            self.last_rssi = rssi
+            self.last_snr = snr_x10 / 10.0
+            self.last_signal_rssi = signal_rssi
+            self._rx_count += 1
+
+            logger.debug(
+                f"RX: {len(lora_data)}B RSSI={rssi}dBm "
+                f"SNR={snr_x10/10:.1f}dB"
+            )
+
+            if self.rx_callback:
+                if self._event_loop is None:
+                    try:
+                        self._event_loop = asyncio.get_event_loop()
+                    except RuntimeError:
+                        pass
+
+                if self._event_loop and self._event_loop.is_running():
+                    self._event_loop.call_soon_threadsafe(
+                        self.rx_callback, lora_data
+                    )
+                else:
+                    try:
+                        self.rx_callback(lora_data)
+                    except Exception as e:
+                        logger.error(f"RX callback error: {e}")
+            else:
+                logger.warning("RX packet but no callback registered")
+
+        elif cmd == CMD_ERROR:
+            err_code = payload[0] if payload else 0xFF
+            logger.warning(f"Modem error: 0x{err_code:02X}")
+            with self._response_lock:
+                for evt_cmd, evt in list(self._response_events.items()):
+                    self._response_data[evt_cmd] = None
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+        elif cmd == CMD_TX_FAIL:
+            # The TX request reached the radio but the chip never asserted
+            # TX_DONE before the firmware's own timeout. Wake up whoever is
+            # blocked on CMD_TX_DONE so the caller doesn't have to wait out
+            # the full 10 s driver timeout.
+            logger.warning("Modem TX_FAIL — radio did not assert TX_DONE")
+            with self._response_lock:
+                evt = self._response_events.get(CMD_TX_DONE)
+                if evt is not None:
+                    self._response_data[CMD_TX_DONE] = None
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+        else:
+            with self._response_lock:
+                if cmd in self._response_events:
+                    self._response_data[cmd] = payload
+                    evt = self._response_events[cmd]
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+    # ── Async command/response ────────────────────────────────
+
+    async def _send_command(
+        self,
+        cmd: int,
+        payload: bytes,
+        expect_cmd: int,
+        timeout: float = 5.0,
+    ) -> Optional[bytes]:
+        if self._sock is None:
+            return None
+
+        if self._event_loop is None:
+            try:
+                self._event_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+
+        evt = asyncio.Event()
+        with self._response_lock:
+            self._response_events[expect_cmd] = evt
+            self._response_data.pop(expect_cmd, None)
+
+        try:
+            frame = build_frame(cmd, payload)
+            try:
+                self._sock_write(frame)
+            except (OSError, ConnectionError) as e:
+                logger.error(f"TCP write failed: {e}")
+                return None
+
+            try:
+                await asyncio.wait_for(evt.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}"
+                )
+                return None
+
+            return self._response_data.get(expect_cmd)
+
+        finally:
+            with self._response_lock:
+                self._response_events.pop(expect_cmd, None)
+                self._response_data.pop(expect_cmd, None)
+
+    async def _perform_cad(self, timeout: float = 1.0) -> bool:
+        resp = await self._send_command(
+            CMD_CAD_REQUEST, b"",
+            expect_cmd=CMD_CAD_RESP,
+            timeout=timeout,
+        )
+        if resp and len(resp) >= 1:
+            busy = resp[0] != 0
+            logger.debug(f"CAD: {'BUSY' if busy else 'CLEAR'}")
+            return busy
+        logger.warning("CAD no response — assuming clear")
+        return False
+
+    # ── Config setters — live push to firmware ───────────────
+    #
+    # Callers (repeater HTTP UI) invoke these from threads that are not
+    # the asyncio loop, so we bridge with run_coroutine_threadsafe().
+    # Local state is always updated first; firmware ack is best-effort —
+    # a timeout downgrades to False but keeps the in-memory state current
+    # so the next begin()/_apply_config_sync will flush it.
+    def _run_async_safe(self, coro, wait_timeout: float = 6.0):
+        """Run *coro* on self._event_loop, whether we're on that loop or not.
+        On-loop caller: schedule with ensure_future (fire-and-forget, logs in bg).
+        Off-loop caller: block with run_coroutine_threadsafe and return its result.
+        Returns True on success/scheduled, False on timeout/exception."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is self._event_loop:
+            # Same thread/loop — can't block; schedule and log outcome asynchronously.
+            async def _bg():
+                try:
+                    res = await coro
+                    logger.info(f"Async config push result: ok={res is not None}")
+                except Exception as e:
+                    logger.error(f"Async config push error: {e}", exc_info=True)
+            asyncio.ensure_future(_bg())
+            return True
+        # Different thread — blocking wait is fine.
+        try:
+            fut = asyncio.run_coroutine_threadsafe(coro, self._event_loop)
+            resp = fut.result(timeout=wait_timeout)
+            return resp is not None
+        except Exception as e:
+            logger.error(f"Cross-thread config push error: {e}", exc_info=True)
+            return False
+
+    def _push_config_live(self, changed: str) -> bool:
+        if not self._initialized:
+            return True
+        if self._event_loop is None or not self._event_loop.is_running():
+            return True
+        payload = struct.pack(
+            RADIO_CONFIG_FMT,
+            self.frequency, self.bandwidth, self.spreading_factor,
+            self.coding_rate, self.tx_power, self.sync_word,
+            self.preamble_length,
+        )
+        ok = self._run_async_safe(
+            self._send_command(CMD_SET_CONFIG, payload,
+                               expect_cmd=CMD_CONFIG_RESP, timeout=5.0),
+            wait_timeout=6.0,
+        )
+        logger.info(f"Live config push ({changed}): {'OK' if ok else 'TIMEOUT'}")
+        return ok
+
+    def set_frequency(self, frequency: int) -> bool:
+        self.frequency = frequency
+        return self._push_config_live(f"freq={frequency}")
+
+    def set_tx_power(self, power: int) -> bool:
+        self.tx_power = power
+        return self._push_config_live(f"power={power}")
+
+    def set_spreading_factor(self, sf: int) -> bool:
+        self.spreading_factor = sf
+        return self._push_config_live(f"sf={sf}")
+
+    def set_bandwidth(self, bw: int) -> bool:
+        self.bandwidth = bw
+        return self._push_config_live(f"bw={bw}")
+
+    def set_coding_rate(self, cr: int) -> bool:
+        self.coding_rate = cr
+        return self._push_config_live(f"cr={cr}")
+
+    def set_preamble_length(self, preamble: int) -> bool:
+        self.preamble_length = preamble
+        return self._push_config_live(f"preamble={preamble}")
+
+    def set_sync_word(self, sync_word: int) -> bool:
+        self.sync_word = sync_word
+        return self._push_config_live(f"syncword=0x{sync_word:04X}")
+
+    # CAD thresholds — v0.5.4 firmware exposes them via CMD_SET_CAD_PARAMS.
+    # symNum=0x01 (2 symbols) and exitMode=0x00 (STDBY) match pymc_core SX1262 defaults.
+    def set_tcp_target(self, host: Optional[str] = None,
+                       port: Optional[int] = None,
+                       token: Optional[str] = None) -> bool:
+        """Change the modem TCP endpoint at runtime.
+
+        Updates self.host/port/token in place, closes the current socket,
+        and lets _rx_worker re-establish the connection via the existing
+        backoff path. Returns True if any field actually changed.
+
+        Use case: a fresh repeater install starts in deferred-connect mode
+        with a placeholder host; the user supplies the real one later
+        through a dedicated config panel, and we apply it without a
+        service restart.
+        """
+        changed = []
+        if host is not None and host != self.host:
+            self.host = host
+            changed.append(f"host={host}")
+        if port is not None:
+            try:
+                p = int(port)
+            except (TypeError, ValueError):
+                p = self.port
+            if p != self.port and 1 <= p <= 65535:
+                self.port = p
+                changed.append(f"port={p}")
+        if token is not None and token != self.token:
+            self.token = token
+            changed.append("token=***")
+
+        if not changed:
+            return False
+
+        logger.info(f"TCP target changed: {', '.join(changed)} — forcing reconnect")
+        # Drop the socket; _rx_worker sees self._sock is None and runs
+        # _reconnect_with_backoff against the new host/port.
+        self._close_sock()
+        return True
+
+    def set_custom_cad_thresholds(self, peak: int, min_val: int) -> bool:
+        self._custom_cad_peak = int(peak)
+        self._custom_cad_min = int(min_val)
+        if not self._initialized:
+            return True
+        if self._event_loop is None or not self._event_loop.is_running():
+            return True
+        payload = bytes([0x01, peak & 0xFF, min_val & 0xFF, 0x00])
+        ok = self._run_async_safe(
+            self._send_command(CMD_SET_CAD_PARAMS, payload,
+                               expect_cmd=CMD_CAD_PARAMS_RESP, timeout=3.0),
+            wait_timeout=4.0,
+        )
+        logger.info(f"CAD thresholds pushed peak={peak} min={min_val}: {'OK' if ok else 'TIMEOUT'}")
+        return ok
+
+    def clear_custom_cad_thresholds(self) -> None:
+        self._custom_cad_peak = None
+        self._custom_cad_min = None
+        # Firmware retains last programmed values until reboot; explicit
+        # reset would need a dedicated command — out of scope for v0.5.4.
+
+    def __del__(self):
+        try:
+            self.cleanup()
+        except Exception:
+            pass

--- a/src/pymc_core/hardware/usb_radio.py
+++ b/src/pymc_core/hardware/usb_radio.py
@@ -1,0 +1,994 @@
+"""
+USB LoRa Radio Driver for pymc_core
+
+Implements the LoRaRadio interface using a pymc_usb modem connected via
+USB-CDC. The modem acts as a "dumb" SX1262 transceiver — all MeshCore
+protocol logic runs on the host in pymc_core.
+
+Drop-in replacement for SX1262Radio in pymc_core's hardware layer.
+
+Default sync word is 0x12 (MeshCore private syncword), matching the
+firmware default — change only if the deployment uses a custom value.
+
+Usage:
+    from pymc_core.hardware.usb_radio import USBLoRaRadio
+
+    radio = USBLoRaRadio(
+        port="/dev/ttyACM0",
+        frequency=869618000,
+        bandwidth=62500,
+        spreading_factor=8,
+        coding_rate=8,
+        tx_power=22,
+        sync_word=0x12,
+        preamble_length=16,
+    )
+    radio.begin()
+    radio.set_rx_callback(my_callback)
+    await radio.send(packet_bytes)
+"""
+
+import asyncio
+import logging
+import random
+import struct
+import threading
+import time
+from typing import Callable, Optional
+
+import serial
+
+from .protocol_constants import (
+    PROTO_SYNC,
+    MAX_LORA_PAYLOAD,
+    CMD_TX_REQUEST, CMD_SET_CONFIG,
+    CMD_STATUS_REQ, CMD_NOISE_REQ,
+    CMD_CAD_REQUEST, CMD_RX_START, CMD_SET_CAD_PARAMS,
+    CMD_SET_WIFI, CMD_WIFI_RESET,
+    CMD_GET_WIFI, CMD_GET_VERSION, CMD_PING,
+    CMD_TX_DONE, CMD_TX_FAIL, CMD_RX_PACKET,
+    CMD_CONFIG_RESP, CMD_STATUS_RESP, CMD_NOISE_RESP,
+    CMD_CAD_RESP, CMD_RX_STARTED, CMD_CAD_PARAMS_RESP,
+    CMD_WIFI_STATUS, CMD_VERSION_RESP,
+    CMD_ERROR, CMD_PONG,
+    WIFI_MODE_OFFLINE, WIFI_MODE_STA_CONNECTING,
+    WIFI_MODE_STA_CONNECTED, WIFI_MODE_AP_CONFIG,
+    RADIO_CONFIG_FMT,
+    STATUS_RESP_FMT, STATUS_RESP_SIZE,
+    crc16_ccitt, build_frame,
+)
+
+logger = logging.getLogger("USBLoRaRadio")
+
+
+# Import LoRaRadio base conditionally — allows standalone testing
+try:
+    from pymc_core.hardware.base import LoRaRadio
+    _HAS_BASE = True
+except ImportError:
+    _HAS_BASE = False
+
+# Define the class with or without the ABC base
+if _HAS_BASE:
+    class _RadioBase(LoRaRadio):
+        pass
+else:
+    class _RadioBase:
+        pass
+
+
+class USBLoRaRadio(_RadioBase):
+    """USB LoRa Radio — pymc_core LoRaRadio interface over USB-CDC serial.
+
+    Communicates with any board running the pymc_usb firmware over a
+    USB-CDC serial link. Provides the same interface as SX1262Radio for
+    transparent integration with pymc_core's Dispatcher and MeshNode.
+    """
+
+    def __init__(
+        self,
+        port: str = "/dev/ttyACM0",
+        baudrate: int = 921600,
+        frequency: int = 869618000,
+        bandwidth: int = 62500,
+        spreading_factor: int = 8,
+        coding_rate: int = 8,
+        tx_power: int = 22,
+        sync_word: int = 0x12,
+        preamble_length: int = 16,
+        lbt_enabled: bool = True,
+        lbt_max_attempts: int = 5,
+    ):
+        self.port = port
+        self.baudrate = baudrate
+
+        # Radio config — matches SX1262Radio constructor params
+        self.frequency = frequency
+        self.bandwidth = bandwidth
+        self.spreading_factor = spreading_factor
+        self.coding_rate = coding_rate
+        self.tx_power = tx_power
+        self.sync_word = sync_word
+        self.preamble_length = preamble_length
+
+        # LBT (Listen Before Talk) via CAD
+        self.lbt_enabled = lbt_enabled
+        self.lbt_max_attempts = lbt_max_attempts
+
+        # State
+        self._serial: Optional[serial.Serial] = None
+        self._initialized = False
+        self._rx_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # Signal metrics — matches SX1262Radio interface
+        self.last_rssi: int = -99
+        self.last_snr: float = 0.0
+        self.last_signal_rssi: int = -99
+        self._noise_floor: float = -99.0
+
+        # RX callback — set by Dispatcher via set_rx_callback()
+        self.rx_callback: Optional[Callable[[bytes], None]] = None
+
+        # Response synchronization (command → response matching)
+        self._response_events: dict[int, asyncio.Event] = {}
+        self._response_data: dict[int, Optional[bytes]] = {}
+        self._response_lock = threading.Lock()
+
+        # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
+        # or perform_cad(det_peak=..., det_min=...); kept in attributes from
+        # construction so the calibration-sample fast-path doesn't trip on
+        # AttributeError before the first call.
+        self._custom_cad_peak: Optional[int] = None
+        self._custom_cad_min: Optional[int] = None
+
+        # TX lock to serialize transmissions (matches SX1262Radio)
+        self._tx_lock = asyncio.Lock()
+
+        # Stats
+        self._tx_count = 0
+        self._rx_count = 0
+
+        logger.info(
+            f"USBLoRaRadio configured: port={port}, freq={frequency/1e6:.1f}MHz, "
+            f"sf={spreading_factor}, bw={bandwidth/1000:.0f}kHz, "
+            f"power={tx_power}dBm, syncword=0x{sync_word:04X}"
+        )
+
+    # ══════════════════════════════════════════════════════════
+    # LoRaRadio interface implementation
+    # ══════════════════════════════════════════════════════════
+
+    def begin(self) -> bool:
+        """Initialize USB serial connection and configure the modem radio."""
+        if self._initialized:
+            return True
+
+        try:
+            # dsrdtr=True tells pyserial to leave DTR/DSR alone on open
+            # rather than pulsing them. On boards with a CP2102 (Heltec
+            # V3 et al.), pyserial's default toggles DTR and the CP2102
+            # in turn pulls EN low, rebooting the ESP32 every time we
+            # (re-)open the port. dsrdtr=True is the workaround; rtscts
+            # stays off because the firmware does not implement hardware
+            # flow control on the RX pipe.
+            self._serial = serial.Serial()
+            self._serial.port = self.port
+            self._serial.baudrate = self.baudrate
+            self._serial.timeout = 0.1
+            self._serial.write_timeout = 2.0
+            self._serial.dsrdtr = True
+            self._serial.rtscts = False
+            self._serial.open()
+
+            # Short settle in case the caller just power-cycled the device.
+            time.sleep(0.3)
+            self._serial.reset_input_buffer()
+            logger.info(f"Serial connected to {self.port}")
+
+            # 35 s covers the worst-case WifiManager::begin() STA-timeout if
+            # the host opens the port right after a cold boot.
+            # Skipping PING here on purpose: SET_CONFIG is itself a
+            # liveness check (firmware replies with CONFIG_RESP), and on
+            # macOS a PING immediately followed by SET_CONFIG confuses the
+            # CDC bulk pipe — CONFIG_RESP never arrives. Keep `_ping_sync`
+            # available for ad-hoc health probes, just don't chain it with
+            # SET_CONFIG at boot.
+            if not self._apply_config_sync():
+                logger.error("Failed to configure radio")
+                self._serial.close()
+                return False
+
+            # Start RX background thread
+            self._stop_event.clear()
+            self._rx_thread = threading.Thread(
+                target=self._rx_worker, daemon=True, name="usb-lora-rx"
+            )
+            self._rx_thread.start()
+
+            self._initialized = True
+            logger.info("USBLoRaRadio initialized successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to initialize USBLoRaRadio: {e}")
+            if self._serial and self._serial.is_open:
+                self._serial.close()
+            return False
+
+    async def send(self, data: bytes) -> Optional[dict]:
+        """Send a LoRa packet asynchronously with LBT (CAD).
+
+        Returns transmission metadata dict matching SX1262Radio.send():
+            {
+                "airtime_ms": float,
+                "lbt_attempts": int,
+                "lbt_backoff_delays_ms": list[float],
+                "lbt_channel_busy": bool,
+            }
+        Returns None on failure.
+        """
+        if not self._initialized:
+            logger.error("Radio not initialized")
+            return None
+
+        async with self._tx_lock:
+            lbt_backoff_delays: list[float] = []
+
+            # ── Listen Before Talk (CAD) ─────────────────────
+            if self.lbt_enabled:
+                for attempt in range(self.lbt_max_attempts):
+                    try:
+                        channel_busy = await self._perform_cad(timeout=1.0)
+                        if not channel_busy:
+                            logger.debug(
+                                f"CAD clear after {attempt + 1} attempt(s)"
+                            )
+                            break
+                        else:
+                            logger.debug("CAD busy — channel activity detected")
+                            if attempt < self.lbt_max_attempts - 1:
+                                base_delay = random.randint(50, 200)
+                                backoff_ms = min(
+                                    base_delay * (2 ** attempt), 5000
+                                )
+                                lbt_backoff_delays.append(float(backoff_ms))
+                                logger.debug(
+                                    f"CAD backoff {backoff_ms}ms "
+                                    f"(attempt {attempt+1}/{self.lbt_max_attempts})"
+                                )
+                                await asyncio.sleep(backoff_ms / 1000.0)
+                            else:
+                                logger.warning(
+                                    "CAD max attempts — transmitting anyway"
+                                )
+                    except Exception as e:
+                        logger.warning(f"CAD failed: {e}, proceeding with TX")
+                        break
+
+            # ── Transmit ─────────────────────────────────────
+            try:
+                resp = await self._send_command(
+                    CMD_TX_REQUEST, data,
+                    expect_cmd=CMD_TX_DONE,
+                    timeout=10.0,
+                )
+
+                if resp is not None:
+                    self._tx_count += 1
+
+                    # Parse airtime from TX_DONE payload (uint32 LE, microseconds)
+                    airtime_us = 0
+                    if len(resp) >= 4:
+                        airtime_us = struct.unpack("<I", resp[:4])[0]
+                    airtime_ms = airtime_us / 1000.0
+
+                    logger.debug(
+                        f"TX done: {len(data)}B, airtime={airtime_ms:.1f}ms"
+                    )
+
+                    # Restore RX continuous mode
+                    await self._send_command(
+                        CMD_RX_START, b"",
+                        expect_cmd=CMD_RX_STARTED,
+                        timeout=2.0,
+                    )
+
+                    return {
+                        "airtime_ms": airtime_ms,
+                        "lbt_attempts": len(lbt_backoff_delays),
+                        "lbt_backoff_delays_ms": lbt_backoff_delays,
+                        "lbt_channel_busy": len(lbt_backoff_delays) > 0,
+                    }
+                else:
+                    logger.error("TX failed — no TX_DONE response")
+                    # Try to restore RX anyway
+                    await self._send_command(
+                        CMD_RX_START, b"",
+                        expect_cmd=CMD_RX_STARTED,
+                        timeout=2.0,
+                    )
+                    return None
+
+            except Exception as e:
+                logger.error(f"TX error: {e}")
+                return None
+
+    async def wait_for_rx(self) -> bytes:
+        """Not used — packets arrive via set_rx_callback()."""
+        raise NotImplementedError(
+            "Use set_rx_callback(callback) to receive packets asynchronously."
+        )
+
+    def set_rx_callback(self, callback: Callable[[bytes], None]):
+        """Set RX callback — called by Dispatcher to register _on_packet_received."""
+        self.rx_callback = callback
+        logger.info("RX callback registered")
+
+        # Capture event loop for thread-safe async event dispatch
+        try:
+            self._event_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+
+    def sleep(self):
+        """Put radio into low-power mode (not typically used with USB modem)."""
+        logger.debug("Sleep not applicable for USB modem")
+
+    def get_last_rssi(self) -> int:
+        return self.last_rssi
+
+    def get_last_snr(self) -> float:
+        return self.last_snr
+
+    def get_last_signal_rssi(self) -> int:
+        return self.last_signal_rssi
+
+    # ══════════════════════════════════════════════════════════
+    # Extended interface (matching SX1262Radio extras used by pymc_core)
+    # ══════════════════════════════════════════════════════════
+
+    def check_radio_health(self) -> bool:
+        """Health check — verify RX thread is alive, restart if dead.
+
+        Called by Dispatcher.run_forever() every 60 seconds.
+        Also triggers a noise floor refresh from the modem.
+        """
+        if not self._initialized:
+            return False
+
+        # Check RX thread
+        if self._rx_thread is None or not self._rx_thread.is_alive():
+            logger.warning("RX thread dead — restarting")
+            self._stop_event.clear()
+            self._rx_thread = threading.Thread(
+                target=self._rx_worker, daemon=True, name="usb-lora-rx"
+            )
+            self._rx_thread.start()
+            return False
+
+        # Schedule noise floor refresh (non-blocking)
+        if self._event_loop:
+            self._event_loop.call_soon_threadsafe(
+                lambda: self._event_loop.create_task(self.refresh_noise_floor())
+            )
+
+        return True
+
+    def get_status(self) -> dict:
+        """Get radio status dict (matches SX1262Radio.get_status())."""
+        return {
+            "initialized": self._initialized,
+            "frequency": self.frequency,
+            "tx_power": self.tx_power,
+            "spreading_factor": self.spreading_factor,
+            "bandwidth": self.bandwidth,
+            "coding_rate": self.coding_rate,
+            "last_rssi": self.last_rssi,
+            "last_snr": self.last_snr,
+            "last_signal_rssi": self.last_signal_rssi,
+            "hardware_ready": self._initialized,
+            "driver": "pymc_usb",
+            "port": self.port,
+            "tx_count": self._tx_count,
+            "rx_count": self._rx_count,
+        }
+
+    async def get_modem_status(self) -> Optional[dict]:
+        """Query detailed status from the modem firmware."""
+        resp = await self._send_command(
+            CMD_STATUS_REQ, b"",
+            expect_cmd=CMD_STATUS_RESP,
+            timeout=2.0,
+        )
+        if resp and len(resp) >= STATUS_RESP_SIZE:
+            fields = struct.unpack(STATUS_RESP_FMT, resp[:STATUS_RESP_SIZE])
+            return {
+                "uptime_sec": fields[0],
+                "rx_count": fields[1],
+                "tx_count": fields[2],
+                "crc_errors": fields[3],
+                "last_rssi": fields[4],
+                "last_snr": fields[5] / 10.0,
+                "noise_floor": fields[6] / 10.0,
+                "temp_c": fields[7],
+                "radio_state": ["idle/rx", "tx", "error"][
+                    min(fields[8], 2)
+                ],
+            }
+        return None
+
+    def get_noise_floor(self) -> Optional[float]:
+        """Get current noise floor in dBm.
+
+        Matches SX1262Radio.get_noise_floor() interface.
+        The noise floor is continuously sampled by the modem firmware
+        using the same algorithm as SX1262Radio._sample_noise_floor():
+        - 20 instantaneous RSSI samples during quiet periods
+        - 500ms quiet time after last packet before sampling
+        - Samples above floor + 10dB threshold rejected
+        - Averaged and clamped to -150...-50 dBm
+
+        This is a synchronous method returning the cached value.
+        The firmware updates it autonomously. For a fresh read,
+        use await get_modem_status() which returns noise_floor.
+        """
+        if not self._initialized:
+            return 0.0
+        if self._tx_lock.locked():
+            return 0.0
+        return self._noise_floor
+
+    async def refresh_noise_floor(self) -> Optional[float]:
+        """Query fresh noise floor from modem firmware.
+
+        Returns noise floor in dBm, or None on failure.
+        Also updates the cached self._noise_floor value.
+        """
+        resp = await self._send_command(
+            CMD_NOISE_REQ, b"",
+            expect_cmd=CMD_NOISE_RESP,
+            timeout=2.0,
+        )
+        if resp and len(resp) >= 2:
+            nf_x10 = struct.unpack("<h", resp[:2])[0]
+            self._noise_floor = nf_x10 / 10.0
+            logger.debug(f"Noise floor: {self._noise_floor:.1f} dBm")
+            return self._noise_floor
+        return None
+
+    async def perform_cad(
+        self,
+        det_peak: Optional[int] = None,
+        det_min: Optional[int] = None,
+        timeout: float = 1.0,
+        calibration: bool = False,
+    ) -> bool:
+        """Public CAD interface matching SX1262Radio.perform_cad().
+
+        When det_peak/det_min are supplied (used by the repeater CAD
+        calibration tool to sweep different thresholds), program the chip
+        with those values via CMD_SET_CAD_PARAMS before running the scan.
+        """
+        if det_peak is not None and det_min is not None:
+            new_peak = int(det_peak)
+            new_min = int(det_min)
+            # Same caching rationale as tcp_radio: avoid re-sending unchanged
+            # thresholds during the per-sample inner loop of calibration.
+            if new_peak != self._custom_cad_peak or new_min != self._custom_cad_min:
+                payload = bytes([
+                    0x01,
+                    new_peak & 0xFF,
+                    new_min & 0xFF,
+                    0x00,
+                ])
+                await self._send_command(
+                    CMD_SET_CAD_PARAMS, payload,
+                    expect_cmd=CMD_CAD_PARAMS_RESP, timeout=2.0,
+                )
+                self._custom_cad_peak = new_peak
+                self._custom_cad_min = new_min
+
+        # Calibration tool sends timeout=0.3 which is tight for our stack;
+        # raise the floor so we don't lose samples to "no response".
+        effective = max(timeout, 0.6)
+        return await self._perform_cad(effective)
+
+    # ── Wi-Fi / OTA provisioning (v0.5) ───────────────────────
+
+    async def set_wifi_credentials(
+        self,
+        ssid: str,
+        password: str,
+        tcp_port: int = 5055,
+        tcp_token: str = "",
+    ) -> Optional[dict]:
+        """Provision Wi-Fi credentials over USB and reboot into STA mode.
+
+        After this call the modem saves SSID/password/port/token to NVS,
+        responds with a WIFI_STATUS frame showing the pending config, then
+        reboots. USB link drops during reboot — caller should re-open the
+        serial port and call `begin()` again, then verify with
+        `get_wifi_status()` that STA came up.
+
+        tcp_token: shared secret. Empty = open LAN (TCP + HTTP OTA). Non-empty
+        enforces CMD_AUTH on TCP and Basic-auth (user='heltec') on HTTP /update.
+
+        Returns the pending WIFI_STATUS dict, or None on timeout/error.
+        """
+        ssid_b = ssid.encode("utf-8")
+        pass_b = password.encode("utf-8")
+        tok_b = tcp_token.encode("utf-8")
+        if len(ssid_b) == 0 or len(ssid_b) > 32:
+            raise ValueError("SSID must be 1..32 bytes")
+        if len(pass_b) > 64:
+            raise ValueError("password must be <=64 bytes")
+        if len(tok_b) > 64:
+            raise ValueError("token must be <=64 bytes")
+        if not (1 <= tcp_port <= 65535):
+            raise ValueError("tcp_port out of range")
+
+        payload = (
+            bytes([len(ssid_b)]) + ssid_b +
+            bytes([len(pass_b)]) + pass_b +
+            struct.pack("<H", tcp_port) +
+            bytes([len(tok_b)]) + tok_b
+        )
+        resp = await self._send_command(
+            CMD_SET_WIFI, payload, expect_cmd=CMD_WIFI_STATUS, timeout=3.0
+        )
+        if resp is None:
+            return None
+        return self._parse_wifi_status(resp)
+
+    async def get_wifi_status(self) -> Optional[dict]:
+        """Query current Wi-Fi/OTA status.
+
+        Returns a dict:
+            {
+              "mode": int,          # 0=off 1=connecting 2=STA 3=AP
+              "mode_name": str,
+              "ip": str,            # "192.168.1.42" or "0.0.0.0"
+              "port": int,          # TCP port
+              "ssid": str,
+              "hostname": str,      # "pymc-ab12cd" — append ".local" for mDNS
+              "mdns": str,          # "pymc-ab12cd.local"
+            }
+        or None on timeout.
+        """
+        resp = await self._send_command(
+            CMD_GET_WIFI, b"", expect_cmd=CMD_WIFI_STATUS, timeout=2.0
+        )
+        if resp is None:
+            return None
+        return self._parse_wifi_status(resp)
+
+    async def get_version(self) -> Optional[str]:
+        """Return firmware version string (e.g. 'v0.5.3').
+
+        None if the modem doesn't implement CMD_GET_VERSION (pre-v0.5.3 firmware)
+        or the request times out.
+        """
+        resp = await self._send_command(
+            CMD_GET_VERSION, b"", expect_cmd=CMD_VERSION_RESP, timeout=2.0
+        )
+        if resp is None:
+            return None
+        try:
+            return resp.decode("ascii", errors="replace")
+        except Exception:
+            return None
+
+    async def wifi_reset(self) -> bool:
+        """Wipe Wi-Fi NVS and reboot into AP config portal.
+
+        Device will reboot and drop the serial link. USB OTA/provisioning
+        remains possible via `set_wifi_credentials()` after re-connecting.
+        """
+        resp = await self._send_command(
+            CMD_WIFI_RESET, b"", expect_cmd=CMD_WIFI_RESET, timeout=2.0
+        )
+        return resp is not None
+
+    @staticmethod
+    def _parse_wifi_status(payload: bytes) -> Optional[dict]:
+        """Parse WIFI_STATUS payload (see protocol.h for layout)."""
+        try:
+            i = 0
+            mode = payload[i]
+            i += 1
+            ip = f"{payload[i]}.{payload[i+1]}.{payload[i+2]}.{payload[i+3]}"
+            i += 4
+            port = payload[i] | (payload[i+1] << 8)
+            i += 2
+            slen = payload[i]
+            i += 1
+            ssid = payload[i:i+slen].decode("utf-8", errors="replace")
+            i += slen
+            hlen = payload[i]
+            i += 1
+            host = payload[i:i+hlen].decode("utf-8", errors="replace")
+        except (IndexError, UnicodeDecodeError) as e:
+            logger.error(f"Malformed WIFI_STATUS: {e}")
+            return None
+
+        mode_names = {
+            WIFI_MODE_OFFLINE: "offline",
+            WIFI_MODE_STA_CONNECTING: "connecting",
+            WIFI_MODE_STA_CONNECTED: "sta",
+            WIFI_MODE_AP_CONFIG: "ap",
+        }
+        return {
+            "mode": mode,
+            "mode_name": mode_names.get(mode, "unknown"),
+            "ip": ip,
+            "port": port,
+            "ssid": ssid,
+            "hostname": host,
+            "mdns": f"{host}.local" if host else "",
+        }
+
+    def cleanup(self):
+        """Clean up resources."""
+        self._initialized = False
+        self._stop_event.set()
+
+        if self._rx_thread and self._rx_thread.is_alive():
+            self._rx_thread.join(timeout=2.0)
+
+        if self._serial and self._serial.is_open:
+            self._serial.close()
+
+        logger.info("USBLoRaRadio cleanup complete")
+
+    # ══════════════════════════════════════════════════════════
+    # Private — serial I/O
+    # ══════════════════════════════════════════════════════════
+
+    def _ping_sync(self, timeout: float = 3.0) -> bool:
+        """Synchronous ping — ad-hoc liveness probe.
+
+        Not used from begin() on purpose: on macOS, chaining PING and
+        SET_CONFIG into the same CDC bulk stream causes SET_CONFIG to be
+        silently dropped. Keep this for explicit health checks.
+        """
+        frame = build_frame(CMD_PING)
+        self._serial.write(frame)
+
+        resp = self._read_frame_sync(timeout=timeout, expect_cmd=CMD_PONG)
+        logger.debug(f"PING _read_frame_sync returned: {resp}")
+        if resp and resp[0] == CMD_PONG:
+            logger.info("Modem PONG received — alive")
+            return True
+        return False
+
+    def _apply_config_sync(self) -> bool:
+        """Synchronous config push — used during begin()."""
+        payload = struct.pack(
+            RADIO_CONFIG_FMT,
+            self.frequency,
+            self.bandwidth,
+            self.spreading_factor,
+            self.coding_rate,
+            self.tx_power,
+            self.sync_word,
+            self.preamble_length,
+        )
+        frame = build_frame(CMD_SET_CONFIG, payload)
+        self._serial.write(frame)
+
+        # 10 s covers the worst case where a burst of RX_PACKET frames from
+        # nearby MeshCore nodes arrives ahead of CONFIG_RESP and the filter
+        # has to skip them.
+        resp = self._read_frame_sync(timeout=10.0, expect_cmd=CMD_CONFIG_RESP)
+        if resp and resp[0] == CMD_CONFIG_RESP:
+            logger.info(
+                f"Radio configured: {self.frequency/1e6:.1f}MHz SF{self.spreading_factor} "
+                f"BW{self.bandwidth/1000:.0f}kHz {self.tx_power}dBm "
+                f"sync=0x{self.sync_word:04X} pre={self.preamble_length}"
+            )
+            return True
+        elif resp and resp[0] == CMD_ERROR:
+            err = resp[1][0] if len(resp) > 1 and len(resp[1]) > 0 else 0xFF
+            logger.error(f"Config rejected by modem: error 0x{err:02X}")
+            return False
+        else:
+            logger.error("No config response from modem")
+            return False
+
+    def _read_frame_sync(
+        self,
+        timeout: float = 2.0,
+        expect_cmd: Optional[int] = None,
+    ) -> Optional[tuple]:
+        """Read one frame synchronously. Returns (cmd, payload) or None.
+
+        When `expect_cmd` is set, frames with a different cmd byte are
+        discarded silently (common case: RX_PACKET from nearby MeshCore
+        nodes arriving between our command and its response). The single
+        `timeout` applies to the whole wait, not per-frame.
+        """
+        old_timeout = self._serial.timeout
+        # Short per-read timeout keeps us responsive; the overall wait is
+        # bounded by `deadline`. Longer timeouts (e.g. 35s) were observed
+        # to swallow incoming bytes on macOS + CP2102, so we poll instead.
+        self._serial.timeout = 0.2
+        deadline = time.time() + timeout
+        try:
+            while time.time() < deadline:
+                b = self._serial.read(1)
+                if len(b) == 0:
+                    continue
+                if b[0] != PROTO_SYNC:
+                    continue
+
+                # A loose 0xAA byte can appear inside an RX_PACKET payload;
+                # if we can't complete the frame (short read / bad CRC),
+                # go back to scanning for the next SYNC instead of bailing.
+                hdr = self._serial.read(3)
+                if len(hdr) < 3:
+                    continue
+                cmd = hdr[0]
+                length = struct.unpack("<H", hdr[1:3])[0]
+                if length > MAX_LORA_PAYLOAD + 16:
+                    continue   # garbage length — must be a fake SYNC
+
+                payload = self._serial.read(length) if length > 0 else b""
+                if len(payload) < length:
+                    continue
+
+                crc_bytes = self._serial.read(2)
+                if len(crc_bytes) < 2:
+                    continue
+
+                received_crc = struct.unpack("<H", crc_bytes)[0]
+                computed_crc = crc16_ccitt(hdr + payload)
+                if received_crc != computed_crc:
+                    logger.debug(
+                        f"CRC mismatch (likely fake SYNC in payload): "
+                        f"recv=0x{received_crc:04X} comp=0x{computed_crc:04X}"
+                    )
+                    continue
+
+                if expect_cmd is not None and cmd != expect_cmd:
+                    if cmd == CMD_ERROR:
+                        return (cmd, payload)
+                    continue
+
+                return (cmd, payload)
+            return None
+        finally:
+            self._serial.timeout = old_timeout
+
+    # ── RX background thread ─────────────────────────────────
+
+    def _rx_worker(self):
+        """Background thread: reads serial, dispatches RX packets and command responses."""
+        logger.debug("RX worker thread started")
+        buf = bytearray()
+
+        while not self._stop_event.is_set():
+            try:
+                if not self._serial or not self._serial.is_open:
+                    time.sleep(0.1)
+                    continue
+
+                waiting = self._serial.in_waiting
+                if waiting > 0:
+                    buf.extend(self._serial.read(waiting))
+                else:
+                    time.sleep(0.001)
+                    continue
+
+                # Parse complete frames from buffer
+                while len(buf) >= 6:  # Min frame: SYNC+CMD+LEN(2)+CRC(2)
+                    # Find sync
+                    sync_idx = buf.find(PROTO_SYNC)
+                    if sync_idx < 0:
+                        buf.clear()
+                        break
+                    if sync_idx > 0:
+                        buf = buf[sync_idx:]
+
+                    if len(buf) < 4:
+                        break
+
+                    cmd = buf[1]
+                    length = buf[2] | (buf[3] << 8)
+                    # Sanity-cap the LEN field. The largest legitimate frame
+                    # is RX_PACKET (6 B header + MAX_LORA_PAYLOAD); anything
+                    # bigger means we're parsing garbage from a desync.
+                    # Drop the SYNC byte we just consumed and resync rather
+                    # than waiting indefinitely for a phantom 64 KB frame.
+                    if length > MAX_LORA_PAYLOAD + 32:
+                        logger.warning(
+                            f"RX frame LEN={length} exceeds sanity bound — "
+                            f"dropping SYNC byte and resyncing"
+                        )
+                        buf = buf[1:]
+                        continue
+                    frame_size = 1 + 1 + 2 + length + 2
+
+                    if len(buf) < frame_size:
+                        break  # Incomplete frame, wait for more
+
+                    # Extract frame
+                    hdr = bytes(buf[1:4])
+                    payload = bytes(buf[4 : 4 + length])
+                    crc_recv = buf[4 + length] | (buf[5 + length] << 8)
+                    crc_comp = crc16_ccitt(hdr + payload)
+
+                    # Consume frame
+                    buf = buf[frame_size:]
+
+                    if crc_recv != crc_comp:
+                        logger.warning(
+                            f"RX CRC mismatch, cmd=0x{cmd:02X}, dropping"
+                        )
+                        continue
+
+                    self._dispatch_frame(cmd, payload)
+
+            except serial.SerialException as e:
+                logger.error(f"Serial error in RX worker: {e}")
+                time.sleep(1.0)
+            except Exception as e:
+                logger.error(f"RX worker error: {e}")
+                time.sleep(0.1)
+
+        logger.debug("RX worker thread exiting")
+
+    def _dispatch_frame(self, cmd: int, payload: bytes):
+        """Route a received frame to the right handler."""
+
+        if cmd == CMD_RX_PACKET:
+            # ── LoRa packet received ─────────────────────────
+            if len(payload) < 6:
+                logger.warning(f"RX_PACKET too short: {len(payload)}B")
+                return
+
+            rssi = struct.unpack("<h", payload[0:2])[0]
+            snr_x10 = struct.unpack("<h", payload[2:4])[0]
+            signal_rssi = struct.unpack("<h", payload[4:6])[0]
+            lora_data = payload[6:]
+
+            self.last_rssi = rssi
+            self.last_snr = snr_x10 / 10.0
+            self.last_signal_rssi = signal_rssi
+            self._rx_count += 1
+
+            logger.debug(
+                f"RX: {len(lora_data)}B RSSI={rssi}dBm "
+                f"SNR={snr_x10/10:.1f}dB"
+            )
+
+            # Invoke RX callback on the event loop thread.
+            # pymc_core dispatcher._on_packet_received calls asyncio.get_running_loop()
+            # inside the callback; if we invoke it from this worker thread, it raises
+            # RuntimeError and the packet is silently dropped (dispatcher.py:306-308).
+            if self.rx_callback:
+                if self._event_loop and self._event_loop.is_running():
+                    self._event_loop.call_soon_threadsafe(self.rx_callback, lora_data)
+                else:
+                    logger.warning("RX packet but event loop not running — dropping")
+            else:
+                logger.warning("RX packet but no callback registered")
+
+        elif cmd == CMD_ERROR:
+            err_code = payload[0] if len(payload) > 0 else 0xFF
+            logger.warning(f"Modem error: 0x{err_code:02X}")
+            # Also signal any waiting command in case the error
+            # is a response to our command
+            with self._response_lock:
+                for evt_cmd, evt in list(self._response_events.items()):
+                    self._response_data[evt_cmd] = None
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+        elif cmd == CMD_TX_FAIL:
+            # The TX request reached the radio but the chip never asserted
+            # TX_DONE before the firmware's own timeout. Wake up whoever is
+            # blocked on CMD_TX_DONE so the caller doesn't sit on the full
+            # driver timeout.
+            logger.warning("Modem TX_FAIL — radio did not assert TX_DONE")
+            with self._response_lock:
+                evt = self._response_events.get(CMD_TX_DONE)
+                if evt is not None:
+                    self._response_data[CMD_TX_DONE] = None
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+        else:
+            # ── Command response ─────────────────────────────
+            with self._response_lock:
+                if cmd in self._response_events:
+                    self._response_data[cmd] = payload
+                    evt = self._response_events[cmd]
+                    if self._event_loop:
+                        self._event_loop.call_soon_threadsafe(evt.set)
+
+    # ── Async command/response ────────────────────────────────
+
+    async def _send_command(
+        self,
+        cmd: int,
+        payload: bytes,
+        expect_cmd: int,
+        timeout: float = 5.0,
+    ) -> Optional[bytes]:
+        """Send a command frame and wait for a specific response frame."""
+        if not self._serial or not self._serial.is_open:
+            return None
+
+        # Ensure event loop is captured
+        if self._event_loop is None:
+            try:
+                self._event_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+
+        # Register response expectation
+        evt = asyncio.Event()
+        with self._response_lock:
+            self._response_events[expect_cmd] = evt
+            self._response_data.pop(expect_cmd, None)
+
+        try:
+            frame = build_frame(cmd, payload)
+            self._serial.write(frame)
+            self._serial.flush()
+
+            try:
+                await asyncio.wait_for(evt.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}"
+                )
+                return None
+
+            return self._response_data.get(expect_cmd)
+
+        finally:
+            with self._response_lock:
+                self._response_events.pop(expect_cmd, None)
+                self._response_data.pop(expect_cmd, None)
+
+    async def _perform_cad(self, timeout: float = 1.0) -> bool:
+        """Perform Channel Activity Detection. Returns True if busy."""
+        resp = await self._send_command(
+            CMD_CAD_REQUEST, b"",
+            expect_cmd=CMD_CAD_RESP,
+            timeout=timeout,
+        )
+        if resp and len(resp) >= 1:
+            busy = resp[0] != 0
+            logger.debug(f"CAD: {'BUSY' if busy else 'CLEAR'}")
+            return busy
+        else:
+            logger.warning("CAD no response — assuming clear")
+            return False
+
+    # ── Config setters (for runtime reconfiguration) ──────────
+
+    def set_frequency(self, frequency: int) -> bool:
+        self.frequency = frequency
+        return True
+
+    def set_tx_power(self, power: int) -> bool:
+        self.tx_power = power
+        return True
+
+    def set_spreading_factor(self, sf: int) -> bool:
+        self.spreading_factor = sf
+        return True
+
+    def set_bandwidth(self, bw: int) -> bool:
+        self.bandwidth = bw
+        return True
+
+    def __del__(self):
+        try:
+            self.cleanup()
+        except Exception:
+            pass

--- a/tests/hardware/test_protocol_constants.py
+++ b/tests/hardware/test_protocol_constants.py
@@ -1,0 +1,150 @@
+"""
+Offline tests for the shared pymc_usb wire-protocol primitives.
+
+Verifies CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, no reflect,
+no xor-out) and frame layout produced by `crc16_ccitt` / `build_frame`
+against fixed reference vectors so the firmware and both Python drivers
+(USB + TCP) cannot drift apart silently.
+
+No network, no hardware — these run in CI on a bare interpreter.
+
+Place this file at:
+    tests/hardware/test_protocol_constants.py
+"""
+
+import struct
+
+import pytest
+
+from pymc_core.hardware.protocol_constants import (
+    CMD_PING,
+    CMD_TX_REQUEST,
+    PROTO_SYNC,
+    build_frame,
+    crc16_ccitt,
+)
+
+
+# ───────────────────────── CRC ─────────────────────────────────────
+
+
+def test_crc_empty_buffer_is_init_value():
+    """Empty input → CRC stays at the init value 0xFFFF."""
+    assert crc16_ccitt(b"") == 0xFFFF
+
+
+def test_crc_ccitt_false_canonical_vector():
+    """
+    Canonical CRC-16/CCITT-FALSE check vector: CRC("123456789") == 0x29B1.
+
+    If this fails, the polynomial, initial value, or bit ordering have
+    drifted from the firmware's `crc16_ccitt` in `protocol.h`.
+    """
+    assert crc16_ccitt(b"123456789") == 0x29B1
+
+
+def test_crc_single_byte_zero():
+    """CRC(0x00) is a stable spot-check: 0xE1F0."""
+    assert crc16_ccitt(b"\x00") == 0xE1F0
+
+
+# ───────────────────────── Frame layout ────────────────────────────
+
+
+def test_ping_frame_layout():
+    """
+    PING frame is the simplest case: SYNC | CMD | LEN(2) | CRC(2).
+    Empty payload → 6 bytes total, no payload field in between.
+    """
+    frame = build_frame(CMD_PING)
+    assert len(frame) == 6
+    assert frame[0] == PROTO_SYNC
+    assert frame[1] == CMD_PING
+    assert frame[2:4] == b"\x00\x00"  # length = 0, little-endian
+
+
+@pytest.mark.parametrize("n", [1, 16, 100, 200, 255])
+def test_frame_with_payload_total_length(n):
+    """Total frame length = 1 (SYNC) + 1 (CMD) + 2 (LEN) + N + 2 (CRC)."""
+    payload = b"\xAB" * n
+    frame = build_frame(CMD_TX_REQUEST, payload)
+    assert len(frame) == 6 + n
+
+
+def test_payload_passes_through_unchanged():
+    """Build a frame and confirm the payload bytes are at the expected offset."""
+    payload = bytes(range(100))
+    frame = build_frame(CMD_TX_REQUEST, payload)
+    assert frame[4 : 4 + 100] == payload
+
+
+def test_length_field_is_little_endian():
+    """
+    300-byte payload exercises both LEN bytes. LE encoding of 300 = 0x012C
+    → bytes [0x2C, 0x01]. If we serialized big-endian, this would be [0x01, 0x2C].
+    """
+    payload = b"\x55" * 300
+    frame = build_frame(CMD_TX_REQUEST, payload)
+    assert frame[2:4] == b"\x2C\x01"
+
+
+def test_crc_covers_cmd_len_payload_but_not_sync():
+    """
+    Per protocol.h: CRC is computed over CMD + LEN + PAYLOAD, *not* over SYNC.
+    Verify by rebuilding the CRC from the raw bytes we expect it to cover.
+    """
+    payload = b"hello world"
+    frame = build_frame(CMD_TX_REQUEST, payload)
+
+    # Last 2 bytes of the frame are the CRC, little-endian.
+    crc_in_frame = struct.unpack("<H", frame[-2:])[0]
+
+    # Everything except SYNC (first byte) and CRC (last 2 bytes) is CRC input.
+    covered = frame[1:-2]
+    assert crc16_ccitt(covered) == crc_in_frame
+
+
+def test_crc_is_little_endian_on_the_wire():
+    """
+    A non-symmetric CRC value lets us distinguish endianness. Build a
+    TX_REQUEST with a known payload; expected CRC bytes are the explicit
+    LE pair `struct.pack('<H', crc)`.
+    """
+    payload = b"\x01\x02\x03\x04"
+    frame = build_frame(CMD_TX_REQUEST, payload)
+    expected_crc = crc16_ccitt(frame[1:-2])
+    assert frame[-2:] == struct.pack("<H", expected_crc)
+
+
+# ───────────────────────── Edge cases ──────────────────────────────
+
+
+def test_max_payload_size():
+    """
+    LEN field is u16, so the wire format technically allows 65535-byte
+    payloads. The firmware caps at 255 (single-byte buffer optimisation),
+    but the framing code itself must handle anything that fits in u16.
+    """
+    payload = b"\xCC" * 255
+    frame = build_frame(CMD_TX_REQUEST, payload)
+    assert len(frame) == 6 + 255
+    # LEN field correctly encodes 255 as 0x00FF little-endian.
+    assert frame[2:4] == b"\xFF\x00"
+
+
+@pytest.mark.parametrize("cmd", [0x00, 0x01, 0x7F, 0x80, 0xFE, 0xFF])
+def test_frame_preserves_command_byte(cmd):
+    """Command byte goes in unchanged regardless of value."""
+    frame = build_frame(cmd, b"")
+    assert frame[1] == cmd
+
+
+def test_build_frame_rejects_oversized_payload():
+    """
+    Payloads larger than 0xFFFF cannot fit in the 16-bit LEN field.
+    build_frame() must raise ValueError with a clear message rather than
+    letting struct.pack blow up with a generic 'ushort format requires
+    0 <= number <= 65535' error.
+    """
+    with pytest.raises(ValueError, match="exceeds 16-bit LEN field"):
+        build_frame(CMD_TX_REQUEST, b"\x00" * 65536)


### PR DESCRIPTION
## Summary

Adds two new `LoRaRadio` implementations under `src/pymc_core/hardware/`:

- **`TCPLoRaRadio`** — talks to a [pymc_usb firmware](https://github.com/itk80/pymc_usb) modem over a TCP socket (Wi-Fi or Ethernet). Stdlib-only (socket / threading / asyncio); no new pymc_core dependencies.
- **`USBLoRaRadio`** — same firmware, but over USB-CDC. Uses `pyserial` (already a transitive dep of the KISS wrappers).

Both are drop-in replacements for `SX1262Radio` when the SX1262 module isn't attached to the host running pymc_core — sector arrays, distant antennas, multi-modem deployments, or simply moving the radio away from RPi RFI.

The firmware itself supports 7 boards from one code tree (Heltec V3, Heltec T114, XIAO Wio-SX1262, RAK3112 WisMesh, ESP32-P4-Nano, Lilygo T3-S3, Ikoka Stick). All speak the same wire protocol; the host driver doesn't need to care which board it's talking to.

## What's included

| File | Notes |
|---|---|
| `src/pymc_core/hardware/tcp_radio.py` | Full `LoRaRadio` impl, async reader thread, auto-reconnect with exponential backoff, optional shared-secret AUTH |
| `src/pymc_core/hardware/usb_radio.py` | Sibling of TCPLoRaRadio over `pyserial`; same wire protocol |
| `src/pymc_core/hardware/__init__.py` | Conditional exports for both, matching the existing `WsRadio` / `SX1262Radio` / `Kiss*` pattern |
| `examples/common.py` | `radio_type='pymc_tcp'` and `'pymc_usb'` branches in `create_radio()`. Env vars: `PYMC_TCP_HOST` / `PYMC_TCP_PORT` / `PYMC_TCP_TOKEN`, plus legacy `HELTEC_*` aliases for users migrating from the standalone driver |
| `tests/hardware/test_tcp_radio_protocol.py` | 20 offline tests: CRC-16/CCITT-FALSE check vectors, frame layout, endianness, length-field handling. No hardware, no socket — runs in CI |

## Wire protocol

Bit-identical between both transports. Documented in [pymc_usb/firmware/include/protocol.h](https://github.com/itk80/pymc_usb/blob/v0.7.0/firmware/include/protocol.h).

```
SYNC(0xAA) | CMD(1B) | LEN(2B LE) | PAYLOAD(0..255B) | CRC-16/CCITT-FALSE(2B LE)
```

CRC is computed over `CMD + LEN + PAYLOAD` (not over SYNC), poly `0x1021`, init `0xFFFF`, no reflect, no xor-out. Same as the canonical XMODEM/CCITT-FALSE; the test file pins the `123456789 → 0x29B1` reference vector so firmware and driver can't drift silently.

Tested against firmware `v0.7.0` ([release with prebuilt binaries for all 7 boards](https://github.com/itk80/pymc_usb/releases/tag/v0.7.0)).

## Test plan

- [x] `python3 -m pytest tests/hardware/test_tcp_radio_protocol.py -v` → 20 passed
- [x] Bench: 4-modem sector array (Heltec V3 over TCP/Wi-Fi) running pymc_repeater for 24h+, no driver-side regressions
- [x] Network drop / reconnect / token-mismatch handling (manual)
- [ ] Reviewer to verify against their own modem (flash `firmware.bin` from the v0.7.0 release)

## Open questions

1. **Splitting**: would you prefer this as two PRs (TCP first, USB follow-up)? They're independent and the TCP path is what the user-facing sector-array deployments actually use; USB is mostly for bench testing. Happy to split if it helps review.

2. **Naming**: I went with `pymc_tcp` / `pymc_usb` for the `radio_type` strings (matching the firmware repo name post-2025 rename). Kept `tcp_heltec` / `usb_heltec` as aliases so anyone with an existing config keeps working. OK or would you prefer different names?

3. **Sync word default**: firmware ships with `0x12` (RadioLib `SYNC_WORD_PRIVATE`, MeshCore default). Historic pymc_core default in some examples was `0x3444`. The `pymc_tcp` / `pymc_usb` branches default to `0x12` to match what the firmware does on first boot, but `SET_CONFIG` from the host overrides it at `begin()` time anyway. Flag if you want this surfaced more loudly in the docstring.

## Out of scope

- pymc_Repeater integration — separate PR there once this lands (needs `pymc_core>=X.Y` dep bump).
- Web admin panel for live host/port/token reconfig — also a pymc_Repeater concern.

## Backward-compat

- Existing `radio_type` values (`waveshare`, `uconsole`, `meshadv-mini`, `kiss-tnc`, `kiss-modem`, `ch341`) untouched.
- Conditional imports keep the package importable on systems missing `pyserial` (USBLoRaRadio just won't be in `__all__`).
- `HELTEC_*` env-var names accepted on top of `PYMC_TCP_*` preferred names; legacy `tcp_heltec` / `usb_heltec` `radio_type` aliases also work.

## References

- Firmware repo + protocol source-of-truth: https://github.com/itk80/pymc_usb
- Prebuilt firmware binaries for all 7 supported boards: https://github.com/itk80/pymc_usb/releases/tag/v0.7.0
- protocol.h (pinned at v0.7.0): https://github.com/itk80/pymc_usb/blob/v0.7.0/firmware/include/protocol.h
