### PR TITLE
hardware: surface modem CRC counter on TCP and USB radios

### DIFF
--- a/src/pymc_core/hardware/tcp_radio.py
+++ b/src/pymc_core/hardware/tcp_radio.py
@@ -151,6 +151,8 @@ class TCPLoRaRadio(_RadioBase):
         # Stats
         self._tx_count = 0
         self._rx_count = 0
+        self._crc_errors = 0
+        self.crc_error_count = 0
 
         logger.info(
             f"TCPLoRaRadio configured: {host}:{port} "
@@ -359,7 +361,9 @@ class TCPLoRaRadio(_RadioBase):
 
         if self._event_loop:
             self._event_loop.call_soon_threadsafe(
-                lambda: self._event_loop.create_task(self.refresh_noise_floor())
+                lambda: self._event_loop.create_task(
+                    self._refresh_background_metrics()
+                )
             )
         return True
 
@@ -380,6 +384,8 @@ class TCPLoRaRadio(_RadioBase):
             "port": self.port,
             "tx_count": self._tx_count,
             "rx_count": self._rx_count,
+            "crc_errors": self._crc_errors,
+            "crc_error_count": self.crc_error_count,
         }
 
     async def get_modem_status(self) -> Optional[dict]:
@@ -390,7 +396,7 @@ class TCPLoRaRadio(_RadioBase):
         )
         if resp and len(resp) >= STATUS_RESP_SIZE:
             fields = struct.unpack(STATUS_RESP_FMT, resp[:STATUS_RESP_SIZE])
-            return {
+            status = {
                 "uptime_sec": fields[0],
                 "rx_count": fields[1],
                 "tx_count": fields[2],
@@ -401,7 +407,20 @@ class TCPLoRaRadio(_RadioBase):
                 "temp_c": fields[7],
                 "radio_state": ["idle/rx", "tx", "error"][min(fields[8], 2)],
             }
+            self._crc_errors = status["crc_errors"]
+            self.crc_error_count = status["crc_errors"]
+            return status
         return None
+
+    async def _refresh_background_metrics(self) -> None:
+        try:
+            await self.refresh_noise_floor()
+        except Exception as e:
+            logger.debug(f"Noise-floor refresh failed: {e}")
+        try:
+            await self.get_modem_status()
+        except Exception as e:
+            logger.debug(f"Status refresh failed: {e}")
 
     def get_noise_floor(self) -> Optional[float]:
         if not self._initialized:

--- a/src/pymc_core/hardware/usb_radio.py
+++ b/src/pymc_core/hardware/usb_radio.py
@@ -149,6 +149,8 @@ class USBLoRaRadio(_RadioBase):
         # Stats
         self._tx_count = 0
         self._rx_count = 0
+        self._crc_errors = 0
+        self.crc_error_count = 0
 
         logger.info(
             f"USBLoRaRadio configured: port={port}, freq={frequency/1e6:.1f}MHz, "
@@ -353,7 +355,7 @@ class USBLoRaRadio(_RadioBase):
         """Health check — verify RX thread is alive, restart if dead.
 
         Called by Dispatcher.run_forever() every 60 seconds.
-        Also triggers a noise floor refresh from the modem.
+        Also refreshes cached modem metrics from the modem.
         """
         if not self._initialized:
             return False
@@ -368,10 +370,12 @@ class USBLoRaRadio(_RadioBase):
             self._rx_thread.start()
             return False
 
-        # Schedule noise floor refresh (non-blocking)
+        # Schedule modem metric refresh (non-blocking)
         if self._event_loop:
             self._event_loop.call_soon_threadsafe(
-                lambda: self._event_loop.create_task(self.refresh_noise_floor())
+                lambda: self._event_loop.create_task(
+                    self._refresh_background_metrics()
+                )
             )
 
         return True
@@ -393,6 +397,8 @@ class USBLoRaRadio(_RadioBase):
             "port": self.port,
             "tx_count": self._tx_count,
             "rx_count": self._rx_count,
+            "crc_errors": self._crc_errors,
+            "crc_error_count": self.crc_error_count,
         }
 
     async def get_modem_status(self) -> Optional[dict]:
@@ -404,7 +410,7 @@ class USBLoRaRadio(_RadioBase):
         )
         if resp and len(resp) >= STATUS_RESP_SIZE:
             fields = struct.unpack(STATUS_RESP_FMT, resp[:STATUS_RESP_SIZE])
-            return {
+            status = {
                 "uptime_sec": fields[0],
                 "rx_count": fields[1],
                 "tx_count": fields[2],
@@ -417,7 +423,20 @@ class USBLoRaRadio(_RadioBase):
                     min(fields[8], 2)
                 ],
             }
+            self._crc_errors = status["crc_errors"]
+            self.crc_error_count = status["crc_errors"]
+            return status
         return None
+
+    async def _refresh_background_metrics(self) -> None:
+        try:
+            await self.refresh_noise_floor()
+        except Exception as e:
+            logger.debug(f"Noise-floor refresh failed: {e}")
+        try:
+            await self.get_modem_status()
+        except Exception as e:
+            logger.debug(f"Status refresh failed: {e}")
 
     def get_noise_floor(self) -> Optional[float]:
         """Get current noise floor in dBm.


### PR DESCRIPTION
## Summary

This PR exposes modem CRC errors through the `TCPLoRaRadio` and `USBLoRaRadio` interfaces in the way `pyMC_Repeater` already expects.

The modem firmware already includes `crc_errors` in `CMD_STATUS_RESP`, but the host-side radio wrappers were not copying that value onto the radio object as `crc_error_count`.

This change:

* Caches modem `crc_errors` in both transport drivers
* Exposes `crc_error_count` on the radio objects
* Refreshes that counter during normal health checks

---

## Problem

`pyMC_Repeater` records CRC errors using:

```python
getattr(radio, "crc_error_count", 0)
```

This already works for local SX1262 radios, but not for `pymc_usb` modem transports unless the wrapper exposes the same attribute.

Before this PR:

* Modem firmware sent `crc_errors` in `CMD_STATUS_RESP`
* `get_modem_status()` parsed the field correctly
* `TCPLoRaRadio` and `USBLoRaRadio` did not expose:

  * `radio.crc_error_count`

As a result, repeater-side CRC tracking remained at `0` even when the modem itself was reporting CRC errors.

---

## What Changed

### 1. Added Cached CRC State to Both Radio Wrappers

Updated:

* `src/pymc_core/hardware/tcp_radio.py`
* `src/pymc_core/hardware/usb_radio.py`

New attributes:

* `self._crc_errors = 0`
* `self.crc_error_count = 0`

---

### 2. Synced Modem CRC Errors Into the Radio Object

After unpacking `CMD_STATUS_RESP`, both wrappers now:

* Store `status["crc_errors"]` in `self._crc_errors`
* Store `status["crc_errors"]` in `self.crc_error_count`

This is the core compatibility fix for repeater integration.

---

### 3. Surfaced CRC Counters in `get_status()`

Both wrappers now expose:

* `"crc_errors"`
* `"crc_error_count"`

This keeps the returned status dictionary aligned with the live cached values.

---

### 4. Refreshed Status During Normal Health Polling

Previously, health polling only refreshed the noise floor.

Now, the periodic health check refreshes:

* Noise floor
* Modem status

This keeps `crc_error_count` current during normal operation without requiring special polling paths.

---

## Why This Is the Right Fix

The existing repeater logic already expects a radio-level attribute:

```python
radio.crc_error_count
```

That means the compatibility boundary belongs inside `pyMC_core` transport wrappers rather than in repeater itself.

This keeps:

* Repeater logic unchanged
* Transport wrappers aligned with the existing radio interface contract
* Modem-specific status normalized into the standard radio abstraction

---

## Files Changed

* `src/pymc_core/hardware/tcp_radio.py`
* `src/pymc_core/hardware/usb_radio.py`

---

## Behavior After This PR

When a `pymc_usb` modem reports CRC errors in `CMD_STATUS_RESP`:

* `TCPLoRaRadio.crc_error_count` updates
* `USBLoRaRadio.crc_error_count` updates
* Repeater storage records CRC error deltas without repeater-side changes
* Existing API/dashboard paths can surface modem CRC history correctly

---

## Testing

Validated by:

* Patching both wrappers
* Successfully compiling both modules with `py_compile`
* Running patched `pyMC_core` against a live repeater install
* Confirming radio objects expose `crc_error_count`
* Confirming repeater storage and API record modem CRC errors after malformed modem frames were injected

Observed on a live system:

* Modem reported CRC errors
* Repeater database recorded CRC deltas
* Authenticated repeater API returned non-zero CRC totals/history

---

## Scope

This PR is intentionally narrow:

* No repeater code changes
* No firmware protocol changes
* No repeater API schema changes
* Only `pyMC_core` transport wrapper behavior changes

This is a compatibility fix so `pymc_usb` modem transports behave like other radios from the repeater’s perspective.
