### PR TITLE
fix: remove flush() in _write_frame to prevent hang on USB CDC ACM

### DIFF
--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -456,11 +456,9 @@ class KissModemWrapper(LoRaRadio):
             except Exception as e:
                 logger.error("Serial write error: %s", e)
                 return False
-        try:
-            self.serial_conn.flush()
-        except Exception as e:
-            logger.error("Serial flush error: %s", e)
-            return False
+        # flush()/tcdrain() removed: hangs indefinitely on USB CDC ACM
+        # (e.g. ESP32 T3S3/S3 with TinyUSB). write() already copies data
+        # to the kernel USB buffer atomically; no drain needed.
         return True
 
     def _set_kiss_tx_delay(self, delay_ms: int) -> None:


### PR DESCRIPTION
## Summary

- `serial.flush()` calls `termios.tcdrain()` internally, which blocks indefinitely on USB CDC ACM devices (e.g. ESP32 T3S3/S3 with TinyUSB) on Linux
- Confirmed on Linux Mint + T3S3 + MeshCore KISS Modem built from upstream/dev
- `pyserial`'s `write()` already copies data into the kernel USB buffer atomically — no explicit drain is needed

## Root Cause

`pyserial`'s `Serial.flush()` calls `termios.tcdrain()` on POSIX systems. For native UART devices `tcdrain()` returns promptly, but USB CDC ACM character devices (backed by TinyUSB on ESP32) do not implement the `tcdrain` completion signal, causing it to hang indefinitely.

## Fix

Replace the `flush()` try/except block with a comment explaining why it was removed:

```python
# flush()/tcdrain() removed: hangs indefinitely on USB CDC ACM
# (e.g. ESP32 T3S3/S3 with TinyUSB). write() already copies data
# to the kernel USB buffer atomically; no drain needed.
```

## Test Plan

- [ ] Connect ESP32 T3S3 via USB CDC ACM (`/dev/ttyACM0`)
- [ ] Run `KissModemWrapper.connect()` and verify it no longer hangs in `_write_frame()`
- [ ] Confirm frame TX and RX operate normally
- [ ] Verify no regression on native UART devices (e.g. `/dev/ttyUSB0` with CH340/CP2102)

**Tested:**
- Linux Mint + ESP32 T3S3 (USB CDC ACM /dev/ttyACM1)
- MeshCore KISS Modem firmware built from upstream/dev branch (commit around 2026-05-23)
- Without fix: hangs indefinitely after "KISS modem connected" log
- With fix: initialization completes, packets received and visible in pyMC_Repeater dashboard