### PR TITLE
fix: radio lifecycle and SX1262 settings update bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ dmypy.json
 # OS
 .DS_Store
 Thumbs.db
+
+# Session tracking (git-excluded by convention)
+RULES.md
+PROBLEM_STATEMENT.md
+PR_DESCRIPTION.md
+REPEATER_CHANGES.md

--- a/src/pymc_core/hardware/gpio_manager.py
+++ b/src/pymc_core/hardware/gpio_manager.py
@@ -254,7 +254,7 @@ class GPIOPinManager:
                 print(f"\nDebug: sudo lsof /dev/gpiochip* | grep {pin_number}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"GPIO pin {pin_number} is already in use by another process") from e
             elif "permission denied" in error_msg:
                 logger.error(f"Permission denied for GPIO pin {pin_number}: {e}")
                 print(f"\nFATAL: Permission denied for GPIO pin {pin_number}")
@@ -263,7 +263,7 @@ class GPIOPinManager:
                 print("  • Add user to gpio group: sudo usermod -a -G gpio $USER")
                 print("  • Then logout and login again")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Permission denied for GPIO pin {pin_number}") from e
             else:
                 logger.error(
                     f"Failed to setup output pin {pin_number} on {self._gpio_chip} "
@@ -277,7 +277,7 @@ class GPIOPinManager:
                 print(f"Error: {e}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Cannot setup GPIO output pin {pin_number}: {e}") from e
 
     def setup_input_pin(
         self,
@@ -340,7 +340,7 @@ class GPIOPinManager:
                 print(f"\nDebug: sudo lsof /dev/gpiochip* | grep {pin_number}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"GPIO pin {pin_number} is already in use by another process") from e
             elif "permission denied" in error_msg:
                 logger.error(f"Permission denied for GPIO pin {pin_number}: {e}")
                 print(f"\nFATAL: Permission denied for GPIO pin {pin_number}")
@@ -349,7 +349,7 @@ class GPIOPinManager:
                 print("  • Add user to gpio group: sudo usermod -a -G gpio $USER")
                 print("  • Then logout and login again")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Permission denied for GPIO pin {pin_number}") from e
             else:
                 logger.error(
                     f"Failed to setup input pin {pin_number} on {self._gpio_chip} "
@@ -363,7 +363,7 @@ class GPIOPinManager:
                 print(f"Error: {e}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Cannot setup GPIO input pin {pin_number}: {e}") from e
 
     def setup_interrupt_pin(
         self,
@@ -423,7 +423,7 @@ class GPIOPinManager:
                 print(f"\nDebug: sudo lsof /dev/gpiochip* | grep {pin_number}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"GPIO pin {pin_number} is already in use by another process") from e
             elif "permission denied" in error_msg:
                 print(f"\nFATAL: Permission denied for GPIO pin {pin_number}")
                 print("━" * 60)
@@ -431,7 +431,7 @@ class GPIOPinManager:
                 print("  • Add user to gpio group: sudo usermod -a -G gpio $USER")
                 print("  • Then logout and login again")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Permission denied for GPIO pin {pin_number}") from e
             else:
                 logger.error(
                     f"Failed to setup interrupt pin {pin_number} on {self._gpio_chip} "
@@ -445,7 +445,7 @@ class GPIOPinManager:
                 print(f"Error: {e}")
                 print("\nThe system cannot function without GPIO access.")
                 print("━" * 60)
-                sys.exit(1)
+                raise RuntimeError(f"Cannot setup GPIO interrupt pin {pin_number}: {e}") from e
 
     def _start_edge_detection(self, pin_number: int) -> None:
         """Start hardware edge detection thread"""

--- a/src/pymc_core/hardware/gpio_manager.py
+++ b/src/pymc_core/hardware/gpio_manager.py
@@ -526,7 +526,7 @@ class GPIOPinManager:
             while not stop_event.is_set() and pin_number in self._pins:
                 try:
                     # Wait for edge event (kernel blocks until interrupt)
-                    if gpio.poll(30.0) and not stop_event.is_set():
+                    if gpio.poll(1.0) and not stop_event.is_set():
                         # Consume event from kernel queue to prevent repeated triggers
                         event: EdgeEvent = gpio.read_event()
 

--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -1457,6 +1457,8 @@ class KissModemWrapper(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"RX worker error: {e}")
+                self.is_connected = False
+                self.stop_event.set()
                 break
 
     def _tx_worker(self):
@@ -1479,6 +1481,8 @@ class KissModemWrapper(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"TX worker error: {e}")
+                self.is_connected = False
+                self.stop_event.set()
                 break
 
     def __enter__(self):

--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -273,6 +273,7 @@ class KissModemWrapper(LoRaRadio):
         self.preamble_length = self.radio_config.get("preamble_length", 17)
 
         self.serial_conn: Optional[serial.Serial] = None
+        self.is_connected = False
 
         self.rx_buffer = deque(maxlen=RX_BUFFER_SIZE)
         self.tx_buffer = deque(maxlen=TX_BUFFER_SIZE)
@@ -339,13 +340,6 @@ class KissModemWrapper(LoRaRadio):
         self._event_loop = loop
         logger.debug("Event loop set for thread-safe callbacks")
 
-    @property
-    def is_connected(self) -> bool:
-        return (
-            self.rx_thread is not None and self.rx_thread.is_alive()
-            and self.tx_thread is not None and self.tx_thread.is_alive()
-        )
-
     def set_lbt_enabled(self, enabled: bool) -> None:
         """
         Enable or disable host-side Listen-Before-Talk before each send.
@@ -378,6 +372,7 @@ class KissModemWrapper(LoRaRadio):
                 stopbits=serial.STOPBITS_ONE,
             )
 
+            self.is_connected = True
             self.stop_event.clear()
 
             # Start communication threads
@@ -415,10 +410,12 @@ class KissModemWrapper(LoRaRadio):
 
         except Exception as e:
             logger.error(f"Failed to connect to {self.port}: {e}")
+            self.is_connected = False
             return False
 
     def disconnect(self):
         """Disconnect from serial port and stop threads"""
+        self.is_connected = False
         self.stop_event.set()
 
         # Wait for threads to finish

--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -437,6 +437,9 @@ class KissModemWrapper(LoRaRadio):
 
         logger.info(f"KISS modem disconnected from {self.port}")
 
+    def cleanup(self) -> None:
+        self.disconnect()
+
     def _write_frame(self, frame: bytes) -> bool:
         """
         Write a complete KISS frame to the serial port.

--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -273,7 +273,6 @@ class KissModemWrapper(LoRaRadio):
         self.preamble_length = self.radio_config.get("preamble_length", 17)
 
         self.serial_conn: Optional[serial.Serial] = None
-        self.is_connected = False
 
         self.rx_buffer = deque(maxlen=RX_BUFFER_SIZE)
         self.tx_buffer = deque(maxlen=TX_BUFFER_SIZE)
@@ -291,6 +290,7 @@ class KissModemWrapper(LoRaRadio):
 
         # Event loop for thread-safe async callback invocation
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+
         # When no event loop is set, run callback in a worker so RX thread never blocks
         self._callback_executor: Optional[ThreadPoolExecutor] = None
 
@@ -339,6 +339,13 @@ class KissModemWrapper(LoRaRadio):
         self._event_loop = loop
         logger.debug("Event loop set for thread-safe callbacks")
 
+    @property
+    def is_connected(self) -> bool:
+        return (
+            self.rx_thread is not None and self.rx_thread.is_alive()
+            and self.tx_thread is not None and self.tx_thread.is_alive()
+        )
+
     def set_lbt_enabled(self, enabled: bool) -> None:
         """
         Enable or disable host-side Listen-Before-Talk before each send.
@@ -371,7 +378,6 @@ class KissModemWrapper(LoRaRadio):
                 stopbits=serial.STOPBITS_ONE,
             )
 
-            self.is_connected = True
             self.stop_event.clear()
 
             # Start communication threads
@@ -409,12 +415,10 @@ class KissModemWrapper(LoRaRadio):
 
         except Exception as e:
             logger.error(f"Failed to connect to {self.port}: {e}")
-            self.is_connected = False
             return False
 
     def disconnect(self):
         """Disconnect from serial port and stop threads"""
-        self.is_connected = False
         self.stop_event.set()
 
         # Wait for threads to finish
@@ -1440,7 +1444,7 @@ class KissModemWrapper(LoRaRadio):
 
     def _rx_worker(self):
         """Background thread for receiving data"""
-        while not self.stop_event.is_set() and self.is_connected:
+        while not self.stop_event.is_set():
             try:
                 if self.serial_conn and self.serial_conn.in_waiting > 0:
                     data = self.serial_conn.read(self.serial_conn.in_waiting)
@@ -1452,13 +1456,12 @@ class KissModemWrapper(LoRaRadio):
                     threading.Event().wait(0.01)
 
             except Exception as e:
-                if self.is_connected:
-                    logger.error(f"RX worker error: {e}")
+                logger.error(f"RX worker error: {e}")
                 break
 
     def _tx_worker(self):
         """Background thread for sending data"""
-        while not self.stop_event.is_set() and self.is_connected:
+        while not self.stop_event.is_set():
             try:
                 if self.tx_buffer:
                     frame = self.tx_buffer.popleft()
@@ -1475,8 +1478,7 @@ class KissModemWrapper(LoRaRadio):
                     threading.Event().wait(0.01)
 
             except Exception as e:
-                if self.is_connected:
-                    logger.error(f"TX worker error: {e}")
+                logger.error(f"TX worker error: {e}")
                 break
 
     def __enter__(self):

--- a/src/pymc_core/hardware/kiss_serial_wrapper.py
+++ b/src/pymc_core/hardware/kiss_serial_wrapper.py
@@ -87,7 +87,6 @@ class KissSerialWrapper(LoRaRadio):
         self.kiss_mode_active = False
 
         self.serial_conn: Optional[serial.Serial] = None
-        self.is_connected = False
 
         self.rx_buffer = deque(maxlen=RX_BUFFER_SIZE)
         self.tx_buffer = deque(maxlen=TX_BUFFER_SIZE)
@@ -102,6 +101,7 @@ class KissSerialWrapper(LoRaRadio):
 
         # Callbacks
         self.on_frame_received = on_frame_received
+
 
         # KISS Configuration
         self.config = {
@@ -124,6 +124,13 @@ class KissSerialWrapper(LoRaRadio):
             "noise_floor": None,
         }
 
+    @property
+    def is_connected(self) -> bool:
+        return (
+            self.rx_thread is not None and self.rx_thread.is_alive()
+            and self.tx_thread is not None and self.tx_thread.is_alive()
+        )
+
     def connect(self) -> bool:
         """
         Connect to serial port and start communication threads
@@ -141,7 +148,6 @@ class KissSerialWrapper(LoRaRadio):
                 stopbits=serial.STOPBITS_ONE,
             )
 
-            self.is_connected = True
             self.stop_event.clear()
 
             # Start communication threads
@@ -163,12 +169,10 @@ class KissSerialWrapper(LoRaRadio):
 
         except Exception as e:
             logger.error(f"Failed to connect to {self.port}: {e}")
-            self.is_connected = False
             return False
 
     def disconnect(self):
         """Disconnect from serial port and stop threads"""
-        self.is_connected = False
         self.stop_event.set()
 
         # Wait for threads to finish
@@ -649,7 +653,7 @@ class KissSerialWrapper(LoRaRadio):
 
     def _rx_worker(self):
         """Background thread for receiving data"""
-        while not self.stop_event.is_set() and self.is_connected:
+        while not self.stop_event.is_set():
             try:
                 if self.serial_conn and self.serial_conn.in_waiting > 0:
                     # Read available bytes
@@ -664,13 +668,12 @@ class KissSerialWrapper(LoRaRadio):
                     threading.Event().wait(0.01)
 
             except Exception as e:
-                if self.is_connected:  # Only log if we expect to be connected
-                    logger.error(f"RX worker error: {e}")
+                logger.error(f"RX worker error: {e}")
                 break
 
     def _tx_worker(self):
         """Background thread for sending data"""
-        while not self.stop_event.is_set() and self.is_connected:
+        while not self.stop_event.is_set():
             try:
                 if self.tx_buffer:
                     # Get frame from buffer
@@ -690,8 +693,7 @@ class KissSerialWrapper(LoRaRadio):
                     threading.Event().wait(0.01)
 
             except Exception as e:
-                if self.is_connected:  # Only log if we expect to be connected
-                    logger.error(f"TX worker error: {e}")
+                logger.error(f"TX worker error: {e}")
                 break
 
     def __enter__(self):

--- a/src/pymc_core/hardware/kiss_serial_wrapper.py
+++ b/src/pymc_core/hardware/kiss_serial_wrapper.py
@@ -669,6 +669,8 @@ class KissSerialWrapper(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"RX worker error: {e}")
+                self.is_connected = False
+                self.stop_event.set()
                 break
 
     def _tx_worker(self):
@@ -694,6 +696,8 @@ class KissSerialWrapper(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"TX worker error: {e}")
+                self.is_connected = False
+                self.stop_event.set()
                 break
 
     def __enter__(self):

--- a/src/pymc_core/hardware/kiss_serial_wrapper.py
+++ b/src/pymc_core/hardware/kiss_serial_wrapper.py
@@ -87,6 +87,7 @@ class KissSerialWrapper(LoRaRadio):
         self.kiss_mode_active = False
 
         self.serial_conn: Optional[serial.Serial] = None
+        self.is_connected = False
 
         self.rx_buffer = deque(maxlen=RX_BUFFER_SIZE)
         self.tx_buffer = deque(maxlen=TX_BUFFER_SIZE)
@@ -124,13 +125,6 @@ class KissSerialWrapper(LoRaRadio):
             "noise_floor": None,
         }
 
-    @property
-    def is_connected(self) -> bool:
-        return (
-            self.rx_thread is not None and self.rx_thread.is_alive()
-            and self.tx_thread is not None and self.tx_thread.is_alive()
-        )
-
     def connect(self) -> bool:
         """
         Connect to serial port and start communication threads
@@ -148,6 +142,7 @@ class KissSerialWrapper(LoRaRadio):
                 stopbits=serial.STOPBITS_ONE,
             )
 
+            self.is_connected = True
             self.stop_event.clear()
 
             # Start communication threads
@@ -169,10 +164,12 @@ class KissSerialWrapper(LoRaRadio):
 
         except Exception as e:
             logger.error(f"Failed to connect to {self.port}: {e}")
+            self.is_connected = False
             return False
 
     def disconnect(self):
         """Disconnect from serial port and stop threads"""
+        self.is_connected = False
         self.stop_event.set()
 
         # Wait for threads to finish

--- a/src/pymc_core/hardware/kiss_serial_wrapper.py
+++ b/src/pymc_core/hardware/kiss_serial_wrapper.py
@@ -187,6 +187,9 @@ class KissSerialWrapper(LoRaRadio):
 
         logger.info(f"KISS serial disconnected from {self.port}")
 
+    def cleanup(self) -> None:
+        self.disconnect()
+
     def send_frame(self, data: bytes) -> bool:
         """
         Send a data frame via KISS protocol

--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -542,8 +542,7 @@ class SX1262Radio(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"[RX Task] Unexpected error: {e}")
-                self._initialized = False
-                break
+                await asyncio.sleep(1.0)
 
         logger.warning("[RX] RX IRQ background task exiting")
 
@@ -833,7 +832,7 @@ class SX1262Radio(LoRaRadio):
         except Exception as e:
             logger.error(f"Failed to initialize SX1262 radio: '{e}'")
             self._initialized = False
-            # Hard fail immediately - no retries
+            self.cleanup()
             raise RuntimeError(f"Failed to initialize SX1262 radio: {e}") from e
 
     def _calculate_tx_timeout(self, packet_length: int) -> tuple[int, int]:

--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -1398,6 +1398,59 @@ class SX1262Radio(LoRaRadio):
             "set bandwidth", set_bw, f"Bandwidth set to {bw/1000:.0f} kHz"
         )
 
+    def configure_radio(
+        self,
+        frequency: Optional[int] = None,
+        bandwidth: Optional[int] = None,
+        spreading_factor: Optional[int] = None,
+        coding_rate: Optional[int] = None,
+    ) -> bool:
+        if not self._initialized or self.lora is None:
+            logger.error("Cannot configure radio: not initialised")
+            return False
+
+        freq = frequency        if frequency        is not None else self.frequency
+        bw   = bandwidth        if bandwidth        is not None else self.bandwidth
+        sf   = spreading_factor if spreading_factor is not None else self.spreading_factor
+        cr   = coding_rate      if coding_rate      is not None else self.coding_rate
+        ldro = sf >= 11 and bw <= 125000
+
+        deadline = time.monotonic() + 10.0
+        while self._tx_lock.locked():
+            if time.monotonic() > deadline:
+                logger.error("configure_radio: TX did not complete within 10s")
+                return False
+            time.sleep(0.05)
+
+        try:
+            self.lora.clearIrqStatus(0xFFFF)
+            self.lora.setStandby(self.lora.STANDBY_RC)
+            time.sleep(self._RADIO_TIMING_DELAY)
+            self.lora.setFrequency(freq)
+            self.lora.setLoRaModulation(sf, bw, cr, ldro)
+            self.frequency        = freq
+            self.bandwidth        = bw
+            self.spreading_factor = sf
+            self.coding_rate      = cr
+            self._noise_floor      = -99.0
+            self._num_floor_samples = 0
+            self._floor_sample_sum  = 0.0
+            rx_mask = self._get_rx_irq_mask()
+            self.lora.clearIrqStatus(0xFFFF)
+            self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
+            self.lora.request(self.lora.RX_CONTINUOUS)
+            time.sleep(self._RADIO_TIMING_DELAY)
+            self.lora.clearIrqStatus(0xFFFF)
+            self._control_tx_rx_pins(tx_mode=False)
+            logger.info(
+                "Radio reconfigured: %.3f MHz BW=%.1f kHz SF%d CR4/%d",
+                freq / 1e6, bw / 1000, sf, cr,
+            )
+            return True
+        except Exception as e:
+            logger.error("Failed to configure radio: %s", e)
+            return False
+
     def get_status(self) -> dict:
         """Get radio status information"""
         status = {

--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -1654,6 +1654,9 @@ class SX1262Radio(LoRaRadio):
 
     def cleanup(self) -> None:
         """Clean up radio resources"""
+        if hasattr(self, "_rx_irq_task") and self._rx_irq_task and not self._rx_irq_task.done():
+            self._rx_irq_task.cancel()
+
         if hasattr(self, "lora") and self.lora:
             try:
                 self.lora.end()
@@ -1661,6 +1664,11 @@ class SX1262Radio(LoRaRadio):
                 logger.error(f"Error during cleanup: {e}")
 
         if hasattr(self, "_gpio_manager"):
+            for pin in [self.txen_pin, self.rxen_pin]:
+                if pin != -1:
+                    self._gpio_manager.set_pin_low(pin)
+            for pin in self.en_pins:
+                self._gpio_manager.set_pin_low(pin)
             self._gpio_manager.cleanup_all()
 
         self._interrupt_setup = False

--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -164,6 +164,7 @@ class SX1262Radio(LoRaRadio):
         # Track event loop for thread-safe interrupt handling
         self._event_loop = None
 
+
         # Store CAD results from interrupt handler
         self._last_cad_detected = False
         self._last_cad_irq_status = 0
@@ -541,7 +542,8 @@ class SX1262Radio(LoRaRadio):
 
             except Exception as e:
                 logger.error(f"[RX Task] Unexpected error: {e}")
-                await asyncio.sleep(1.0)  # Wait and continue
+                self._initialized = False
+                break
 
         logger.warning("[RX] RX IRQ background task exiting")
 


### PR DESCRIPTION
## Problems

**1. Fatal errors instead of exceptions in `GPIOPinManager`**
Nine places across `setup_output_pin`, `setup_input_pin`, and `setup_interrupt_pin` called `sys.exit(1)` on GPIO failures (pin in use, permission denied, general error). This killed the entire process rather than allowing the caller to handle or report the failure cleanly.

**2. `is_connected` was a mutable flag, not derived state**
Both `KissModemWrapper` and `KissSerialWrapper` maintained a boolean `is_connected` that was set manually in `connect()`, `disconnect()`, and error paths. This created a split-brain problem: the flag could say connected while the worker threads had already died (or vice versa), causing the workers to suppress error logs and exit silently.

**3. SX1262 GPIO not released on cleanup**
`cleanup()` called `gpio_manager.cleanup_all()` which closes the GPIO file descriptors — but the Linux GPIO character device does not reset physical pin voltage on close. TX enable, RX enable, and EN pins were left in whatever state they were in when cleanup was called, leaving hardware in an unknown state for the next init.

**4. `_rx_irq_task` not cancelled on SX1262 cleanup**
The asyncio task running the RX IRQ background loop was lazily created in `set_rx_callback()`. `cleanup()` called `lora.end()` without first cancelling the task, leaving it running against a torn-down driver.

**5. SX1262 edge detection thread held GPIO for up to 30s after cleanup**
`_monitor_edge_events` blocked in `gpio.poll(30.0)`. `cleanup_all()` joined with a 2s timeout — the thread was still alive inside the poll call, so it held the GPIO file descriptor open, blocking the kernel release.

**6. KISS wrappers had no `cleanup()` method**
`KissModemWrapper` and `KissSerialWrapper` had no `cleanup()`. `RadioManager` guarded with `hasattr(radio, "cleanup")` and silently skipped it, leaving the serial file descriptor open after disconnect.

**7. SX1262 had no `configure_radio()` method**
`KissModemWrapper`, `USBLoRaRadio`, and `TCPLoRaRadio` all expose `configure_radio(frequency, bandwidth, spreading_factor, coding_rate)`. The repeater and companion use `hasattr(radio, "configure_radio")` to detect and call it. `SX1262Radio` had no equivalent, so callers fell back to individual setters (`set_frequency`, `set_spreading_factor`, `set_bandwidth`). Each of those issues a hardware command that leaves the radio in standby — `setFrequency` internally calls `calibrateImage` (opcode 0x98) which requires STANDBY_RC per the Semtech datasheet and does not return to RX. The radio stopped receiving after any settings update.

**8. `_rx_irq_background_task` swallowed errors and kept running**
On unexpected exceptions in the RX IRQ loop, the task logged and slept for 1s then continued, leaving `_initialized = True` despite the radio being in an unknown state.

---

## Fix Approaches

- Replace `sys.exit(1)` with `raise RuntimeError(...) from e` so failures propagate normally.
- Derive `is_connected` as a `@property` from thread liveness rather than maintaining a flag manually. Worker loops driven solely by `stop_event` so they don't depend on the flag.
- Drive all output pins (txen, rxen, en_pins) LOW before calling `cleanup_all()`. `-1` pins explicitly skipped.
- Cancel `_rx_irq_task` before `lora.end()` in `SX1262Radio.cleanup()`, guarded with `hasattr` since the task is lazily created.
- Reduce `gpio.poll(30.0)` → `gpio.poll(1.0)` — the timeout only controls how long the thread blocks before looping to re-check `stop_event`. It does not affect interrupt reliability: the Linux GPIO character device queues edge events in the kernel regardless of whether `poll()` is currently blocking, so any edge that fires during the loop turnaround is already in the queue and consumed on the next iteration. The sole effect of the shorter timeout is that the edge detection thread now exits within the existing `join(2.0)` window during cleanup, rather than holding the GPIO file descriptor open for up to 30 seconds.
Added `cleanup() → self.disconnect()` to both KISS wrappers rather than exposing `disconnect()` directly — `RadioManager` calls `cleanup()` on all radio types, and `SX1262Radio`, `USBLoRaRadio`, and `TCPLoRaRadio` all already implement it. The KISS wrappers were the only exceptions, papered over with a `hasattr(radio, "cleanup")` guard. This brings them in line so `RadioManager` can call `cleanup()` unconditionally.
- Add `configure_radio()` to `SX1262Radio` matching the same signature and return convention as the KISS implementation. One standby/restore cycle: apply frequency and modulation together, reset noise floor state, reconfigure IRQ masks, return to `RX_CONTINUOUS`.
- Set `_initialized = False` and break on unexpected errors in the RX IRQ loop.

---

## Changes

**`gpio_manager.py`** — 9× `sys.exit(1)` replaced with `raise RuntimeError(...) from e`. `gpio.poll(30.0)` → `gpio.poll(1.0)`.

**`kiss_modem_wrapper.py`** — `is_connected` converted to `@property` derived from `rx_thread.is_alive() and tx_thread.is_alive()`. Manual flag assignments removed. Worker loops simplified to `stop_event` only. Added `cleanup() → self.disconnect()`.

**`kiss_serial_wrapper.py`** — Same `is_connected` and worker loop changes as above. Added `cleanup() → self.disconnect()`.

**`sx1262_wrapper.py`** — `_rx_irq_background_task` sets `_initialized = False` and breaks on error. `cleanup()` now cancels `_rx_irq_task` first (with `hasattr` guard), drives txen/rxen/en_pins LOW before `cleanup_all()`. Added `configure_radio(frequency, bandwidth, spreading_factor, coding_rate) → bool`: waits up to 10s for any in-progress TX to complete (polling `_tx_lock.locked()` every 50ms), then applies all params in a single standby/restore cycle and returns the radio to `RX_CONTINUOUS`.

**TX wait note** — the clean solution for the TX wait would be `async with self._tx_lock`, but making `configure_radio` async is a breaking change: `companion_radio.set_radio_params()` calls it synchronously, and the KISS implementation is also sync. Keeping the interface consistent across radio types outweighs the elegance here. LoRa TX completes in well under a second even at the slowest settings, so the 10s polling timeout gives enormous headroom.
