### PR TITLE
refactor(companion): fix node discovery and advert handling

### DIFF
--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -2098,8 +2098,14 @@ class CompanionBase(ABC):
                         contact, inbound_path, path_len_encoded=path_len_encoded
                     )
                     if applied is not None:
+                        # Stored (existing or newly auto-added): persist + app contact update.
                         await self._fire_callbacks("advert_received", applied)
-                await self._fire_callbacks("node_discovered", data)
+                    # Firmware parity (BaseChatMesh::onAdvertRecv -> onDiscoveredContact):
+                    # notify the client for *every* valid advert (stored or not). The frame
+                    # layer decides full NEW_ADVERT vs short ADVERT by whether the contact
+                    # ended up in the store.
+                    disc_contact = applied if applied is not None else contact
+                    await self._fire_callbacks("node_discovered", disc_contact)
             elif event_type == MeshEvents.TELEMETRY_UPDATED:
                 await self._fire_callbacks("telemetry_response", data)
         except Exception as e:

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -420,7 +420,24 @@ class CompanionFrameServer:
             )
             _write_push(data)
 
+        async def _push_advert_frames(contact: Contact, *, is_new: bool) -> None:
+            """Push the advert frame for a contact, mirroring firmware onDiscoveredContact:
+            the full NEW_ADVERT when the contact was not stored (``is_new``), otherwise the
+            short ADVERT (pubkey only) for a stored contact.
+            """
+            pubkey = contact.public_key
+            if not isinstance(pubkey, bytes) or len(pubkey) < 32:
+                return
+            short, full = await asyncio.to_thread(_build_advert_push_frames, contact)
+            if is_new:
+                if full is not None:
+                    _write_push(full)
+            else:
+                _write_push(short)
+
         async def on_advert_received(contact):
+            """Stored advert: persist the contact. The client frame push is handled by
+            on_node_discovered (firmware onDiscoveredContact)."""
             try:
                 if not isinstance(contact, Contact):
                     logger.warning(
@@ -428,19 +445,28 @@ class CompanionFrameServer:
                         type(contact).__name__,
                     )
                     contact = Contact.from_dict(contact) if isinstance(contact, dict) else contact
-                pubkey = contact.public_key
-                if not isinstance(pubkey, bytes) or len(pubkey) < 32:
-                    return
-                short, full = await asyncio.to_thread(_build_advert_push_frames, contact)
-                _write_push(short)
-                if full is not None:
-                    _write_push(full)
-            except Exception as e:
-                logger.exception("advert_received callback error: %s", e)
-            try:
                 await self._maybe_persist_contact(contact)
             except Exception as e:
-                logger.warning("Persist contact after advert failed: %s", e)
+                logger.exception("advert_received callback error: %s", e)
+
+        async def on_node_discovered(contact_or_data):
+            """Firmware onDiscoveredContact: fires for every valid advert. Pushes the full
+            NEW_ADVERT when the contact was not stored, else the short ADVERT for a stored
+            contact. "Stored" is determined by whether the contact is in the contact book
+            (the advert pipeline has already applied any auto-add by this point)."""
+            try:
+                if isinstance(contact_or_data, Contact):
+                    contact = contact_or_data
+                elif isinstance(contact_or_data, dict):
+                    contact = Contact.from_dict(contact_or_data, now=int(time.time()))
+                else:
+                    return
+                if not contact.name:
+                    return
+                is_new = self.bridge.contacts.get_by_key(contact.public_key) is None
+                await _push_advert_frames(contact, is_new=is_new)
+            except Exception as e:
+                logger.exception("node_discovered callback error: %s", e)
 
         async def on_contact_path_updated(contact):
             # Defense-in-depth: only push PATH and persist for known contacts
@@ -562,6 +588,7 @@ class CompanionFrameServer:
         self.bridge.on_channel_data_received(on_channel_data_received)
         self.bridge.on_send_confirmed(on_send_confirmed)
         self.bridge.on_advert_received(on_advert_received)
+        self.bridge.on_node_discovered(on_node_discovered)
         self.bridge.on_contact_path_updated(on_contact_path_updated)
         self.bridge.on_binary_response(on_binary_response)
         self.bridge.on_path_discovery_response(on_path_discovery_response)

--- a/src/pymc_core/node/dispatcher.py
+++ b/src/pymc_core/node/dispatcher.py
@@ -262,19 +262,24 @@ class Dispatcher:
 
     def _is_own_packet(self, pkt: Packet) -> bool:
         """Check if this packet came from us by comparing the source hash."""
-        if not self.local_identity or len(pkt.payload) < 2:
+        if not self.local_identity or not pkt.payload:
             return False
 
-        # Get our public key hash (first byte)
         our_pubkey = self.local_identity.get_public_key()
         our_hash = our_pubkey[0] if len(our_pubkey) > 0 else 0
 
-        # Compare with src_hash in payload[1]
-        src_hash = pkt.payload[1]
-        is_own = src_hash == our_hash
+        ptype = pkt.get_payload_type()
+        if ptype == PAYLOAD_TYPE_ADVERT:
+            if len(pkt.payload) < 1:
+                return False
+            is_own = pkt.payload[0] == our_hash
+        else:
+            if len(pkt.payload) < 2:
+                return False
+            is_own = pkt.payload[1] == our_hash
 
         if is_own:
-            self._log(f"Own packet detected: src_hash={src_hash:02X}, our_hash={our_hash:02X}")
+            self._log(f"Own packet detected: our_hash={our_hash:02X}")
 
         return is_own
 

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -598,8 +598,8 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         node_discovered_calls = []
         advert_received_calls = []
 
-        def on_node(data):
-            node_discovered_calls.append(data)
+        def on_node(contact):
+            node_discovered_calls.append(contact)
 
         def on_advert(c):
             advert_received_calls.append(c)
@@ -610,7 +610,8 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         assert bridge.contacts.get_count() == 0
         assert len(advert_received_calls) == 0
         assert len(node_discovered_calls) == 1
-        assert node_discovered_calls[0]["name"] == "RepeaterNode"
+        assert node_discovered_calls[0].name == "RepeaterNode"
+        assert isinstance(node_discovered_calls[0], Contact)
 
     async def test_node_discovered_event_path_adds_contact_and_fires_advert_received(self):
         """Event path with optional inbound_path: store updated, advert_received fired once."""
@@ -644,6 +645,34 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
         assert bridge.contacts.get_count() == 1
         assert len(advert_received_calls) == 2
+
+    async def test_stored_contact_fires_both_advert_received_and_node_discovered(self):
+        """Firmware parity (onDiscoveredContact fires for every advert): a stored contact
+        fires advert_received (persist) AND node_discovered (client frame push)."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        peer = LocalIdentity()
+        event_data = {
+            "public_key": peer.get_public_key().hex(),
+            "name": "StoredNode",
+            "contact_type": ADV_TYPE_CHAT,
+            "lat": 0.0,
+            "lon": 0.0,
+            "advert_timestamp": 1000,
+            "timestamp": 1000,
+            "snr": 0.0,
+            "rssi": 0,
+        }
+        node_discovered_calls = []
+        advert_received_calls = []
+
+        bridge.on_node_discovered(lambda c: node_discovered_calls.append(c))
+        bridge.on_advert_received(lambda c: advert_received_calls.append(c))
+        await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
+        assert bridge.contacts.get_count() == 1
+        assert len(advert_received_calls) == 1
+        assert len(node_discovered_calls) == 1
+        assert node_discovered_calls[0].name == "StoredNode"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -511,19 +511,41 @@ class TestDispatcherSendPacket:
         assert result is False
 
     def test_own_packet_detection(self, dispatcher):
-        """Test detection of own packets."""
-        # Create packet with our own address as source
+        """Test detection of own packets (TXT uses payload[1] as src hash)."""
         our_hash = dispatcher.local_identity.get_public_key()[0]
         payload = bytes([0, our_hash]) + b"test"  # dest_hash=0, src_hash=our_hash
         packet_data = create_test_packet(PAYLOAD_TYPE_TXT_MSG, payload)
 
-        # Parse the packet to check
         packet = Packet()
         packet.read_from(packet_data)
 
-        # Should detect as own packet
-        is_own = packet.payload[1] == our_hash
-        assert is_own
+        assert dispatcher._is_own_packet(packet) is True
+
+    def test_own_advert_uses_payload_first_byte(self, dispatcher):
+        """ADVERT packets carry pubkey at payload[0]; must not use payload[1]."""
+        our_hash = dispatcher.local_identity.get_public_key()[0]
+        # Second pubkey byte matches our_hash but first byte does not — must not drop.
+        other_pubkey = bytes([our_hash ^ 0xFF]) + bytes([our_hash]) + bytes(30)
+        packet = Packet()
+        packet.header = (1 << 6) | (PAYLOAD_TYPE_ADVERT << 2)
+        packet.payload = bytearray(other_pubkey + b"\x00" * 40)
+        packet.payload_len = len(packet.payload)
+        packet.path_len = 0
+
+        assert packet.payload[1] == our_hash
+        assert packet.payload[0] != our_hash
+        assert dispatcher._is_own_packet(packet) is False
+
+    def test_own_advert_detected_by_first_pubkey_byte(self, dispatcher):
+        """Own advert: payload[0] equals our pubkey hash."""
+        our_pubkey = dispatcher.local_identity.get_public_key()
+        packet = Packet()
+        packet.header = (1 << 6) | (PAYLOAD_TYPE_ADVERT << 2)
+        packet.payload = bytearray(our_pubkey + b"\x00" * 40)
+        packet.payload_len = len(packet.payload)
+        packet.path_len = 0
+
+        assert dispatcher._is_own_packet(packet) is True
 
 
 class TestDispatcherCallbacks:

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -100,6 +100,91 @@ def test_build_advert_push_frames_out_path_len_negative_becomes_0xff():
     assert full[35] == 0xFF
 
 
+@pytest.mark.asyncio
+async def test_node_discovered_pushes_new_advert_when_auto_add_filtered():
+    """Chat node filtered by selective auto-add still pushes NEW_ADVERT to client."""
+    from unittest.mock import AsyncMock
+
+    from pymc_core.companion.companion_bridge import CompanionBridge
+    from pymc_core.companion.constants import AUTOADD_REPEATER
+    from pymc_core.node.events import MeshEvents
+    from pymc_core.protocol import LocalIdentity
+
+    injector = AsyncMock(return_value=True)
+    bridge = CompanionBridge(LocalIdentity(), injector)
+    bridge.prefs.manual_add_contacts = 1
+    bridge.prefs.autoadd_config = AUTOADD_REPEATER
+
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+    server._setup_push_callbacks()
+
+    peer = LocalIdentity()
+    event_data = {
+        "public_key": peer.get_public_key().hex(),
+        "name": "Meshcore_Jetson_Node",
+        "contact_type": 1,
+        "lat": 0.0,
+        "lon": 0.0,
+        "advert_timestamp": 1000,
+        "timestamp": 1000,
+        "snr": 12.5,
+        "rssi": -38,
+    }
+    await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
+
+    assert bridge.contacts.get_count() == 0
+    assert server._write_queue.qsize() == 1
+    frame = server._write_queue.get_nowait()
+    # Queued frames carry a 3-byte outbound header (FRAME_OUTBOUND_PREFIX + uint16 length)
+    # prepended by _enqueue_frame; the push code and payload start after it.
+    data = frame[3:]
+    assert data[0] == PUSH_CODE_NEW_ADVERT
+    name_offset = 1 + 32 + 3 + MAX_PATH_SIZE
+    name_b = data[name_offset : name_offset + 32]
+    assert name_b.startswith(b"Meshcore_Jetson_Node")
+
+
+@pytest.mark.asyncio
+async def test_node_discovered_pushes_short_advert_for_stored_contact():
+    """A stored (auto-added) contact's advert pushes the short ADVERT only, mirroring
+    firmware onDiscoveredContact(is_new=false)."""
+    from unittest.mock import AsyncMock
+
+    from pymc_core.companion.companion_bridge import CompanionBridge
+    from pymc_core.node.events import MeshEvents
+    from pymc_core.protocol import LocalIdentity
+
+    injector = AsyncMock(return_value=True)
+    bridge = CompanionBridge(LocalIdentity(), injector)
+    bridge.prefs.manual_add_contacts = 0  # auto-add all types
+
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+    server._setup_push_callbacks()
+
+    peer = LocalIdentity()
+    event_data = {
+        "public_key": peer.get_public_key().hex(),
+        "name": "StoredNode",
+        "contact_type": 1,
+        "lat": 0.0,
+        "lon": 0.0,
+        "advert_timestamp": 1000,
+        "timestamp": 1000,
+        "snr": 12.5,
+        "rssi": -38,
+    }
+    await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
+
+    assert bridge.contacts.get_count() == 1  # stored
+    assert server._write_queue.qsize() == 1
+    frame = server._write_queue.get_nowait()
+    data = frame[3:]  # strip the 3-byte outbound header
+    assert data[0] == PUSH_CODE_ADVERT  # short frame only (no full NEW_ADVERT)
+    assert len(data) == 1 + PUB_KEY_SIZE
+
+
 def test_build_advert_push_frames_name_truncated_to_32_bytes():
     """Long name is truncated to 32 bytes in full frame."""
     pubkey = bytes(range(32))


### PR DESCRIPTION
Updated the CompanionBase and CompanionFrameServer classes to improve the handling of node discovery events and advert frames. Previously, if companion auto-add was disabled, only adverts for existing contacts were delivered to the companion. These changes ensure that every valid advert triggers a node discovery callback, which now distinguishes between new and stored contacts, pushing the appropriate advert frames accordingly. Additionally, the dispatcher now correctly identifies own packets for both advert and non-advert payloads. Enhanced tests to verify the correct behavior of the new advert handling logic and ensure firmware compatibility.