### PR TITLE
Companion/post 1160

### DIFF
--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -47,6 +47,7 @@ from ..protocol.transport_keys import calc_transport_code, get_auto_key_for
 from .channel_store import ChannelStore
 from .constants import (
     ADV_TYPE_CHAT,
+    ADV_TYPE_NONE,
     ADV_TYPE_REPEATER,
     ADV_TYPE_ROOM,
     ADV_TYPE_SENSOR,
@@ -286,8 +287,13 @@ class CompanionBase(ABC):
     # -------------------------------------------------------------------------
 
     def get_contacts(self, since: int = 0) -> list[Contact]:
-        """Return all contacts, optionally filtered by modification time."""
-        return self.contacts.get_all(since=since)
+        """Return all contacts, optionally filtered by modification time.
+
+        Transient/anon contacts (ADV_TYPE_NONE) created for non-contact anon
+        requests are excluded — they are never synced to the app, mirroring the
+        firmware contacts iterator in MyMesh::checkSerialInterface.
+        """
+        return [c for c in self.contacts.get_all(since=since) if c.adv_type != ADV_TYPE_NONE]
 
     def get_contact_by_key(self, pub_key: bytes) -> Optional[Contact]:
         """Look up a contact by its full 32-byte public key."""
@@ -970,7 +976,10 @@ class CompanionBase(ABC):
             from . import binary_parsing
 
             parsed = binary_parsing.parse_binary_response(
-                request_type, response_data, pubkey_prefix=pubkey_prefix, context=context
+                request_type,
+                response_data,
+                pubkey_prefix=pubkey_prefix,
+                context=context,
             )
         except Exception as e:
             logger.debug(f"Binary response parse for type {request_type}: {e}")
@@ -1191,8 +1200,22 @@ class CompanionBase(ABC):
         """
         contact = self.contacts.get_by_key(pub_key)
         if not contact:
-            return SentResult(success=False)
-        proxy = self.contacts.get_by_name(contact.name)
+            # FIRMWARE_VER_CODE 13+ (PR #2672): allow non-contact anon requests by
+            # creating a transient zero-hop contact. Mirrors firmware sendAnonReq:
+            # out_path_len=0 => direct zero-hop, type=ADV_TYPE_NONE (unknown).
+            contact = Contact(
+                public_key=pub_key,
+                name="",
+                adv_type=ADV_TYPE_NONE,
+                out_path_len=0,
+                out_path=b"",
+                lastmod=int(time.time()),
+            )
+            if not self.contacts.add_transient(contact):
+                return SentResult(success=False)
+        # Resolve the proxy by key (anon contacts have an empty name, which
+        # get_by_name would mis-match against any other empty-named contact).
+        proxy = self.contacts.get_proxy_by_key(pub_key)
         if not proxy:
             return SentResult(success=False)
         request_type = PROTOCOL_CODE_ANON_REQ
@@ -1724,7 +1747,11 @@ class CompanionBase(ABC):
         """
         out_path_len = getattr(proxy, "out_path_len", -1)
         out_path = getattr(proxy, "out_path", b"") or b""
-        logger.debug("[PATHDIAG] %s pre-send: %s", request_type, _fmt_path(out_path_len, out_path))
+        logger.debug(
+            "[PATHDIAG] %s pre-send: %s",
+            request_type,
+            _fmt_path(out_path_len, out_path),
+        )
 
     async def send_status_request(self, pub_key: bytes, timeout: float = 15.0) -> dict:
         """Send a protocol request for repeater status/stats."""

--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -220,6 +220,9 @@ class CompanionBase(ABC):
         self._custom_vars: dict[str, str] = {}
         self._sign_buffer: Optional[bytearray] = None
         self._flood_transport_key: Optional[bytes] = None
+        # One-shot "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
+        # when set, the next flood ignores the default scope and floods unscoped.
+        self._flood_unscoped: bool = False
         self._time_offset: float = 0.0
 
         self._event_service = EventService()
@@ -580,11 +583,24 @@ class CompanionBase(ABC):
     # -------------------------------------------------------------------------
 
     def set_flood_scope(self, transport_key: Optional[bytes] = None) -> None:
-        """Set or clear the flood transport key for scoped flooding."""
+        """Set or clear the flood transport key for scoped flooding.
+
+        Also cancels any pending explicit-unscoped request (firmware sets
+        ``send_unscoped = false`` whenever a scope override is set or reset).
+        """
         if transport_key and len(transport_key) >= 16:
             self._flood_transport_key = transport_key[:16]
         else:
             self._flood_transport_key = None
+        self._flood_unscoped = False
+
+    def set_flood_unscoped(self) -> None:
+        """Force the next flood to be unscoped, bypassing the default scope.
+
+        Mirrors firmware CMD_SET_FLOOD_SCOPE_KEY mode 1 (FW PR #2492): a one-shot
+        flag consumed by the next flood-routed packet in _apply_flood_scope.
+        """
+        self._flood_unscoped = True
 
     def set_default_flood_scope(
         self,
@@ -646,12 +662,18 @@ class CompanionBase(ABC):
 
         Matches firmware ``sendFloodScoped()`` in ``BaseChatMesh.cpp``.
         """
-        effective_key = self._resolve_flood_transport_key()
-        if effective_key is None:
-            return
         route_type = pkt.get_route_type()
         if route_type != ROUTE_TYPE_FLOOD:
             return  # only scope flood packets, not direct
+        if self._flood_unscoped:
+            # App explicitly requested unscoped (FW #2492): leave as plain flood,
+            # ignoring any default scope. One-shot — consumed here, as firmware
+            # resets send_unscoped after each flood.
+            self._flood_unscoped = False
+            return
+        effective_key = self._resolve_flood_transport_key()
+        if effective_key is None:
+            return
         code = calc_transport_code(effective_key, pkt)
         pkt.transport_codes[0] = code
         pkt.transport_codes[1] = 0  # reserved for home region (firmware TODO)

--- a/src/pymc_core/companion/constants.py
+++ b/src/pymc_core/companion/constants.py
@@ -8,7 +8,8 @@ from enum import IntEnum
 # ---------------------------------------------------------------------------
 # ADV Types (contact/node classification)
 # ---------------------------------------------------------------------------
-ADV_TYPE_NONE = 0  # transient/anon contact (non-contact request), never persisted/synced
+# transient/anon contact (non-contact request), never persisted/synced
+ADV_TYPE_NONE = 0
 ADV_TYPE_CHAT = 1
 ADV_TYPE_REPEATER = 2
 ADV_TYPE_ROOM = 3
@@ -252,7 +253,8 @@ FRAME_OUTBOUND_PREFIX = 0x3E  # '>'
 FRAME_INBOUND_PREFIX = 0x3C  # '<'
 # Match firmware: writeFrame() refuses to send if len > MAX_FRAME_SIZE; BLE MTU
 # is set to this (e.g. BLEDevice::setMTU(MAX_FRAME_SIZE)). Frame = prefix(1) + len(2) + payload.
-MAX_FRAME_SIZE = 172
+# 176 since MeshCore PR #2022 (+4 over the old 172 for region-scoping transport codes).
+MAX_FRAME_SIZE = 176
 MAX_PAYLOAD_SIZE = MAX_FRAME_SIZE - 3  # max bytes after prefix + 2-byte length
 # Firmware companion command parser uses MAX_FRAME_SIZE - 9 for channel binary payloads.
 MAX_CHANNEL_DATA_LENGTH = MAX_FRAME_SIZE - 9

--- a/src/pymc_core/companion/constants.py
+++ b/src/pymc_core/companion/constants.py
@@ -8,10 +8,15 @@ from enum import IntEnum
 # ---------------------------------------------------------------------------
 # ADV Types (contact/node classification)
 # ---------------------------------------------------------------------------
+ADV_TYPE_NONE = 0  # transient/anon contact (non-contact request), never persisted/synced
 ADV_TYPE_CHAT = 1
 ADV_TYPE_REPEATER = 2
 ADV_TYPE_ROOM = 3
 ADV_TYPE_SENSOR = 4
+
+# Max number of transient (ADV_TYPE_NONE) anon-request contacts kept at once.
+# Mirrors firmware MAX_ANON_CONTACTS (BaseChatMesh.h).
+MAX_ANON_CONTACTS = 8
 
 # ---------------------------------------------------------------------------
 # Text Types
@@ -110,7 +115,9 @@ MAX_PENDING_ACK_CRCS = 64
 # 11+ adds channel binary datagrams and default flood scope commands.
 # 12+ matches the MeshCore dev-branch companion (v1.15.x/1.16.0 family): adds
 #     CMD_GET_ALLOWED_REPEAT_FREQ and CMD_SEND_RAW_PACKET.
-FIRMWARE_VER_CODE = 12
+# 13+ (MeshCore PR #2672, v1.16.0): non-contact CMD_SEND_ANON_REQ — the device
+#     creates a transient zero-hop contact for a pubkey not already in contacts.
+FIRMWARE_VER_CODE = 13
 
 # ---------------------------------------------------------------------------
 # Commands (app -> radio)

--- a/src/pymc_core/companion/contact_store.py
+++ b/src/pymc_core/companion/contact_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Iterable, Iterator, Optional, Tuple
 
-from .constants import DEFAULT_MAX_CONTACTS
+from .constants import ADV_TYPE_NONE, DEFAULT_MAX_CONTACTS, MAX_ANON_CONTACTS
 from .models import Contact
 
 
@@ -89,6 +89,14 @@ class ContactStore:
                 return proxy
         return None
 
+    def get_proxy_by_key(self, public_key: bytes) -> Optional[ContactProxy]:
+        """Lookup the ContactProxy by full 32-byte public key.
+
+        Preferred over get_by_name for transient/anon contacts, whose name is
+        empty and would otherwise collide with any other empty-named contact.
+        """
+        return self._proxies.get(public_key)
+
     # ------------------------------------------------------------------
     # Companion radio CRUD operations
     # ------------------------------------------------------------------
@@ -118,7 +126,13 @@ class ContactStore:
             oldest_key: Optional[bytes] = None
             oldest_lastmod = 0xFFFFFFFF
             for key, c in self._contacts.items():
-                if (c.flags & 0x01) == 0 and c.lastmod < oldest_lastmod:
+                # Exclude transient/anon entries: real contacts never evict an
+                # anon slot, mirroring firmware allocateContactSlot (non-transient).
+                if (
+                    (c.flags & 0x01) == 0
+                    and c.adv_type != ADV_TYPE_NONE
+                    and c.lastmod < oldest_lastmod
+                ):
                     oldest_lastmod = c.lastmod
                     oldest_key = key
             if oldest_key is None:
@@ -131,6 +145,25 @@ class ContactStore:
         self._contacts[contact.public_key] = contact
         self._proxies[contact.public_key] = ContactProxy(contact)
         return True, None
+
+    def add_transient(self, contact: Contact) -> bool:
+        """Add a transient (ADV_TYPE_NONE) anon-request contact.
+
+        Mirrors firmware allocateContactSlot(transient_only=True): the anon pool
+        is capped at MAX_ANON_CONTACTS, reusing the oldest transient slot (by
+        lastmod) when full. Real contacts are never evicted.
+
+        Returns True on success, False only if the call is somehow misused.
+        """
+        if contact.public_key in self._contacts:
+            return self.update(contact)
+        anon_keys = [k for k, c in self._contacts.items() if c.adv_type == ADV_TYPE_NONE]
+        if len(anon_keys) >= MAX_ANON_CONTACTS:
+            oldest_key = min(anon_keys, key=lambda k: self._contacts[k].lastmod)
+            self.remove(oldest_key)
+        self._contacts[contact.public_key] = contact
+        self._proxies[contact.public_key] = ContactProxy(contact)
+        return True
 
     def update(self, contact: Contact) -> bool:
         """Update an existing contact. Returns False if not found."""
@@ -252,6 +285,9 @@ class ContactStore:
         """Export all contacts as a list of plain dicts for serialization."""
         result = []
         for c in self._contacts.values():
+            # Transient/anon entries are never persisted (firmware save_filter).
+            if c.adv_type == ADV_TYPE_NONE:
+                continue
             result.append(
                 {
                     "public_key": c.public_key.hex(),

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -1782,13 +1782,20 @@ class CompanionFrameServer:
         self._write_ok() if ok else self._write_err(ERR_CODE_NOT_FOUND)
 
     async def _cmd_set_flood_scope(self, data: bytes) -> None:
-        """Delegate flood scope to the bridge.
+        """Delegate flood scope to the bridge (CMD_SET_FLOOD_SCOPE_KEY).
 
-        Wire format after cmd byte is stripped: [reserved=0x00 (1)] [key (16)]
-        The firmware (MyMesh.cpp) uses cmd_frame[2] as key start, skipping the
-        reserved byte at cmd_frame[1].  We mirror that by using data[1:17].
+        Wire format after the cmd byte is stripped: [mode (1)] [key (16)].
+        The firmware (MyMesh.cpp:1909) treats data[0] as a mode selector:
+          * mode 0: set the scope override key (data[1:17]) when present, else
+            reset the override; cancels any pending explicit-unscoped request.
+          * mode 1 (FIRMWARE_VER_CODE 12+, PR #2492): force the next flood to be
+            unscoped, ignoring the configured default scope.
+        Older apps always sent mode 0, so this is backward compatible.
         """
-        if len(data) >= 17:
+        mode = data[0] if len(data) >= 1 else 0
+        if mode == 1:
+            self.bridge.set_flood_unscoped()
+        elif len(data) >= 17:
             self.bridge.set_flood_scope(data[1:17])
         else:
             self.bridge.set_flood_scope(None)

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -1231,7 +1231,9 @@ class CompanionFrameServer:
             self._write_err(ERR_CODE_ILLEGAL_ARG)
             return
         if not result.success:
-            self._write_err(ERR_CODE_NOT_FOUND)
+            # FW PR #2672: anon req no longer returns NOT_FOUND. Both "couldn't add
+            # transient contact" and "send failed" map to ERR_CODE_TABLE_FULL.
+            self._write_err(ERR_CODE_TABLE_FULL)
             return
         tag = result.expected_ack if result.expected_ack is not None else 0
         timeout_ms = result.timeout_ms if result.timeout_ms is not None else 10000
@@ -1384,7 +1386,14 @@ class CompanionFrameServer:
                     + text_bytes
                 )
             return (
-                bytes([RESP_CODE_CHANNEL_MSG_RECV, msg.channel_idx, path_len_byte, txt_type])
+                bytes(
+                    [
+                        RESP_CODE_CHANNEL_MSG_RECV,
+                        msg.channel_idx,
+                        path_len_byte,
+                        txt_type,
+                    ]
+                )
                 + struct.pack("<I", msg.timestamp)
                 + text_bytes
             )
@@ -1461,7 +1470,10 @@ class CompanionFrameServer:
         stats_data = result.get("stats", {})
         raw_bytes = stats_data.get("raw_bytes", b"")
         if not raw_bytes:
-            logger.debug("Status response had no raw_bytes for %s; no push sent", pubkey[:6].hex())
+            logger.debug(
+                "Status response had no raw_bytes for %s; no push sent",
+                pubkey[:6].hex(),
+            )
             return
         self._write_frame(bytes([PUSH_CODE_STATUS_RESPONSE, 0]) + pubkey[:6] + raw_bytes)
 
@@ -1490,7 +1502,8 @@ class CompanionFrameServer:
         raw_bytes = telem_data.get("raw_bytes", b"")
         if not raw_bytes:
             logger.debug(
-                "Telemetry response had no raw_bytes for %s; no push sent", pubkey[:6].hex()
+                "Telemetry response had no raw_bytes for %s; no push sent",
+                pubkey[:6].hex(),
             )
             return
         self._write_frame(bytes([PUSH_CODE_TELEMETRY_RESPONSE, 0]) + pubkey[:6] + raw_bytes)

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -23,6 +23,7 @@ from ..protocol import CryptoUtils
 from ..protocol.packet_utils import PathUtils
 from .constants import (
     ADV_TYPE_CHAT,
+    ADV_TYPE_NONE,
     CMD_ADD_UPDATE_CONTACT,
     CMD_APP_START,
     CMD_DEVICE_QUERY,
@@ -349,6 +350,18 @@ class CompanionFrameServer:
         Default returns ``None``."""
         return None
 
+    async def _maybe_persist_contact(self, contact) -> None:
+        """Dispatch to :meth:`_persist_contact`, skipping transient/anon entries.
+
+        Transient contacts (ADV_TYPE_NONE) created for non-contact anon requests
+        are never persisted, mirroring the firmware save_filter. The guard lives
+        here rather than in _persist_contact so it still applies when a subclass
+        overrides the persistence hook (e.g. the repeater's SQLite upsert).
+        """
+        if getattr(contact, "adv_type", None) == ADV_TYPE_NONE:
+            return
+        await self._persist_contact(contact)
+
     async def _persist_contact(self, contact) -> None:
         """Hook: persist a single contact.  Default is a no-op.
 
@@ -425,7 +438,7 @@ class CompanionFrameServer:
             except Exception as e:
                 logger.exception("advert_received callback error: %s", e)
             try:
-                await self._persist_contact(contact)
+                await self._maybe_persist_contact(contact)
             except Exception as e:
                 logger.warning("Persist contact after advert failed: %s", e)
 
@@ -442,7 +455,7 @@ class CompanionFrameServer:
                 return
             _write_push(bytes([PUSH_CODE_PATH_UPDATED]) + contact.public_key[:32])
             try:
-                await self._persist_contact(contact)
+                await self._maybe_persist_contact(contact)
             except Exception as e:
                 logger.warning("Persist contact after path update failed: %s", e)
 

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -145,7 +145,7 @@ class TestApplyPathHashMode:
         pkt = Packet()
         pkt.header = 0x06
         # 3 hops with 1-byte hashes
-        pkt.set_path(b"\xAA\xBB\xCC")
+        pkt.set_path(b"\xaa\xbb\xcc")
         pkt.payload = bytearray(b"test")
         pkt.payload_len = 4
 
@@ -267,6 +267,45 @@ async def test_share_contact_replays_remote_pubkey_zero_hop():
     assert len(out.path) == 0
 
 
+@pytest.mark.asyncio
+async def test_send_anon_req_to_non_contact_creates_transient_and_sends_direct():
+    """PR #2672: anon req to an unknown pubkey creates a zero-hop transient contact."""
+    remote = LocalIdentity()
+    sent = []
+
+    async def _capture(pkt, wait_for_ack=False):
+        sent.append(pkt)
+        return True
+
+    bridge = CompanionBridge(LocalIdentity(), _capture)
+    pub_key = remote.get_public_key()
+    assert bridge.contacts.get_by_key(pub_key) is None
+
+    result = await bridge.send_anon_req(pub_key, b"\x07")
+
+    assert result.success is True
+    assert result.is_flood is False  # zero-hop direct, not flood
+    assert len(sent) == 1
+    # Transient contact recorded with ADV_TYPE_NONE, zero-hop direct path...
+    transient = bridge.contacts.get_by_key(pub_key)
+    assert transient is not None
+    assert transient.adv_type == 0
+    assert transient.out_path_len == 0
+    # ...but excluded from the app-facing contact sync and from persistence.
+    assert all(c.public_key != pub_key for c in bridge.get_contacts())
+    assert all(d["public_key"] != pub_key.hex() for d in bridge.contacts.to_dicts())
+
+
+@pytest.mark.asyncio
+async def test_send_anon_req_returns_failure_when_anon_pool_full():
+    """When add_transient fails the request reports failure (-> ERR_CODE_TABLE_FULL)."""
+    bridge = CompanionBridge(LocalIdentity(), lambda *a, **k: None)
+    pub_key = LocalIdentity().get_public_key()
+    bridge.contacts.add_transient = lambda c: False  # simulate full anon pool
+    result = await bridge.send_anon_req(pub_key, b"\x07")
+    assert result.success is False
+
+
 def test_apply_flood_scope_uses_default_scope_when_transient_unset():
     """Persisted default scope key applies transport flooding when transient scope is unset."""
     bridge = _make_bridge(path_hash_mode=0)
@@ -299,7 +338,7 @@ async def test_group_data_packet_is_queued_for_sync():
     assert bridge.set_channel(0, "Public", b"\x11" * 32)
 
     ch = bridge.get_channel(0)
-    plaintext = b"\x34\x12\x02\xAA\xBB"  # data_type=0x1234, len=2, payload=AABB
+    plaintext = b"\x34\x12\x02\xaa\xbb"  # data_type=0x1234, len=2, payload=AABB
     pkt = PacketBuilder.create_group_data_packet(
         PAYLOAD_TYPE_GRP_DATA,
         channel_hash=hashlib.sha256(ch.secret).digest()[0],
@@ -314,4 +353,4 @@ async def test_group_data_packet_is_queued_for_sync():
     assert queued.is_channel is True
     assert queued.channel_idx == 0
     assert queued.channel_data_type == 0x1234
-    assert queued.channel_data_payload == b"\xAA\xBB"
+    assert queued.channel_data_payload == b"\xaa\xbb"

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -22,6 +22,7 @@ from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_GRP_DATA,
     PAYLOAD_TYPE_TRACE,
     ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
     ROUTE_TYPE_TRANSPORT_FLOOD,
 )
 from pymc_core.protocol.utils import determine_contact_type_from_flags, get_contact_type_name
@@ -323,6 +324,46 @@ def test_apply_flood_scope_uses_default_scope_when_transient_unset():
     bridge._apply_flood_scope(pkt)
     assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
     assert pkt.transport_codes[0] != 0
+
+
+def _make_flood_pkt() -> Packet:
+    pkt = Packet()
+    pkt.header = (PAYLOAD_TYPE_TRACE << 2) | 0x01  # route type FLOOD
+    pkt.path_len = 0
+    pkt.path = bytearray()
+    pkt.payload = bytearray(b"abc")
+    pkt.payload_len = 3
+    return pkt
+
+
+def test_set_flood_unscoped_overrides_default_scope_one_shot():
+    """FW #2492: explicit unscoped forces a plain flood, bypassing the default scope."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", bytes(range(16))) is True
+
+    bridge.set_flood_unscoped()
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    # Stays a plain flood — no transport scoping applied.
+    assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt.transport_codes[0] == 0
+
+    # One-shot: the next flood falls back to the default scope.
+    pkt2 = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt2)
+    assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+    assert pkt2.transport_codes[0] != 0
+
+
+def test_set_flood_scope_cancels_pending_unscoped():
+    """Setting/resetting a scope clears a pending explicit-unscoped request."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", bytes(range(16))) is True
+    bridge.set_flood_unscoped()
+    bridge.set_flood_scope(None)  # cancels the unscoped request
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
 
 
 @pytest.mark.asyncio

--- a/tests/test_companion_stores.py
+++ b/tests/test_companion_stores.py
@@ -222,6 +222,56 @@ class TestContactStore:
         assert store.get_by_key_prefix(b"\x11\x22\x33").name == "Prefix"
         assert store.get_by_key_prefix(b"\xff\xff") is None
 
+    # --- Transient/anon contacts (ADV_TYPE_NONE, PR #2672) ---
+
+    def _anon(self, b: int, lastmod: int = 0) -> Contact:
+        return Contact(
+            public_key=bytes([b]) * 32,
+            name="",
+            adv_type=0,
+            out_path_len=0,
+            lastmod=lastmod,
+        )
+
+    def test_add_transient_basic(self):
+        store = ContactStore(max_contacts=5)
+        assert store.add_transient(self._anon(1)) is True
+        assert store.get_by_key(b"\x01" * 32) is not None
+
+    def test_add_transient_pool_capped_reuses_oldest(self):
+        from pymc_core.companion.constants import MAX_ANON_CONTACTS
+
+        store = ContactStore(max_contacts=1000)
+        for i in range(MAX_ANON_CONTACTS):
+            store.add_transient(self._anon(i + 1, lastmod=i + 1))
+        assert store.get_count() == MAX_ANON_CONTACTS
+        # Oldest (lastmod=1, key 0x01) should be evicted by the 9th.
+        store.add_transient(self._anon(99, lastmod=100))
+        assert store.get_count() == MAX_ANON_CONTACTS
+        assert store.get_by_key(b"\x01" * 32) is None
+        assert store.get_by_key(b"\x63" * 32) is not None  # 0x63 == 99
+
+    def test_to_dicts_excludes_transient(self):
+        store = ContactStore(max_contacts=5)
+        store.add(Contact(public_key=b"\xaa" * 32, name="Real", adv_type=1))
+        store.add_transient(self._anon(2))
+        dicts = store.to_dicts()
+        assert len(dicts) == 1
+        assert dicts[0]["name"] == "Real"
+
+    def test_add_or_overwrite_never_evicts_for_or_via_anon(self):
+        # A full store of real contacts plus an anon entry: overwrite must replace
+        # a real non-favourite, never the anon slot, and never be blocked by it.
+        store = ContactStore(max_contacts=2)
+        store.add(Contact(public_key=b"\x01" * 32, name="A", adv_type=1, lastmod=10))
+        store.add_transient(self._anon(2, lastmod=1))  # oldest overall, but anon
+        ok, overwritten = store.add_or_overwrite(
+            Contact(public_key=b"\x03" * 32, name="C", adv_type=1, lastmod=50)
+        )
+        assert ok is True
+        assert overwritten == b"\x01" * 32  # the real contact, not the anon slot
+        assert store.get_by_key(b"\x02" * 32) is not None  # anon untouched
+
 
 # ---------------------------------------------------------------------------
 # ChannelStore

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -974,3 +974,41 @@ async def test_maybe_persist_contact_skips_transient():
     real = SimpleNamespace(adv_type=1)  # ADV_TYPE_CHAT
     await server._maybe_persist_contact(real)
     assert persisted == [real]  # persisted
+
+
+@pytest.mark.asyncio
+async def test_cmd_set_flood_scope_dispatches_mode_byte():
+    """CMD_SET_FLOOD_SCOPE_KEY: mode 1 -> unscoped, mode 0 -> set/reset scope (FW #2492)."""
+    bridge = Mock()
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_ok = Mock()
+
+    # mode 1 (v12+): force unscoped
+    await server._cmd_set_flood_scope(bytes([0x01]))
+    bridge.set_flood_unscoped.assert_called_once()
+    bridge.set_flood_scope.assert_not_called()
+
+    # mode 0 with a 16-byte key: set scope override (key from data[1:17])
+    bridge.reset_mock()
+    key = bytes(range(16))
+    await server._cmd_set_flood_scope(bytes([0x00]) + key)
+    bridge.set_flood_scope.assert_called_once_with(key)
+    bridge.set_flood_unscoped.assert_not_called()
+
+    # mode 0, short: reset scope
+    bridge.reset_mock()
+    await server._cmd_set_flood_scope(bytes([0x00]))
+    bridge.set_flood_scope.assert_called_once_with(None)
+
+
+def test_max_frame_size_is_176():
+    """Companion frame size tracks firmware PR #2022 (172 -> 176)."""
+    from pymc_core.companion.constants import (
+        MAX_CHANNEL_DATA_LENGTH,
+        MAX_FRAME_SIZE,
+        MAX_PAYLOAD_SIZE,
+    )
+
+    assert MAX_FRAME_SIZE == 176
+    assert MAX_PAYLOAD_SIZE == 173
+    assert MAX_CHANNEL_DATA_LENGTH == 167

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -905,8 +905,53 @@ def test_parse_binary_response_anon_not_mistaken_for_owner_info():
     assert "owner_info" not in parsed
 
 
-def test_device_info_reports_firmware_ver_code_12():
-    """Companion advertises FIRMWARE_VER_CODE 12 to match the firmware dev branch."""
+def test_device_info_reports_firmware_ver_code_13():
+    """Companion advertises FIRMWARE_VER_CODE 13 (PR #2672 non-contact anon requests)."""
     from pymc_core.companion.constants import FIRMWARE_VER_CODE
 
-    assert FIRMWARE_VER_CODE == 12
+    assert FIRMWARE_VER_CODE == 13
+
+
+class _MockBridgeAnonReq:
+    """Minimal bridge for CMD_SEND_ANON_REQ tests."""
+
+    def __init__(self, result: SentResult):
+        self._result = result
+        self.calls = []
+
+    async def send_anon_req(self, pub_key: bytes, data: bytes):
+        self.calls.append((pub_key, data))
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_anon_req_failure_writes_table_full():
+    """PR #2672: anon-req failure maps to ERR_CODE_TABLE_FULL, not NOT_FOUND."""
+    bridge = _MockBridgeAnonReq(SentResult(success=False))
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_err = Mock()
+    server._write_frame = Mock()
+    await server._cmd_send_anon_req(b"\x01" * 32 + b"\x07")
+    assert len(bridge.calls) == 1
+    server._write_err.assert_called_once_with(ERR_CODE_TABLE_FULL)
+    server._write_frame.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_anon_req_success_writes_sent():
+    """Successful anon req emits a RESP_CODE_SENT frame (direct => flood byte 0)."""
+    from pymc_core.companion.constants import RESP_CODE_SENT
+
+    bridge = _MockBridgeAnonReq(
+        SentResult(success=True, is_flood=False, expected_ack=0x11223344, timeout_ms=4000)
+    )
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames = []
+    server._write_frame = Mock(side_effect=lambda f: frames.append(f))
+    server._write_err = Mock()
+    await server._cmd_send_anon_req(b"\x02" * 32 + b"\x07")
+    server._write_err.assert_not_called()
+    assert len(frames) == 1
+    assert frames[0][0] == RESP_CODE_SENT
+    assert frames[0][1] == 0  # not flood
+    assert struct.unpack("<I", frames[0][2:6])[0] == 0x11223344

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -955,3 +955,22 @@ async def test_cmd_send_anon_req_success_writes_sent():
     assert frames[0][0] == RESP_CODE_SENT
     assert frames[0][1] == 0  # not flood
     assert struct.unpack("<I", frames[0][2:6])[0] == 0x11223344
+
+
+@pytest.mark.asyncio
+async def test_maybe_persist_contact_skips_transient():
+    """_maybe_persist_contact guards transient (ADV_TYPE_NONE) entries even when a
+    subclass overrides _persist_contact (e.g. the repeater's SQLite upsert)."""
+    from types import SimpleNamespace
+
+    server = CompanionFrameServer(object(), "hash", port=0)
+    persisted = []
+    server._persist_contact = AsyncMock(side_effect=lambda c: persisted.append(c))
+
+    await server._maybe_persist_contact(SimpleNamespace(adv_type=0))  # ADV_TYPE_NONE
+    assert persisted == []  # skipped
+    server._persist_contact.assert_not_called()
+
+    real = SimpleNamespace(adv_type=1)  # ADV_TYPE_CHAT
+    await server._maybe_persist_contact(real)
+    assert persisted == [real]  # persisted

--- a/tests/test_transport_compat.py
+++ b/tests/test_transport_compat.py
@@ -151,14 +151,14 @@ class TestFirmwareCompatibility:
 class TestCmdSetFloodScopeWireFormat:
     """Verify the CMD_SET_FLOOD_SCOPE byte-extraction matches the firmware wire format.
 
-    Firmware (MyMesh.cpp:1775-1779):
+    Firmware (MyMesh.cpp:1909):
         cmd_frame[0] = CMD_SET_FLOOD_SCOPE
-        cmd_frame[1] = 0x00  (reserved, must be 0)
-        cmd_frame[2..17] = 16-byte key   (len >= 2+16 = 18 total)
+        cmd_frame[1] = mode  (0 = scope override/reset; 1 = explicit unscoped, v12+)
+        cmd_frame[2..17] = 16-byte key for mode 0   (len >= 2+16 = 18 total)
 
     frame_server._handle_cmd strips payload[0] (cmd byte) before calling the handler,
-    so the handler receives data = [reserved=0x00] + [key(16)] = 17 bytes.
-    The correct slice is data[1:17], NOT data[:16].
+    so the handler receives data = [mode] + [key(16)] = 17 bytes for a mode-0 set.
+    The correct key slice is data[1:17], NOT data[:16].
     """
 
     def test_key_slice_skips_reserved_byte(self):


### PR DESCRIPTION
Improves companion parity with firmware features from the 1.16.0 release:

Non-contact anon requests ([#2672](https://github.com/meshcore-dev/MeshCore/pull/2672)): CMD_SEND_ANON_REQ to an unknown pubkey creates a transient zero-hop contact instead of failing; bumps FIRMWARE_VER_CODE → 13. Transient contacts are capped (8, oldest-reuse), never synced/persisted, and never evict real contacts.
Explicit unscoped override (#2492): CMD_SET_FLOOD_SCOPE_KEY mode 1 forces the next flood unscoped, bypassing the default scope.
Frame size (#2022): MAX_FRAME_SIZE 172 → 176.