### PR TITLE
Allow specifying timestamp in create_text_message

### DIFF
--- a/src/pymc_core/protocol/packet_builder.py
+++ b/src/pymc_core/protocol/packet_builder.py
@@ -743,6 +743,7 @@ class PacketBuilder:
         message_type: str = "direct",
         out_path: Optional[list] = None,
         txt_type: int = 0,
+        timestamp: Optional[int] = None,
     ) -> tuple[Packet, int]:
         """
         Create a secure text message with encryption and CRC validation.
@@ -760,6 +761,7 @@ class PacketBuilder:
             txt_type: Text type in upper 6 bits of the flags byte (0=PLAIN, 1=CLI_DATA, …),
                 combined with attempt as ``(txt_type << 2) | (attempt & 3)``. Matches MeshCore
                 ``TXT_TYPE_*`` so repeaters skip delivery ACK for CLI_DATA.
+            timestamp: Optional timestamp (uses current time if None).
 
         Returns:
             tuple: (packet, crc) - The encrypted packet and CRC for ACK verification.
@@ -778,7 +780,8 @@ class PacketBuilder:
         attempt &= 0x03
         txt_type &= 0x3F
         flags_byte = (txt_type << 2) | attempt
-        timestamp = PacketBuilder._get_timestamp()
+        if timestamp is None:
+            timestamp = PacketBuilder._get_timestamp()
 
         # Use  timestamp+data packing
         plaintext = PacketBuilder._pack_timestamp_data(timestamp, flags_byte, message, b"\x00")


### PR DESCRIPTION
This enables the ability to send messages in the past, allowing the creation of room servers that replay old messages to each client.