### PR TITLE
fix: clear IRQ register after RX restore to prevent gpiod polling dea…

### DIFF
--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -517,6 +517,7 @@ class SX1262Radio(LoRaRadio):
                             if not self._tx_lock.locked():
                                 try:
                                     self.lora.request(self.lora.RX_CONTINUOUS)
+                                    self.lora.clearIrqStatus(0xFFFF)
                                     await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                     logger.debug(
                                         f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"


### PR DESCRIPTION
## fix: radio deafness on gpiod devices after back-to-back corrupted packets

### Problem

On devices using the `gpiod` GPIO backend, the radio would intermittently go completely deaf — receiving no packets until the next transmit cycle or a restart.

The root cause is a race between back-to-back LoRa IRQs and the gpiod polling interval. The `gpiod` backend detects interrupts by polling DIO1 every 20ms, looking for a LOW→HIGH transition. When two IRQs arrive close together (e.g. a corrupted preamble followed immediately by another), DIO1 is already HIGH when the second IRQ fires. The polling thread sees HIGH→HIGH, not LOW→HIGH, so the second interrupt is silently lost. DIO1 stays HIGH indefinitely, `_handle_interrupt` is never called again, and the radio stops receiving.

The condition was confirmed in production logs: DIO1 remained stuck HIGH for over 100 seconds with no recovery.

### Fix

After calling `request(RX_CONTINUOUS)` to restore the radio at the end of IRQ handling, immediately call `clearIrqStatus(0xFFFF)`. This sends an SPI command to the SX1262 to clear all pending IRQ flags, which causes the chip to de-assert DIO1. The line goes LOW, and the polling thread can now detect the next real rising edge normally.

### Why this isn't guarded to gpiod only

The `periphery` backend uses kernel-level edge detection (hardware FIFO), so it doesn't suffer from missed edges. However, the `clearIrqStatus` call is an SPI transaction that executes in approximately 8µs — far shorter than the minimum possible LoRa Time-on-Air (~5ms at SF5/250kHz). No valid packet can arrive and complete reception in that window on any supported SF or bandwidth combination, making the call safe to apply unconditionally on both backends.
