### PR TITLE
ci: trigger repeater docker rebuilds when core changes

### DIFF
--- a/.github/workflows/trigger-repeater-docker-rebuild.yml
+++ b/.github/workflows/trigger-repeater-docker-rebuild.yml
@@ -1,0 +1,76 @@
+name: Trigger Repeater Docker Rebuild
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+    inputs:
+      repeater_repository:
+        description: "Repository to dispatch the repeater image rebuild to"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: |
+      github.repository == 'pyMC-dev/pyMC_core' ||
+      github.repository == 'rightup/pyMC_core' ||
+      github.repository == 'yellowcooln/pyMC_core'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine dispatch target
+        id: target
+        shell: bash
+        env:
+          INPUT_REPEATER_REPOSITORY: ${{ inputs.repeater_repository }}
+        run: |
+          set -euo pipefail
+
+          channel="${GITHUB_REF_NAME}"
+          case "${channel}" in
+            main|dev) ;;
+            *)
+              echo "Unsupported core channel: ${channel}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -n "${INPUT_REPEATER_REPOSITORY}" ]; then
+            repeater_repository="${INPUT_REPEATER_REPOSITORY}"
+          elif [ "${GITHUB_REPOSITORY}" = "yellowcooln/pyMC_core" ]; then
+            repeater_repository="yellowcooln/pyMC_Repeater"
+          else
+            repeater_repository="pyMC-dev/pyMC_Repeater"
+          fi
+
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+          echo "repeater_repository=${repeater_repository}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger repeater image rebuild
+        env:
+          DISPATCH_TOKEN: ${{ secrets.REPEATER_REPO_DISPATCH_TOKEN }}
+          REPEATER_REPOSITORY: ${{ steps.target.outputs.repeater_repository }}
+          CHANNEL: ${{ steps.target.outputs.channel }}
+          CORE_SHA: ${{ github.sha }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            echo "REPEATER_REPO_DISPATCH_TOKEN is not set" >&2
+            exit 1
+          fi
+
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            "https://api.github.com/repos/${REPEATER_REPOSITORY}/dispatches" \
+            -d "{\"event_type\":\"rebuild-from-core\",\"client_payload\":{\"channel\":\"${CHANNEL}\",\"core_ref\":\"${CHANNEL}\",\"core_sha\":\"${CORE_SHA}\",\"source_repository\":\"${SOURCE_REPOSITORY}\",\"source_run_url\":\"${SOURCE_RUN_URL}\"}}"

--- a/.github/workflows/trigger-repeater-docker-rebuild.yml
+++ b/.github/workflows/trigger-repeater-docker-rebuild.yml
@@ -19,7 +19,6 @@ jobs:
   dispatch:
     if: |
       github.repository == 'pyMC-dev/pyMC_core' ||
-      github.repository == 'rightup/pyMC_core' ||
       github.repository == 'yellowcooln/pyMC_core'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## PR Summary

This PR adds a GitHub Actions workflow to `pyMC_core` that automatically triggers a `pyMC_Repeater` Docker image rebuild whenever `pyMC_core` `main` or `dev` changes.

The goal is to keep published repeater images aligned with the current core branch automatically, without requiring manual rebuilds every time `pyMC_core` advances.

---

## What It Does

The new workflow runs on:

* Pushes to `main`
* Pushes to `dev`
* Optional manual `workflow_dispatch`

When triggered, it:

* Determines the current channel from the branch name (`main` or `dev`)
* Selects the repeater repository to notify:
  * `pyMC-dev/pyMC_Repeater` 
* Sends a `repository_dispatch` event to the repeater repo
* Includes:

  * `channel`
  * `core_ref`
  * Exact `core_sha`

This allows the repeater repo’s Docker publish workflow to rebuild the matching image channel using the exact current core commit.

---

## Why This Is Needed

`pyMC_Repeater` Docker images bundle `pyMC_core`, but repeater images are only rebuilt when repeater CI itself runs.

Without this workflow:

* `pyMC_core` can move forward
* Repeater Docker images can remain stale
* Users can pull a fresh repeater image tag that still contains an older core commit

This workflow closes that gap by proactively triggering repeater rebuilds whenever core changes.

---

## File Added

* `.github/workflows/trigger-repeater-docker-rebuild.yml`

---

## Behavior

* `dev` core changes trigger repeater `dev` rebuilds
* `main` core changes trigger repeater `main` rebuilds
* No manual core commit entry is required
* Exact core commit SHAs are passed through automatically

---

## Required Secret

This workflow requires a repository secret in the `pyMC_core` repo:

* `REPEATER_REPO_DISPATCH_TOKEN`

The token is used to call:

```text
POST /repos/<repeater-repo>/dispatches
```

---

## Token Permissions

### Recommended

Use a fine-grained GitHub Personal Access Token.

### Minimum Access

Repository access to the target repeater repo with:

* Actions:

  * Read and write
* Contents:

  * Read-only

### Classic PAT Alternative

If using a classic PAT instead:

* `repo` scope is typically sufficient
* Fine-grained tokens are still preferred

---

## Creating the Token

On the GitHub account that owns or has access to the target repeater repo:

1. Open GitHub Settings
2. Go to:

   * Developer settings
3. Open:

   * Personal access tokens
4. Create:

   * Fine-grained token
5. Select the target repeater repo:

     * `pyMC-dev/pyMC_Repeater`
6. Grant the required permissions
7. Copy the token
8. Add it to the `pyMC_core` repo as:

   * `REPEATER_REPO_DISPATCH_TOKEN`

Path:

* Settings
* Secrets and variables
* Actions
* New repository secret

---

## Important Note

This workflow only sends the dispatch event.

The repeater repo must already contain the matching `repository_dispatch` handler workflow on its default branch, otherwise no rebuild will occur.

The full chain requires:

1. Repeater workflow support for `repository_dispatch`
2. This core dispatch workflow
3. `REPEATER_REPO_DISPATCH_TOKEN` configured in `pyMC_core`

---

## Result

Once both sides are merged and the secret is configured:

* Merging to `pyMC_core/dev` automatically rebuilds repeater `dev`
* Merging to `pyMC_core/main` automatically rebuilds repeater `main`
* Published repeater Docker images stay aligned with the current core branch automatically
