### PR TITLE
Speed up KISS RX reader to reduce serial backpressure

### DIFF
--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -55,6 +55,10 @@ KISS_FESC = 0xDB  # Frame Escape
 KISS_TFEND = 0xDC  # Transposed Frame End
 KISS_TFESC = 0xDD  # Transposed Frame Escape
 
+# Bytes forms of the delimiters, for C-level bytes.find() scanning in the bulk decoder.
+_KISS_FEND_B = bytes([KISS_FEND])
+_KISS_FESC_B = bytes([KISS_FESC])
+
 # Standard KISS type bytes (port in bits 7-4, command in bits 3-0)
 CMD_DATA = 0x00  # Data frame (raw packet)
 KISS_CMD_TXDELAY = 0x01  # Transmitter keyup delay in 10ms units (firmware default 50 = 500ms)
@@ -195,6 +199,10 @@ RX_BUFFER_SIZE = 1024
 TX_BUFFER_SIZE = 1024
 DEFAULT_BAUDRATE = 115200
 DEFAULT_TIMEOUT = 1.0
+# The RX worker uses a short blocking read so it sleeps in the kernel (releasing the GIL)
+# instead of busy-polling, while still checking stop_event promptly on shutdown. The actual
+# port timeout is min(this, self.timeout) so a caller-supplied lower timeout still wins.
+RX_READ_TIMEOUT_S = 0.1
 RESPONSE_TIMEOUT = 5.0  # Timeout for command responses
 # Extra margin added to estimated airtime when waiting for a DATA TX_DONE, so a long
 # transmit (e.g. a high-SF flood advert) is not cut short by the flat command timeout.
@@ -489,7 +497,9 @@ class KissModemWrapper(LoRaRadio):
             self.serial_conn = serial.Serial(
                 port=self.port,
                 baudrate=self.baudrate,
-                timeout=self.timeout,
+                # Sole reader is _rx_worker, which does a short blocking read; cap the port
+                # timeout so it releases the GIL while idle yet stays shutdown-responsive.
+                timeout=min(self.timeout, RX_READ_TIMEOUT_S),
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
@@ -1797,6 +1807,89 @@ class KissModemWrapper(LoRaRadio):
                 else:
                     self.rx_frame_buffer.append(byte)
 
+    def _decode_kiss(self, data: bytes) -> None:
+        """Bulk KISS decoder used by the RX worker.
+
+        Behaviorally identical to feeding each byte through ``_decode_kiss_byte`` (which
+        the unit tests still exercise), but copies runs of plain bytes with C-level
+        ``bytes.find``/slicing and only does per-byte work at FEND/FESC delimiters. This
+        slashes Python-level work — and therefore GIL hold time — under bursty traffic, so
+        the reader keeps draining the port instead of letting backpressure reach the modem.
+
+        Frame state (in_frame / escaped / rx_frame_buffer) persists on self across calls,
+        so frames that span multiple read chunks decode correctly.
+        """
+        n = len(data)
+        if n == 0:
+            return
+
+        buf = self.rx_frame_buffer  # bytearray, mutated in place
+        in_frame = self.in_frame
+        escaped = self.escaped
+        i = 0
+
+        while i < n:
+            if escaped:
+                b = data[i]
+                i += 1
+                escaped = False
+                # Mirrors _decode_kiss_byte: escaped bytes are appended without a size check
+                if b == KISS_TFEND:
+                    buf.append(KISS_FEND)
+                elif b == KISS_TFESC:
+                    buf.append(KISS_FESC)
+                else:
+                    self.stats["frame_errors"] += 1
+                    logger.warning(f"Invalid KISS escape sequence: 0x{b:02X}")
+                    buf.clear()
+                    in_frame = False
+                continue
+
+            # Scan to the next delimiter; everything in between is plain frame data.
+            fend = data.find(_KISS_FEND_B, i)
+            fesc = data.find(_KISS_FESC_B, i)
+            if fend == -1:
+                nxt = fesc
+            elif fesc == -1:
+                nxt = fend
+            else:
+                nxt = fend if fend < fesc else fesc
+
+            run_end = n if nxt == -1 else nxt
+            if run_end > i and in_frame:
+                run = data[i:run_end]
+                # Honor the MAX_FRAME_SIZE resync rule from _decode_kiss_byte: fill to the
+                # cap, then the next plain byte triggers a resync (lost-FEND protection).
+                space = MAX_FRAME_SIZE - len(buf)
+                if len(run) <= space:
+                    buf += run
+                else:
+                    if space > 0:
+                        buf += run[:space]
+                    self.stats["frame_errors"] += 1
+                    logger.warning("KISS frame exceeded max size (%d), resyncing", MAX_FRAME_SIZE)
+                    buf.clear()
+                    in_frame = False
+
+            if nxt == -1:
+                break
+
+            i = run_end
+            b = data[i]
+            i += 1
+            if b == KISS_FEND:
+                if in_frame and len(buf) > 0:
+                    self._process_received_frame()
+                buf.clear()
+                in_frame = True
+                escaped = False
+            else:  # KISS_FESC
+                if in_frame:
+                    escaped = True
+
+        self.in_frame = in_frame
+        self.escaped = escaped
+
     def _dispatch_rx_callback(self, data: bytes, rssi: int, snr: float) -> None:
         """
         Dispatch RX callback without blocking the RX thread.
@@ -1950,14 +2043,19 @@ class KissModemWrapper(LoRaRadio):
             and self.serial_conn.is_open
         ):
             try:
-                if self.serial_conn and self.serial_conn.in_waiting > 0:
-                    data = self.serial_conn.read(self.serial_conn.in_waiting)
-
-                    for byte in data:
-                        self._decode_kiss_byte(byte)
-
-                else:
-                    threading.Event().wait(0.01)
+                conn = self.serial_conn
+                if conn is None:
+                    break
+                # Blocking read of >=1 byte: sleeps in the kernel (releasing the GIL) until
+                # data or the port timeout, instead of busy-polling. On wake, drain whatever
+                # else has arrived and bulk-decode it in one pass.
+                chunk = conn.read(1)
+                if not chunk:
+                    continue  # timeout with no data; loop re-checks stop_event
+                pending = conn.in_waiting
+                if pending:
+                    chunk += conn.read(pending)
+                self._decode_kiss(chunk)
 
             except Exception as e:
                 if self.is_connected:

--- a/src/pymc_core/hardware/kiss_modem_wrapper.py
+++ b/src/pymc_core/hardware/kiss_modem_wrapper.py
@@ -880,6 +880,13 @@ class KissModemWrapper(LoRaRadio):
                 self.modem_identity = identity_resp[1]
                 logger.info(f"Modem identity: {self.modem_identity.hex()[:16]}...")
 
+            # Get device name. Diagnostic firmwares append crash info here (e.g. the
+            # F103 KISS modem reports "HF#n pc=... cfsr=..." after a HardFault reboot),
+            # so logging it on every (re)connect surfaces those records automatically.
+            device_name = self.get_device_name()
+            if device_name:
+                logger.info(f"Modem device: {device_name}")
+
         except Exception as e:
             logger.warning(f"Failed to query modem info: {e}")
 

--- a/src/pymc_core/hardware/kiss_serial_wrapper.py
+++ b/src/pymc_core/hardware/kiss_serial_wrapper.py
@@ -19,6 +19,10 @@ KISS_FESC = 0xDB  # Frame Escape
 KISS_TFEND = 0xDC  # Transposed Frame End
 KISS_TFESC = 0xDD  # Transposed Frame Escape
 
+# Bytes forms of the delimiters, for C-level bytes.find() scanning in the bulk decoder.
+_KISS_FEND_B = bytes([KISS_FEND])
+_KISS_FESC_B = bytes([KISS_FESC])
+
 # KISS Command Masks
 KISS_MASK_PORT = 0xF0
 KISS_MASK_CMD = 0x0F
@@ -39,6 +43,9 @@ RX_BUFFER_SIZE = 1024
 TX_BUFFER_SIZE = 1024
 DEFAULT_BAUDRATE = 115200
 DEFAULT_TIMEOUT = 1.0
+# RX worker uses a short blocking read so it sleeps in the kernel (releasing the GIL)
+# instead of busy-polling. Actual port timeout is min(this, self.timeout).
+RX_READ_TIMEOUT_S = 0.1
 
 logger = logging.getLogger("KissSerialWrapper")
 
@@ -135,7 +142,9 @@ class KissSerialWrapper(LoRaRadio):
             self.serial_conn = serial.Serial(
                 port=self.port,
                 baudrate=self.baudrate,
-                timeout=self.timeout,
+                # Sole reader is _rx_worker (short blocking read); cap the port timeout so it
+                # releases the GIL while idle yet stays shutdown-responsive.
+                timeout=min(self.timeout, RX_READ_TIMEOUT_S),
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
@@ -617,6 +626,71 @@ class KissSerialWrapper(LoRaRadio):
             if self.in_frame:
                 self.rx_frame_buffer.append(byte)
 
+    def _decode_kiss(self, data: bytes) -> None:
+        """Bulk KISS decoder used by the RX worker.
+
+        Behaviorally identical to feeding each byte through ``_decode_kiss_byte``, but
+        copies runs of plain bytes with C-level ``bytes.find``/slicing and only does
+        per-byte work at FEND/FESC. This cuts Python-level work (and GIL hold time) under
+        bursty traffic so the reader keeps draining the port. Frame state persists on self
+        across calls, so frames spanning multiple read chunks decode correctly.
+        """
+        n = len(data)
+        if n == 0:
+            return
+
+        buf = self.rx_frame_buffer  # bytearray, mutated in place
+        in_frame = self.in_frame
+        escaped = self.escaped
+        i = 0
+
+        while i < n:
+            if escaped:
+                b = data[i]
+                i += 1
+                escaped = False
+                if b == KISS_TFEND:
+                    buf.append(KISS_FEND)
+                elif b == KISS_TFESC:
+                    buf.append(KISS_FESC)
+                else:
+                    # Mirrors _decode_kiss_byte: count + log, but do NOT clear/resync
+                    self.stats["frame_errors"] += 1
+                    logger.warning(f"Invalid KISS escape sequence: 0x{b:02X}")
+                continue
+
+            fend = data.find(_KISS_FEND_B, i)
+            fesc = data.find(_KISS_FESC_B, i)
+            if fend == -1:
+                nxt = fesc
+            elif fesc == -1:
+                nxt = fend
+            else:
+                nxt = fend if fend < fesc else fesc
+
+            run_end = n if nxt == -1 else nxt
+            if run_end > i and in_frame:
+                buf += data[i:run_end]  # this decoder applies no MAX_FRAME_SIZE cap
+
+            if nxt == -1:
+                break
+
+            i = run_end
+            b = data[i]
+            i += 1
+            if b == KISS_FEND:
+                if in_frame and len(buf) > 1:
+                    self._process_received_frame()
+                buf.clear()
+                in_frame = True
+                escaped = False
+            else:  # KISS_FESC
+                if in_frame:
+                    escaped = True
+
+        self.in_frame = in_frame
+        self.escaped = escaped
+
     def _process_received_frame(self):
         """Process a complete received KISS frame"""
         if len(self.rx_frame_buffer) < 1:
@@ -651,17 +725,19 @@ class KissSerialWrapper(LoRaRadio):
         """Background thread for receiving data"""
         while not self.stop_event.is_set() and self.is_connected:
             try:
-                if self.serial_conn and self.serial_conn.in_waiting > 0:
-                    # Read available bytes
-                    data = self.serial_conn.read(self.serial_conn.in_waiting)
-
-                    # Process each byte through KISS decoder
-                    for byte in data:
-                        self._decode_kiss_byte(byte)
-
-                else:
-                    # Short sleep when no data available
-                    threading.Event().wait(0.01)
+                conn = self.serial_conn
+                if conn is None:
+                    break
+                # Blocking read of >=1 byte: sleeps in the kernel (releasing the GIL) until
+                # data or the port timeout, instead of busy-polling. Then drain whatever else
+                # arrived and bulk-decode it in one pass.
+                chunk = conn.read(1)
+                if not chunk:
+                    continue  # timeout with no data; loop re-checks stop_event
+                pending = conn.in_waiting
+                if pending:
+                    chunk += conn.read(pending)
+                self._decode_kiss(chunk)
 
             except Exception as e:
                 if self.is_connected:  # Only log if we expect to be connected

--- a/tests/test_kiss_modem_wrapper.py
+++ b/tests/test_kiss_modem_wrapper.py
@@ -2012,3 +2012,111 @@ class TestKissDataTxSingleFlight:
 
         assert modem.send_frame_and_wait(b"AA", timeout=2.0) is False
         modem.send_frame.assert_not_called()
+
+
+class TestBulkDecodeEquivalence:
+    """The bulk _decode_kiss() must be byte-for-byte equivalent to _decode_kiss_byte(),
+    including across arbitrary read-chunk boundaries (escape/frame state spans chunks)."""
+
+    @staticmethod
+    def _kiss_encode(type_byte, payload):
+        out = bytearray([KISS_FEND, type_byte])
+        for b in payload:
+            if b == KISS_FEND:
+                out += bytes([KISS_FESC, KISS_TFEND])
+            elif b == KISS_FESC:
+                out += bytes([KISS_FESC, KISS_TFESC])
+            else:
+                out.append(b)
+        out.append(KISS_FEND)
+        return bytes(out)
+
+    @staticmethod
+    def _new_modem():
+        m = KissModemWrapper(port="/dev/null", auto_configure=False)
+        m.is_connected = True
+        frames = []
+        m.on_frame_received = lambda data: frames.append(data)
+        return m, frames
+
+    def _run_single(self, stream):
+        m, frames = self._new_modem()
+        for byte in stream:
+            m._decode_kiss_byte(byte)
+        return frames, m.stats["frame_errors"]
+
+    def _run_bulk(self, stream, chunk_sizes):
+        m, frames = self._new_modem()
+        idx = 0
+        for size in chunk_sizes:
+            m._decode_kiss(stream[idx : idx + size])
+            idx += size
+        if idx < len(stream):
+            m._decode_kiss(stream[idx:])
+        return frames, m.stats["frame_errors"]
+
+    def _assert_equiv(self, stream, chunk_sizes):
+        exp_frames, exp_errors = self._run_single(stream)
+        got_frames, got_errors = self._run_bulk(stream, chunk_sizes)
+        assert got_frames == exp_frames
+        assert got_errors == exp_errors
+
+    def test_escape_split_across_chunk_boundary(self):
+        # DATA payload = escaped FEND; split the stream right between FESC and TFEND
+        stream = self._kiss_encode(CMD_DATA, bytes([0xC0])) + self._kiss_encode(
+            KISS_CMD_SETHARDWARE, bytes([HW_RESP_RX_META, 0x10, 0xB0])
+        )
+        fesc_pos = stream.index(KISS_FESC)
+        self._assert_equiv(stream, [fesc_pos + 1])  # chunk ends just after FESC
+
+    def test_oversize_frame_resync(self):
+        # A frame with a lost FEND exceeds MAX_FRAME_SIZE, then a valid pair follows.
+        from pymc_core.hardware.kiss_modem_wrapper import MAX_FRAME_SIZE
+
+        runaway = bytes([KISS_FEND, CMD_DATA]) + bytes(MAX_FRAME_SIZE + 50)  # no closing FEND
+        valid = self._kiss_encode(CMD_DATA, b"\x01\x02") + self._kiss_encode(
+            KISS_CMD_SETHARDWARE, bytes([HW_RESP_RX_META, 0x10, 0xB0])
+        )
+        stream = runaway + valid
+        self._assert_equiv(stream, [1] * len(stream))  # byte-at-a-time chunks
+        self._assert_equiv(stream, [len(stream)])  # whole thing at once
+        self._assert_equiv(stream, [7, 600, 50])  # split through the oversize region
+
+    def test_invalid_escape_sequence(self):
+        # FESC followed by a non-transpose byte -> frame error + resync, then a valid pair.
+        bad = bytes([KISS_FEND, CMD_DATA, KISS_FESC, 0x42, 0x99, KISS_FEND])
+        valid = self._kiss_encode(CMD_DATA, b"\x07") + self._kiss_encode(
+            KISS_CMD_SETHARDWARE, bytes([HW_RESP_RX_META, 0x10, 0xB0])
+        )
+        stream = bad + valid
+        self._assert_equiv(stream, [len(stream)])
+        self._assert_equiv(stream, [3, 1, 2, len(stream)])
+
+    def test_fuzz_random_streams_and_chunkings(self):
+        import random
+
+        for seed in range(60):
+            rng = random.Random(seed)
+            stream = bytearray()
+            for _ in range(rng.randint(1, 8)):
+                payload_len = rng.randint(1, 40)
+                payload = bytes(rng.randint(0, 255) for _ in range(payload_len))
+                stream += self._kiss_encode(CMD_DATA, payload)
+                snr = rng.randint(0, 255)
+                rssi = rng.randint(0, 255)
+                stream += self._kiss_encode(
+                    KISS_CMD_SETHARDWARE, bytes([HW_RESP_RX_META, snr, rssi])
+                )
+            # Inject occasional stray delimiters / leading noise between frames
+            if seed % 3 == 0:
+                stream = bytes([KISS_FEND, KISS_FEND]) + bytes(stream)
+            stream = bytes(stream)
+
+            # Random chunk boundaries
+            chunks = []
+            remaining = len(stream)
+            while remaining > 0:
+                size = rng.randint(1, max(1, remaining // 2 or 1))
+                chunks.append(size)
+                remaining -= size
+            self._assert_equiv(stream, chunks)


### PR DESCRIPTION
The RX worker decoded one byte at a time through a Python state machine and busy-polled in_waiting with a 10ms sleep. Under bursty traffic it held the GIL long enough to fall behind, letting backpressure reach the modem and stalling TX_DONE/replies.
- Add _decode_kiss(bytes): bulk decoder that scans to FEND/FESC with C-level   bytes.find and copies plain runs by slice, doing per-byte work only at   delimiters. State persists across chunks; _decode_kiss_byte kept for tests.
- RX worker now does a short blocking read(1) (sleeps in kernel, releases GIL)   then drains in_waiting in one pass; port timeout capped at min(timeout, 0.1s) to stay shutdown-responsive.
- Mirror both to kiss_serial_wrapper (preserving its distinct frame semantics). Add fuzzed equivalence tests proving _decode_kiss matches the byte-by-byte decoder across arbitrary chunk splits, escape-across-boundary, oversize resync, and invalid escapes.