### PR TITLE
hardware: add configure_radio to SX1262Radio

### DIFF
--- a/src/pymc_core/hardware/sx1262_wrapper.py
+++ b/src/pymc_core/hardware/sx1262_wrapper.py
@@ -1412,6 +1412,65 @@ class SX1262Radio(LoRaRadio):
             "set bandwidth", set_bw, f"Bandwidth set to {bw/1000:.0f} kHz"
         )
 
+    def configure_radio(
+        self,
+        frequency: Optional[int] = None,
+        bandwidth: Optional[int] = None,
+        spreading_factor: Optional[int] = None,
+        coding_rate: Optional[int] = None,
+    ) -> bool:
+        """Reconfigure LoRa parameters inline without restarting the radio.
+
+        Any omitted parameter retains its current value. Waits for any
+        in-flight TX to complete before touching the hardware, then restores
+        RX_CONTINUOUS so the caller does not need to restart.
+        """
+        if not self._initialized or self.lora is None:
+            logger.error("Cannot configure radio: not initialised")
+            return False
+
+        freq = frequency        if frequency        is not None else self.frequency
+        bw   = bandwidth        if bandwidth        is not None else self.bandwidth
+        sf   = spreading_factor if spreading_factor is not None else self.spreading_factor
+        cr   = coding_rate      if coding_rate      is not None else self.coding_rate
+        ldro = sf >= 11 and bw <= 125000
+
+        deadline = time.monotonic() + 10.0
+        while self._tx_lock.locked():
+            if time.monotonic() > deadline:
+                logger.error("configure_radio: TX did not complete within 10s")
+                return False
+            time.sleep(0.05)
+
+        try:
+            self.lora.clearIrqStatus(0xFFFF)
+            self.lora.setStandby(self.lora.STANDBY_RC)
+            time.sleep(self._RADIO_TIMING_DELAY)
+            self.lora.setFrequency(freq)
+            self.lora.setLoRaModulation(sf, bw, cr, ldro)
+            self.frequency        = freq
+            self.bandwidth        = bw
+            self.spreading_factor = sf
+            self.coding_rate      = cr
+            self._noise_floor         = -99.0
+            self._num_floor_samples   = 0
+            self._floor_sample_sum    = 0.0
+            rx_mask = self._get_rx_irq_mask()
+            self.lora.clearIrqStatus(0xFFFF)
+            self.lora.setDioIrqParams(rx_mask, rx_mask, self.lora.IRQ_NONE, self.lora.IRQ_NONE)
+            self.lora.request(self.lora.RX_CONTINUOUS)
+            time.sleep(self._RADIO_TIMING_DELAY)
+            self.lora.clearIrqStatus(0xFFFF)
+            self._control_tx_rx_pins(tx_mode=False)
+            logger.info(
+                "Radio reconfigured: %.3f MHz BW=%.1f kHz SF%d CR4/%d",
+                freq / 1e6, bw / 1000, sf, cr,
+            )
+            return True
+        except Exception as e:
+            logger.error("Failed to configure radio: %s", e)
+            return False
+
     def get_status(self) -> dict:
         """Get radio status information"""
         status = {


### PR DESCRIPTION
## Problem

When a user updated radio settings (frequency, SF, BW, coding rate) on a device running the SX1262 radio wrapper, the radio would enter a broken state: it appeared to apply the new parameters but never returned to RX continuous mode. The result was a permanently stuck noise floor reading of **-127.5 dBm** — the sentinel value returned when no valid samples have been collected — and the radio would silently stop receiving packets entirely until a full restart.

This happened because the individual `set_frequency` / `set_spreading_factor` / `set_bandwidth` setters each call `setLoRaModulation` or similar in isolation, but none of them restore `RX_CONTINUOUS` afterwards or reset the noise floor accumulators. The radio ends up in standby with stale IRQ state and no active receive path.

## Fix

Adds `configure_radio(frequency, bandwidth, spreading_factor, coding_rate)` to `SX1262Radio`, matching the signature already present on `KissModemWrapper`.

The method:
1. Waits up to 10s for any in-flight TX to drain (respects `_tx_lock`)
2. Clears IRQ status and enters standby
3. Applies new frequency and modulation params (with LDRO auto-calculated from SF/BW)
4. Resets noise floor accumulators (channel characteristics have changed)
5. Restores `RX_CONTINUOUS` with correct IRQ mask and clears any spurious IRQs
6. Returns the TX/RX pins to RX mode via `_control_tx_rx_pins`

The radio is fully operational again after the call — no restart required.

## Why this isn't needed on the other wrappers

| Wrapper | Status | Reason |
|---|---|---|
| `kiss_modem_wrapper` | ✅ Already has `configure_radio` | Sends `CMD_SET_RADIO` over serial; firmware handles the rest |
| `tcp_radio` | ✅ Not needed | Each individual setter calls `_push_config_live()` which sends `CMD_SET_CONFIG` to the firmware immediately — reconfiguration is handled at the firmware layer, not the host |
| `wsradio` | ✅ Not needed | WebSocket radio; `_send_radio_config` pushes config to remote hardware. Host has no direct radio control |
| `kiss_serial_wrapper` | ✅ Not needed | `configure_radio_and_enter_kiss` is an init-time setup helper, not a live-update path |
| `usb_radio` | ⚠️ See issue | Individual setters are stubs that only update local attributes — see linked issue |

## Testing

Installed from this branch on a device running the SX1262 radio and confirmed:
- Radio returns to active RX after `configure_radio()` with changed parameters
- Noise floor resumes sampling correctly (no longer stuck at -127.5 dBm)
- No restart required

```bash
sudo /opt/pymc_repeater/venv/bin/pip install git+https://github.com/zindello/pyMC_core.git@feat/sx1262-configure-radio
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)