### PR TITLE
fix(ack): firmware-compatible ACK format + multi-ack support

### DIFF
--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -1066,6 +1066,12 @@ class CompanionBase(ABC):
         """Return the text message handler, or ``None``."""
         return None
 
+    def _apply_multi_acks_pref(self) -> None:
+        """Push the current ``multi_acks`` pref into the text handler (best-effort)."""
+        th = self._get_text_handler()
+        if th is not None and hasattr(th, "set_multi_acks"):
+            th.set_multi_acks(getattr(self.prefs, "multi_acks", 0))
+
     # -------------------------------------------------------------------------
     # Unified TX methods (shared between Radio and Bridge)
     # -------------------------------------------------------------------------

--- a/src/pymc_core/companion/companion_bridge.py
+++ b/src/pymc_core/companion/companion_bridge.py
@@ -284,6 +284,17 @@ class CompanionBridge(CompanionBase):
     def _get_text_handler(self) -> Any:
         return self._text_handler_ref
 
+    def set_other_params(
+        self,
+        manual_add: int,
+        telemetry_modes: int,
+        advert_loc_policy: int,
+        multi_acks: int,
+    ) -> None:
+        """Set other params and sync the multi_acks pref to the text handler."""
+        super().set_other_params(manual_add, telemetry_modes, advert_loc_policy, multi_acks)
+        self._apply_multi_acks_pref()
+
     def _get_group_text_handler(self):
         """Return the group text handler for name sync."""
         return self._handlers.get(PAYLOAD_TYPE_GRP_TXT)
@@ -330,6 +341,7 @@ class CompanionBridge(CompanionBase):
 
     async def start(self) -> None:
         self._running = True
+        self._apply_multi_acks_pref()
         logger.info(
             f"CompanionBridge started: name={self.prefs.node_name}, "
             f"key={self._identity.get_public_key().hex()[:16]}..."

--- a/src/pymc_core/companion/companion_radio.py
+++ b/src/pymc_core/companion/companion_radio.py
@@ -126,6 +126,7 @@ class CompanionRadio(CompanionBase):
             return
         self._running = True
         self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
+        self._apply_multi_acks_pref()
         self._dispatcher_task = asyncio.create_task(self.node.start())
         logger.info(
             f"CompanionRadio started: name={self.prefs.node_name}, "
@@ -170,6 +171,17 @@ class CompanionRadio(CompanionBase):
         """Set path hash mode and sync to dispatcher default."""
         super().set_path_hash_mode(mode)
         self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
+
+    def set_other_params(
+        self,
+        manual_add: int,
+        telemetry_modes: int,
+        advert_loc_policy: int,
+        multi_acks: int,
+    ) -> None:
+        """Set other params and sync the multi_acks pref to the text handler."""
+        super().set_other_params(manual_add, telemetry_modes, advert_loc_policy, multi_acks)
+        self._apply_multi_acks_pref()
 
     # -------------------------------------------------------------------------
     # Device Configuration (overrides for radio hardware)

--- a/src/pymc_core/node/dispatcher.py
+++ b/src/pymc_core/node/dispatcher.py
@@ -23,6 +23,7 @@ from .handlers import (
     AckHandler,
     AnonReqResponseHandler,
     ControlHandler,
+    MultipartAckHandler,
     TraceHandler,
     create_core_handlers,
 )
@@ -179,6 +180,11 @@ class Dispatcher:
         ack_handler = AckHandler(self._log, self)
         ack_handler.set_ack_received_callback(self._register_ack_received)
         self.register_handler(AckHandler.payload_type(), ack_handler)
+
+        # --- Multi-ack handler: extract the embedded ACK from MULTIPART packets ---
+        multipart_ack_handler = MultipartAckHandler(self._log)
+        multipart_ack_handler.set_ack_received_callback(self._register_ack_received)
+        self.register_handler(MultipartAckHandler.payload_type(), multipart_ack_handler)
 
         # --- Core handlers via shared factory ---
         core = create_core_handlers(

--- a/src/pymc_core/node/handlers/__init__.py
+++ b/src/pymc_core/node/handlers/__init__.py
@@ -9,6 +9,7 @@ from .base import BaseHandler
 from .control import ControlHandler
 from .group_text import GroupTextHandler
 from .login_response import AnonReqResponseHandler, LoginResponseHandler
+from .multipart import MultipartAckHandler
 from .path import PathHandler
 from .protocol_request import ProtocolRequestHandler
 from .protocol_response import ProtocolResponseHandler
@@ -23,6 +24,7 @@ __all__ = [
     "TextMessageHandler",
     "AdvertHandler",
     "AckHandler",
+    "MultipartAckHandler",
     "PathHandler",
     "GroupTextHandler",
     "LoginResponseHandler",

--- a/src/pymc_core/node/handlers/ack.py
+++ b/src/pymc_core/node/handlers/ack.py
@@ -47,12 +47,14 @@ class AckHandler(BaseHandler):
         self.log(f"Processing discrete ACK: payload_len={len(packet.payload)}")
         self.log(f"ACK payload (hex): {packet.payload.hex().upper()}")
 
-        if len(packet.payload) != 4:
-            self.log(f"Invalid ACK length: {len(packet.payload)} bytes (expected 4)")
+        if len(packet.payload) < 4:
+            self.log(f"Invalid ACK length: {len(packet.payload)} bytes (expected >= 4)")
             return None
 
-        # Extract CRC checksum (4 bytes, little endian per protocol spec)
-        crc = int.from_bytes(packet.payload, "little")
+        # Extract CRC checksum from the first 4 bytes (little endian per protocol spec).
+        # Firmware emits 6-byte ACKs for plain DMs (4-byte hash + ext-attempt + random byte);
+        # only the first 4 bytes are matched against the expected ACK.
+        crc = int.from_bytes(packet.payload[:4], "little")
         self.log(f"Discrete ACK received: CRC={crc:08X}")
         return crc
 

--- a/src/pymc_core/node/handlers/multipart.py
+++ b/src/pymc_core/node/handlers/multipart.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable, Optional
+
+from ...protocol import Packet
+from ...protocol.constants import PAYLOAD_TYPE_ACK, PAYLOAD_TYPE_MULTIPART
+from .base import BaseHandler
+
+
+class MultipartAckHandler(BaseHandler):
+    """Handle PAYLOAD_TYPE_MULTIPART packets that carry an embedded ACK ("multi-ack").
+
+    Mirrors the endpoint-receive branch of MeshCore ``Mesh::onRecvPacket``
+    (PAYLOAD_TYPE_MULTIPART case): the payload is a one-byte wrapper
+    ``(remaining << 4) | inner_type`` followed by the embedded ACK bytes. When the
+    inner type is PAYLOAD_TYPE_ACK, the first 4 bytes after the wrapper are the ACK
+    CRC, which is routed into the same ack-received path as discrete ACKs so a pending
+    send is cancelled identically.
+
+    Forwarding/retransmission of multi-acks (the repeater role) is intentionally not
+    implemented here.
+    """
+
+    @staticmethod
+    def payload_type() -> int:
+        return PAYLOAD_TYPE_MULTIPART
+
+    def __init__(self, log_fn):
+        self.log = log_fn
+        self._ack_received_callback: Optional[Callable[[int], Awaitable[None] | None]] = None
+
+    def set_ack_received_callback(
+        self, callback: Optional[Callable[[int], Awaitable[None] | None]]
+    ):
+        """Set callback to notify the dispatcher when an embedded ACK is received."""
+        self._ack_received_callback = callback
+
+    async def __call__(self, packet: Packet) -> None:
+        crc = self.extract_ack_crc(packet)
+        if crc is not None:
+            await self._notify_ack_received(crc)
+
+    def extract_ack_crc(self, packet: Packet) -> Optional[int]:
+        """Return the embedded ACK CRC, or None if this is not a multi-ack."""
+        payload = packet.payload
+        # wrapper byte (1) + at least a 4-byte CRC
+        if len(payload) < 5:
+            self.log(f"MULTIPART too short for embedded ACK: {len(payload)} bytes")
+            return None
+
+        inner_type = payload[0] & 0x0F
+        if inner_type != PAYLOAD_TYPE_ACK:
+            # FUTURE: other multipart inner types
+            self.log(f"MULTIPART inner type {inner_type} is not an ACK, ignoring")
+            return None
+
+        crc = int.from_bytes(payload[1:5], "little")
+        self.log(f"Multi-ack received: CRC={crc:08X}")
+        return crc
+
+    async def _notify_ack_received(self, crc: int):
+        """Notify the dispatcher that an ACK was received."""
+        if self._ack_received_callback:
+            cb = self._ack_received_callback
+            if asyncio.iscoroutinefunction(cb):
+                await cb(crc)
+            else:
+                cb(crc)

--- a/src/pymc_core/node/handlers/text.py
+++ b/src/pymc_core/node/handlers/text.py
@@ -90,7 +90,6 @@ class TextMessageHandler(BaseHandler):
         # Extract fields from decrypted data
         timestamp = decrypted[:4]  # First 4 bytes are the timestamp
         flags = decrypted[4]  # 5th byte contains flags
-        attempt = flags & 0x03  # Last 2 bits are the attempt number
         txt_type = (flags >> 2) & 0x3F  # Upper 6 bits are txt_type
         message_body = decrypted[5:]  # Rest is the message content
 
@@ -113,15 +112,21 @@ class TextMessageHandler(BaseHandler):
         send_ack = txt_type == TXT_TYPE_PLAIN
 
         if send_ack:
+            # Compute the firmware-compatible 6-byte ACK hash once (same value for both
+            # DIRECT and FLOOD responses). Mirror MeshCore BaseChatMesh::onPeerDataRecv:
+            # the hash covers timestamp || flags_byte || text (C-string, no null), and the
+            # extended-attempt byte is the byte *after* the text's null terminator.
+            nul = message_body.find(b"\x00")
+            text_len = nul if nul >= 0 else len(message_body)
+            text_bytes = message_body[:text_len]
+            ext_attempt = message_body[text_len + 1] if (text_len + 1) < len(message_body) else 0
+            ack_hash = PacketBuilder.calc_text_ack_hash(
+                pubkey, timestamp_int, flags, text_bytes, ext_attempt
+            )
+
             # Create appropriate ACK response
             if is_flood:
-                # FLOOD messages use PATH ACK responses with ACK hash in extra payload
-                text_bytes = message_body.rstrip(b"\x00")
-
-                # Calculate ACK hash using standard method (same as DIRECT messages)
-                pack_data = PacketBuilder._pack_timestamp_data(timestamp_int, attempt, text_bytes)
-                ack_hash = CryptoUtils.sha256(pack_data + pubkey)[:4]
-
+                # FLOOD messages use PATH ACK responses with the ACK hash in extra payload
                 # Create PATH ACK response
                 incoming_path = list(packet.path if hasattr(packet, "path") else [])
                 path_len_encoded = (
@@ -152,12 +157,7 @@ class TextMessageHandler(BaseHandler):
 
             else:
                 # DIRECT messages use discrete ACK packets
-                ack_packet = PacketBuilder.create_ack(
-                    pubkey=pubkey,
-                    timestamp=timestamp_int,
-                    attempt=attempt,
-                    text=message_body.rstrip(b"\x00"),
-                )
+                ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash)
 
                 packet_len = len(ack_packet.write_to())
                 ack_airtime = PacketTimingUtils.estimate_airtime_ms(packet_len, self.radio_config)

--- a/src/pymc_core/node/handlers/text.py
+++ b/src/pymc_core/node/handlers/text.py
@@ -66,7 +66,8 @@ class TextMessageHandler(BaseHandler):
         - DIRECT with a known out_path: the ACK routed along that path, plus (when
           ``multi_acks`` is enabled) a multi-ack emitted ~300ms earlier so repeaters can
           forward the embedded ACK.
-        - DIRECT with unknown out_path: a path-less discrete ACK.
+        - DIRECT with unknown out_path: a flood-routed discrete ACK (so it can reach the
+          sender without a known reverse path).
         """
         # The firmware-compatible 6-byte ACK hash is the same for every response. The hash
         # covers timestamp || flags_byte || text (C-string, no null); the extended-attempt
@@ -112,10 +113,13 @@ class TextMessageHandler(BaseHandler):
         )
 
         if not has_known_path:
-            # out_path unknown: path-less discrete ACK
-            ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash)
-            delay_ms = PacketTimingUtils.calc_direct_timeout_ms(airtime(ack_packet), 0)
-            self.log(f"DIRECT ACK timing - delay:{delay_ms:.1f}ms")
+            # out_path unknown: flood the discrete ACK so it can reach the sender without a
+            # known reverse path (mirrors firmware sendAckTo OUT_PATH_UNKNOWN -> sendFloodScoped;
+            # a path-less direct ACK would not be relayed past direct neighbours). The
+            # dispatcher applies flood scope at send time.
+            ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash, route_type="flood")
+            delay_ms = PacketTimingUtils.calc_flood_timeout_ms(airtime(ack_packet))
+            self.log(f"FLOOD ACK timing (no out_path) - delay:{delay_ms:.1f}ms")
             return [(ack_packet, delay_ms / 1000.0)]
 
         out_path = bytes(out_path_raw)

--- a/src/pymc_core/node/handlers/text.py
+++ b/src/pymc_core/node/handlers/text.py
@@ -4,6 +4,10 @@ from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder, PacketTimi
 from ...protocol.constants import PAYLOAD_TYPE_ACK, PAYLOAD_TYPE_TXT_MSG
 from .base import BaseHandler
 
+# Stagger between a multi-ack and the normal ACK on a known direct route, mirroring the
+# firmware's `d += 300` in BaseChatMesh::sendAckTo.
+MULTI_ACK_STAGGER_MS = 300
+
 
 class TextMessageHandler(BaseHandler):
     @staticmethod
@@ -26,15 +30,126 @@ class TextMessageHandler(BaseHandler):
         self.event_service = event_service  # Event service for broadcasting
         self.command_response_callback = None  # Callback for command responses
         self.radio_config = radio_config or {}  # Radio configuration for airtime calculations
+        self.multi_acks = 0  # multi_acks pref (0=off); set via set_multi_acks()
 
     def set_command_response_callback(self, callback):
         """Set callback function for command responses."""
         self.command_response_callback = callback
 
+    def set_multi_acks(self, value: int) -> None:
+        """Set the ``multi_acks`` preference (mirrors firmware getExtraAckTransmitCount)."""
+        self.multi_acks = int(value) if value else 0
+
     def _contact_pubkey_bytes(self, contact) -> bytes:
         """Return contact's public key as 32 bytes (handles hex str or bytes)."""
         pk = contact.public_key
         return bytes.fromhex(pk) if isinstance(pk, str) else bytes(pk)
+
+    def _build_ack_responses(
+        self,
+        *,
+        packet,
+        matched_contact,
+        shared_secret,
+        pubkey,
+        timestamp_int,
+        flags,
+        message_body,
+        is_flood,
+    ) -> list:
+        """Build the ACK packet(s) to emit for a received plain DM.
+
+        Returns a list of ``(packet, delay_seconds)`` tuples. Mirrors MeshCore
+        ``BaseChatMesh::onPeerDataRecv`` / ``sendAckTo``:
+
+        - FLOOD: a PATH-return packet carrying the ACK hash as its extra payload.
+        - DIRECT with a known out_path: the ACK routed along that path, plus (when
+          ``multi_acks`` is enabled) a multi-ack emitted ~300ms earlier so repeaters can
+          forward the embedded ACK.
+        - DIRECT with unknown out_path: a path-less discrete ACK.
+        """
+        # The firmware-compatible 6-byte ACK hash is the same for every response. The hash
+        # covers timestamp || flags_byte || text (C-string, no null); the extended-attempt
+        # byte is the byte *after* the text's null terminator.
+        nul = message_body.find(b"\x00")
+        text_len = nul if nul >= 0 else len(message_body)
+        text_bytes = message_body[:text_len]
+        ext_attempt = message_body[text_len + 1] if (text_len + 1) < len(message_body) else 0
+        ack_hash = PacketBuilder.calc_text_ack_hash(
+            pubkey, timestamp_int, flags, text_bytes, ext_attempt
+        )
+
+        def airtime(pkt) -> float:
+            return PacketTimingUtils.estimate_airtime_ms(len(pkt.write_to()), self.radio_config)
+
+        if is_flood:
+            incoming_path = list(packet.path if hasattr(packet, "path") else [])
+            path_len_encoded = (
+                getattr(packet, "path_len", None)
+                if PathUtils.is_valid_path_len(getattr(packet, "path_len", -1))
+                else None
+            )
+            ack_packet = PacketBuilder.create_path_return(
+                dest_hash=PacketBuilder._hash_byte(pubkey),
+                src_hash=PacketBuilder._hash_byte(self.local_identity.get_public_key()),
+                secret=shared_secret,
+                path=incoming_path,
+                extra_type=PAYLOAD_TYPE_ACK,
+                extra=ack_hash,
+                path_len_encoded=path_len_encoded,
+            )
+            delay_ms = PacketTimingUtils.calc_flood_timeout_ms(airtime(ack_packet))
+            self.log(f"FLOOD ACK timing - delay:{delay_ms:.1f}ms")
+            return [(ack_packet, delay_ms / 1000.0)]
+
+        # DIRECT
+        out_path_len = getattr(matched_contact, "out_path_len", -1)
+        out_path_raw = getattr(matched_contact, "out_path", b"") or b""
+        has_known_path = (
+            out_path_len is not None
+            and out_path_len >= 0
+            and PathUtils.is_valid_path_len(out_path_len)
+        )
+
+        if not has_known_path:
+            # out_path unknown: path-less discrete ACK
+            ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash)
+            delay_ms = PacketTimingUtils.calc_direct_timeout_ms(airtime(ack_packet), 0)
+            self.log(f"DIRECT ACK timing - delay:{delay_ms:.1f}ms")
+            return [(ack_packet, delay_ms / 1000.0)]
+
+        out_path = bytes(out_path_raw)
+        path_hops = PathUtils.get_path_hash_count(out_path_len)
+        ack_packet = PacketBuilder.create_ack_from_bytes(
+            ack_hash, path=out_path, path_len_encoded=out_path_len
+        )
+        base_delay_ms = PacketTimingUtils.calc_direct_timeout_ms(airtime(ack_packet), path_hops)
+
+        if self.multi_acks <= 0:
+            self.log(f"DIRECT ACK timing (routed) - delay:{base_delay_ms:.1f}ms, hops:{path_hops}")
+            return [(ack_packet, base_delay_ms / 1000.0)]
+
+        # multi-ack fires at the base delay; the normal ACK is staggered later
+        multi_packet = PacketBuilder.create_multi_ack(
+            ack_hash, remaining=1, path=out_path, path_len_encoded=out_path_len
+        )
+        self.log(f"DIRECT multi-ack timing - base_delay:{base_delay_ms:.1f}ms, hops:{path_hops}")
+        return [
+            (multi_packet, base_delay_ms / 1000.0),
+            (ack_packet, (base_delay_ms + MULTI_ACK_STAGGER_MS) / 1000.0),
+        ]
+
+    async def _send_delayed_ack(self, pkt, delay_s, timestamp_int) -> None:
+        """Send a single ACK packet after ``delay_s`` seconds (best-effort)."""
+        await asyncio.sleep(delay_s)
+        try:
+            await self.send_packet(pkt, wait_for_ack=False)
+            self.log(
+                f"ACK packet sent successfully (delayed {delay_s*1000:.1f}ms) "
+                f"for timestamp {timestamp_int}"
+            )
+        except Exception as ack_send_error:
+            self.log(f"Failed to send ACK packet: {ack_send_error}")
 
     async def __call__(self, packet: Packet) -> None:
         if len(packet.payload) < 4:
@@ -112,76 +227,19 @@ class TextMessageHandler(BaseHandler):
         send_ack = txt_type == TXT_TYPE_PLAIN
 
         if send_ack:
-            # Compute the firmware-compatible 6-byte ACK hash once (same value for both
-            # DIRECT and FLOOD responses). Mirror MeshCore BaseChatMesh::onPeerDataRecv:
-            # the hash covers timestamp || flags_byte || text (C-string, no null), and the
-            # extended-attempt byte is the byte *after* the text's null terminator.
-            nul = message_body.find(b"\x00")
-            text_len = nul if nul >= 0 else len(message_body)
-            text_bytes = message_body[:text_len]
-            ext_attempt = message_body[text_len + 1] if (text_len + 1) < len(message_body) else 0
-            ack_hash = PacketBuilder.calc_text_ack_hash(
-                pubkey, timestamp_int, flags, text_bytes, ext_attempt
+            scheduled = self._build_ack_responses(
+                packet=packet,
+                matched_contact=matched_contact,
+                shared_secret=shared_secret,
+                pubkey=pubkey,
+                timestamp_int=timestamp_int,
+                flags=flags,
+                message_body=message_body,
+                is_flood=is_flood,
             )
-
-            # Create appropriate ACK response
-            if is_flood:
-                # FLOOD messages use PATH ACK responses with the ACK hash in extra payload
-                # Create PATH ACK response
-                incoming_path = list(packet.path if hasattr(packet, "path") else [])
-                path_len_encoded = (
-                    getattr(packet, "path_len", None)
-                    if PathUtils.is_valid_path_len(getattr(packet, "path_len", -1))
-                    else None
-                )
-
-                ack_packet = PacketBuilder.create_path_return(
-                    dest_hash=PacketBuilder._hash_byte(pubkey),
-                    src_hash=PacketBuilder._hash_byte(self.local_identity.get_public_key()),
-                    secret=shared_secret,
-                    path=incoming_path,
-                    extra_type=PAYLOAD_TYPE_ACK,
-                    extra=ack_hash,
-                    path_len_encoded=path_len_encoded,
-                )
-
-                packet_len = len(ack_packet.write_to())
-                ack_airtime = PacketTimingUtils.estimate_airtime_ms(packet_len, self.radio_config)
-                ack_timeout_ms = PacketTimingUtils.calc_flood_timeout_ms(ack_airtime)
-
-                self.log(
-                    f"FLOOD ACK timing - packet:{packet_len}B, airtime:{ack_airtime:.1f}ms, "
-                    f"delay:{ack_timeout_ms:.1f}ms"
-                )
-                ack_timeout_ms = ack_timeout_ms / 1000.0  # Convert to seconds
-
-            else:
-                # DIRECT messages use discrete ACK packets
-                ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash)
-
-                packet_len = len(ack_packet.write_to())
-                ack_airtime = PacketTimingUtils.estimate_airtime_ms(packet_len, self.radio_config)
-                ack_timeout_ms = PacketTimingUtils.calc_direct_timeout_ms(ack_airtime, 0)
-
-                self.log(
-                    f"DIRECT ACK timing - packet:{packet_len}B, airtime:{ack_airtime:.1f}ms, "
-                    f"delay:{ack_timeout_ms:.1f}ms, radio_config:{self.radio_config}"
-                )
-                ack_timeout_ms = ack_timeout_ms / 1000.0  # Convert to seconds
-
-            async def send_delayed_ack():
-                await asyncio.sleep(ack_timeout_ms)
-                try:
-                    await self.send_packet(ack_packet, wait_for_ack=False)
-                    self.log(
-                        f"ACK packet sent successfully (delayed {ack_timeout_ms*1000:.1f}ms) "
-                        f"for timestamp {timestamp_int}"
-                    )
-                except Exception as ack_send_error:
-                    self.log(f"Failed to send ACK packet: {ack_send_error}")
-
-            # Schedule ACK to be sent after delay (non-blocking)
-            asyncio.create_task(send_delayed_ack())
+            # Schedule each ACK to be sent after its delay (non-blocking)
+            for pkt, delay_s in scheduled:
+                asyncio.create_task(self._send_delayed_ack(pkt, delay_s, timestamp_int))
         else:
             self.log(f"Skipping ACK for txt_type={txt_type} (CLI command)")
 

--- a/src/pymc_core/protocol/packet_builder.py
+++ b/src/pymc_core/protocol/packet_builder.py
@@ -24,6 +24,7 @@ from .constants import (
     PAYLOAD_TYPE_CONTROL,
     PAYLOAD_TYPE_GRP_DATA,
     PAYLOAD_TYPE_GRP_TXT,
+    PAYLOAD_TYPE_MULTIPART,
     PAYLOAD_TYPE_PATH,
     PAYLOAD_TYPE_RAW_CUSTOM,
     PAYLOAD_TYPE_REQ,
@@ -287,15 +288,64 @@ class PacketBuilder:
         return digest[:4] + bytes([ext_attempt & 0xFF]) + last_byte
 
     @staticmethod
-    def create_ack_from_bytes(ack_bytes: bytes) -> Packet:
+    def create_ack_from_bytes(
+        ack_bytes: bytes,
+        path: Optional[Sequence[int]] = None,
+        path_len_encoded: Optional[int] = None,
+    ) -> Packet:
         """
         Wrap raw ACK bytes into a PAYLOAD_TYPE_ACK packet.
 
         Mirror of firmware ``Mesh::createAck(const uint8_t* ack, uint8_t len)`` which simply
         copies the raw ACK bytes into the packet payload.
+
+        Args:
+            ack_bytes: Raw ACK payload bytes.
+            path: Optional routing path (one byte per hop) to send the ACK directly along
+                a known ``out_path`` (mirrors firmware ``sendDirect``). When omitted the
+                ACK is a path-less direct packet.
+            path_len_encoded: Optional pre-encoded path_len byte (for 2/3-byte hashes).
         """
-        header = PacketBuilder._create_header(PAYLOAD_TYPE_ACK)
-        return PacketBuilder._create_packet(header, bytes(ack_bytes))
+        has_path = bool(path)
+        header = PacketBuilder._create_header(
+            PAYLOAD_TYPE_ACK, route_type="direct", has_routing_path=has_path
+        )
+        pkt = PacketBuilder._create_packet(header, bytes(ack_bytes))
+        if has_path:
+            pkt.set_path(bytes(path), path_len_encoded)
+        return pkt
+
+    @staticmethod
+    def create_multi_ack(
+        ack_bytes: bytes,
+        remaining: int = 1,
+        path: Optional[Sequence[int]] = None,
+        path_len_encoded: Optional[int] = None,
+    ) -> Packet:
+        """
+        Wrap raw ACK bytes into a PAYLOAD_TYPE_MULTIPART packet ("multi-ack").
+
+        Mirror of firmware ``Mesh::createMultiAck(ack, len, remaining)``: the payload is a
+        one-byte header ``(remaining << 4) | PAYLOAD_TYPE_ACK`` followed by the raw ACK
+        bytes. Intermediate repeaters forward this packet and extract the embedded ACK
+        early, improving delivery-confirmation reliability on multi-hop direct routes.
+
+        Args:
+            ack_bytes: Raw ACK payload bytes (embedded after the wrapper byte).
+            remaining: Number of additional multi-acks still to be sent in the sequence
+                (encoded in the upper nibble of the wrapper byte).
+            path: Optional routing path to send directly along a known ``out_path``.
+            path_len_encoded: Optional pre-encoded path_len byte (for 2/3-byte hashes).
+        """
+        has_path = bool(path)
+        header = PacketBuilder._create_header(
+            PAYLOAD_TYPE_MULTIPART, route_type="direct", has_routing_path=has_path
+        )
+        payload = bytes([((remaining & 0x0F) << 4) | PAYLOAD_TYPE_ACK]) + bytes(ack_bytes)
+        pkt = PacketBuilder._create_packet(header, payload)
+        if has_path:
+            pkt.set_path(bytes(path), path_len_encoded)
+        return pkt
 
     @staticmethod
     def create_self_advert(

--- a/src/pymc_core/protocol/packet_builder.py
+++ b/src/pymc_core/protocol/packet_builder.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import struct
 import threading
 import time
@@ -244,11 +245,57 @@ class PacketBuilder:
             if isinstance(text, str)
             else bytes(text).strip(b"\x00")
         )
-        temp = PacketBuilder._pack_timestamp_data(timestamp, attempt, text_bytes)
-        digest = CryptoUtils.sha256(temp + pubkey)
+        ack_hash = PacketBuilder.calc_text_ack_hash(pubkey, timestamp, attempt, text_bytes)
+        return PacketBuilder.create_ack_from_bytes(ack_hash)
 
+    @staticmethod
+    def calc_text_ack_hash(
+        pubkey: bytes,
+        timestamp: int,
+        flags_byte: int,
+        text: Union[str, bytes, memoryview],
+        ext_attempt: int = 0,
+        randomize: bool = True,
+    ) -> bytes:
+        """
+        Compute the firmware-compatible 6-byte ACK hash for a plain text message.
+
+        Mirrors MeshCore ``BaseChatMesh::onPeerDataRecv`` (TXT_TYPE_PLAIN): the ACK is
+        ``sha256(timestamp || flags_byte || text || pubkey)[:4]`` followed by an
+        extended-attempt byte and a random byte. Only the first 4 bytes are matched by
+        the sender; bytes 4-5 exist solely to give each emitted ACK packet a unique
+        packet hash (so mesh dedup never drops a legitimate ACK).
+
+        Args:
+            pubkey: 32-byte public key of the message sender.
+            timestamp: Unix timestamp from the original message.
+            flags_byte: The original message's full flags byte (``(txt_type << 2) | attempt``).
+                For TXT_TYPE_PLAIN this equals the attempt number.
+            text: Message text (without the null terminator).
+            ext_attempt: Extended-attempt byte (the byte after the text's null terminator
+                in the decrypted payload); 0 for normal messages.
+            randomize: When True the 6th byte is random (firmware behaviour); set False for
+                deterministic output in tests.
+
+        Returns:
+            bytes: 6-byte ACK hash.
+        """
+        text_bytes = text.encode("utf-8") if isinstance(text, str) else bytes(text)
+        temp = PacketBuilder._pack_timestamp_data(timestamp, flags_byte & 0xFF, text_bytes)
+        digest = CryptoUtils.sha256(temp + pubkey)
+        last_byte = os.urandom(1) if randomize else b"\x00"
+        return digest[:4] + bytes([ext_attempt & 0xFF]) + last_byte
+
+    @staticmethod
+    def create_ack_from_bytes(ack_bytes: bytes) -> Packet:
+        """
+        Wrap raw ACK bytes into a PAYLOAD_TYPE_ACK packet.
+
+        Mirror of firmware ``Mesh::createAck(const uint8_t* ack, uint8_t len)`` which simply
+        copies the raw ACK bytes into the packet payload.
+        """
         header = PacketBuilder._create_header(PAYLOAD_TYPE_ACK)
-        return PacketBuilder._create_packet(header, digest[:4])
+        return PacketBuilder._create_packet(header, bytes(ack_bytes))
 
     @staticmethod
     def create_self_advert(

--- a/src/pymc_core/protocol/packet_builder.py
+++ b/src/pymc_core/protocol/packet_builder.py
@@ -292,6 +292,7 @@ class PacketBuilder:
         ack_bytes: bytes,
         path: Optional[Sequence[int]] = None,
         path_len_encoded: Optional[int] = None,
+        route_type: str = "direct",
     ) -> Packet:
         """
         Wrap raw ACK bytes into a PAYLOAD_TYPE_ACK packet.
@@ -303,12 +304,16 @@ class PacketBuilder:
             ack_bytes: Raw ACK payload bytes.
             path: Optional routing path (one byte per hop) to send the ACK directly along
                 a known ``out_path`` (mirrors firmware ``sendDirect``). When omitted the
-                ACK is a path-less direct packet.
+                ACK is a path-less packet.
             path_len_encoded: Optional pre-encoded path_len byte (for 2/3-byte hashes).
+            route_type: ``"direct"`` (default) or ``"flood"``. Use ``"flood"`` when the
+                reverse path is unknown so the ACK can propagate without a path (mirrors
+                firmware ``sendAckTo`` falling back to ``sendFloodScoped``). The dispatcher
+                applies flood scope to flood-routed packets at send time.
         """
         has_path = bool(path)
         header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_ACK, route_type="direct", has_routing_path=has_path
+            PAYLOAD_TYPE_ACK, route_type=route_type, has_routing_path=has_path
         )
         pkt = PacketBuilder._create_packet(header, bytes(ack_bytes))
         if has_path:

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -68,6 +68,19 @@ class TestCompanionBridgeInit:
         )
         assert bridge._handlers is not None
 
+    def test_set_other_params_propagates_multi_acks(self):
+        """set_other_params pushes the multi_acks pref into the text handler."""
+        bridge = CompanionBridge(LocalIdentity(), MockPacketInjector(), node_name="Test")
+        text_handler = bridge._get_text_handler()
+        assert text_handler is not None
+
+        bridge.set_other_params(manual_add=0, telemetry_modes=0, advert_loc_policy=0, multi_acks=1)
+        assert bridge.prefs.multi_acks == 1
+        assert text_handler.multi_acks == 1
+
+        bridge.set_other_params(manual_add=0, telemetry_modes=0, advert_loc_policy=0, multi_acks=0)
+        assert text_handler.multi_acks == 0
+
 
 # ---------------------------------------------------------------------------
 # Lifecycle

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -8,6 +8,7 @@ from pymc_core.protocol import Packet
 from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
+    PAYLOAD_TYPE_MULTIPART,
     PAYLOAD_TYPE_TRACE,
     PAYLOAD_TYPE_TXT_MSG,
     ROUTE_TYPE_DIRECT,
@@ -176,6 +177,27 @@ class TestDispatcherInitialization:
 
         assert 100 in dispatcher._handlers
         assert dispatcher._handlers[100] == mock_handler
+
+    @pytest.mark.asyncio
+    async def test_multipart_ack_releases_waiting_send(self, dispatcher):
+        """A received MULTIPART ack is routed into _register_ack_received and releases a
+        waiting send, just like a discrete ACK."""
+        dispatcher.register_default_handlers(
+            contacts=None, local_identity=dispatcher.local_identity, event_service=None
+        )
+        assert PAYLOAD_TYPE_MULTIPART in dispatcher._handlers
+
+        crc = 0x12345678
+        evt = asyncio.Event()
+        dispatcher._waiting_acks[crc] = evt
+
+        # wrapper byte (remaining=1, inner=ACK) + 4-byte CRC (little-endian 0x12345678)
+        payload = bytes([(1 << 4) | PAYLOAD_TYPE_ACK]) + b"\x78\x56\x34\x12"
+        data = create_test_packet(PAYLOAD_TYPE_MULTIPART, payload)
+        await dispatcher._process_received_packet(data)
+
+        assert evt.is_set()
+        assert crc not in dispatcher._waiting_acks
 
 
 class TestDispatcherPacketProcessing:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -327,6 +327,37 @@ class TestTextMessageHandler:
         assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
 
     @pytest.mark.asyncio
+    async def test_direct_unknown_path_floods_ack(self):
+        """With an unknown reverse out_path, the ACK is flood-routed (not path-less direct)."""
+        sender = LocalIdentity()
+        receiver = self.local_identity
+
+        class _SendContact:
+            def __init__(self, pubkey_hex):
+                self.public_key = pubkey_hex
+                self.out_path = []
+                self.out_path_len = -1
+
+        receiver_contact = _SendContact(receiver.get_public_key().hex())
+        packet, ack_crc = PacketBuilder.create_text_message(
+            receiver_contact, sender, "no reverse path", attempt=0, message_type="direct"
+        )
+        # Sender is a known contact but with an UNKNOWN out_path back to it.
+        self.contacts.contacts = [
+            MockContact(public_key=sender.get_public_key().hex(), name="sender")
+        ]
+
+        await self.handler(packet)
+        await self._wait_for_sends(1)
+
+        assert self.send_packet_fn.call_count == 1
+        ack_packet = self.send_packet_fn.call_args_list[0].args[0]
+        assert ack_packet.get_payload_type() == PAYLOAD_TYPE_ACK
+        assert (ack_packet.header & 0x03) == ROUTE_TYPE_FLOOD  # flooded, not direct
+        assert ack_packet.path_len == 0  # no path
+        assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
+
+    @pytest.mark.asyncio
     async def test_direct_multi_ack_emits_multipart_then_ack(self):
         """With multi_acks on and a known path, a MULTIPART fires before the normal ACK."""
         self.handler.set_multi_acks(1)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -11,6 +11,7 @@ from pymc_core.node.handlers import (
     BaseHandler,
     GroupTextHandler,
     LoginResponseHandler,
+    MultipartAckHandler,
     PathHandler,
     ProtocolRequestHandler,
     ProtocolResponseHandler,
@@ -23,6 +24,7 @@ from pymc_core.protocol.constants import (
     PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_ANON_REQ,
     PAYLOAD_TYPE_GRP_TXT,
+    PAYLOAD_TYPE_MULTIPART,
     PAYLOAD_TYPE_PATH,
     PAYLOAD_TYPE_REQ,
     PAYLOAD_TYPE_RESPONSE,
@@ -34,6 +36,7 @@ from pymc_core.protocol.constants import (
     SIGNATURE_SIZE,
     TIMESTAMP_SIZE,
 )
+from pymc_core.protocol.packet_utils import PathUtils
 
 
 # Mock classes for testing
@@ -146,6 +149,47 @@ class TestAckHandler:
 
 
 # Text Message Handler Tests
+class TestMultipartAckHandler:
+    def setup_method(self):
+        self.log_fn = MagicMock()
+        self.callback = AsyncMock()
+        self.handler = MultipartAckHandler(self.log_fn)
+        self.handler.set_ack_received_callback(self.callback)
+
+    def test_payload_type(self):
+        assert MultipartAckHandler.payload_type() == PAYLOAD_TYPE_MULTIPART
+
+    @pytest.mark.asyncio
+    async def test_extracts_embedded_ack(self):
+        """A MULTIPART ACK notifies the callback with the embedded 4-byte CRC."""
+        packet = Packet()
+        # wrapper byte (remaining=1, inner=ACK) + 4-byte CRC + extra bytes
+        packet.payload = bytearray(
+            bytes([(1 << 4) | PAYLOAD_TYPE_ACK]) + b"\x78\x56\x34\x12\x00\xAB"
+        )
+
+        await self.handler(packet)
+        self.callback.assert_awaited_once_with(0x12345678)
+
+    @pytest.mark.asyncio
+    async def test_too_short_ignored(self):
+        """Payload without a full embedded CRC notifies nothing."""
+        packet = Packet()
+        packet.payload = bytearray(bytes([(1 << 4) | PAYLOAD_TYPE_ACK]) + b"\x12\x34")
+
+        await self.handler(packet)
+        self.callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_ack_inner_type_ignored(self):
+        """A MULTIPART whose inner type is not ACK notifies nothing."""
+        packet = Packet()
+        packet.payload = bytearray(bytes([(1 << 4) | 0x02]) + b"\x78\x56\x34\x12")
+
+        await self.handler(packet)
+        self.callback.assert_not_awaited()
+
+
 class TestTextMessageHandler:
     def setup_method(self):
         self.local_identity = LocalIdentity()
@@ -230,6 +274,81 @@ class TestTextMessageHandler:
         assert ack_packet.get_payload_type() == PAYLOAD_TYPE_ACK
         assert len(ack_packet.payload) == 6
         assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
+
+    def _make_direct_dm_with_path(self, text="multi ack route"):
+        """Build a direct DM addressed to the handler, with the sender registered as a
+        contact that has a known multi-hop out_path. Returns (packet, ack_crc, out_path,
+        out_path_len)."""
+        sender = LocalIdentity()
+        receiver = self.local_identity
+
+        class _SendContact:
+            def __init__(self, pubkey_hex):
+                self.public_key = pubkey_hex
+                self.out_path = []
+                self.out_path_len = -1
+
+        receiver_contact = _SendContact(receiver.get_public_key().hex())
+        packet, ack_crc = PacketBuilder.create_text_message(
+            receiver_contact, sender, text, attempt=0, message_type="direct"
+        )
+
+        # Sender contact known to the receiver, with a 2-hop out_path
+        out_path = bytes([0x11, 0x22])
+        out_path_len = PathUtils.encode_path_len(1, 2)
+        contact = MockContact(public_key=sender.get_public_key().hex(), name="sender")
+        contact.out_path = out_path
+        contact.out_path_len = out_path_len
+        self.contacts.contacts = [contact]
+        return packet, ack_crc, out_path, out_path_len
+
+    async def _wait_for_sends(self, count):
+        import asyncio
+
+        for _ in range(120):
+            if self.send_packet_fn.call_count >= count:
+                break
+            await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_direct_known_path_routes_ack(self):
+        """With a known out_path and multi_acks off, the ACK is routed along the path."""
+        self.handler.set_multi_acks(0)
+        packet, ack_crc, out_path, out_path_len = self._make_direct_dm_with_path()
+
+        await self.handler(packet)
+        await self._wait_for_sends(1)
+
+        assert self.send_packet_fn.call_count == 1
+        ack_packet = self.send_packet_fn.call_args_list[0].args[0]
+        assert ack_packet.get_payload_type() == PAYLOAD_TYPE_ACK
+        assert bytes(ack_packet.path) == out_path
+        assert ack_packet.path_len == out_path_len
+        assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
+
+    @pytest.mark.asyncio
+    async def test_direct_multi_ack_emits_multipart_then_ack(self):
+        """With multi_acks on and a known path, a MULTIPART fires before the normal ACK."""
+        self.handler.set_multi_acks(1)
+        packet, ack_crc, out_path, out_path_len = self._make_direct_dm_with_path()
+
+        await self.handler(packet)
+        await self._wait_for_sends(2)
+
+        assert self.send_packet_fn.call_count == 2
+        first = self.send_packet_fn.call_args_list[0].args[0]
+        second = self.send_packet_fn.call_args_list[1].args[0]
+
+        # multipart is staggered earlier, so it is sent first
+        assert first.get_payload_type() == PAYLOAD_TYPE_MULTIPART
+        assert second.get_payload_type() == PAYLOAD_TYPE_ACK
+
+        # both carry the out_path and the same embedded CRC
+        assert bytes(first.path) == out_path and first.path_len == out_path_len
+        assert bytes(second.path) == out_path and second.path_len == out_path_len
+        assert (first.payload[0] & 0x0F) == PAYLOAD_TYPE_ACK
+        assert int.from_bytes(first.payload[1:5], "little") == ack_crc
+        assert int.from_bytes(second.payload[:4], "little") == ack_crc
 
 
 # Advert Handler Tests

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -120,6 +120,17 @@ class TestAckHandler:
         self.log_fn.assert_called()
 
     @pytest.mark.asyncio
+    async def test_process_discrete_ack_six_bytes(self):
+        """Firmware emits 6-byte ACKs (hash + ext-attempt + random); match first 4 bytes."""
+        packet = Packet()
+        # 4-byte CRC 0x12345678 followed by an ext-attempt byte and a random byte
+        packet.payload = bytearray(b"\x78\x56\x34\x12\x02\xAB")
+
+        crc = await self.handler.process_discrete_ack(packet)
+        assert crc == 0x12345678
+        self.log_fn.assert_called()
+
+    @pytest.mark.asyncio
     async def test_call_discrete_ack(self):
         """Test calling ACK handler with discrete ACK packet."""
         # Create packet with 4-byte CRC payload
@@ -178,6 +189,47 @@ class TestTextMessageHandler:
 
         # Should return early without processing
         self.log_fn.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_direct_ack_roundtrip_matches_sender_crc(self):
+        """Receiver-emitted ACK[:4] equals the sender's expected ack_crc (firmware parity)."""
+        import asyncio
+
+        from pymc_core.protocol.packet_builder import PacketBuilder
+
+        sender = LocalIdentity()
+        receiver = self.local_identity  # handler's identity
+
+        class _SendContact:
+            def __init__(self, pubkey_hex):
+                self.public_key = pubkey_hex
+                self.out_path = []
+                self.out_path_len = -1
+
+        # Sender composes a DIRECT DM addressed to the receiver
+        receiver_contact = _SendContact(receiver.get_public_key().hex())
+        packet, ack_crc = PacketBuilder.create_text_message(
+            receiver_contact, sender, "hello round trip", attempt=0, message_type="direct"
+        )
+
+        # Receiver knows the sender as a contact (32-byte pubkey)
+        self.contacts.contacts = [
+            MockContact(public_key=sender.get_public_key().hex(), name="sender")
+        ]
+
+        await self.handler(packet)
+
+        # ACK is emitted after a delay via a background task; poll for it.
+        for _ in range(80):
+            if self.send_packet_fn.called:
+                break
+            await asyncio.sleep(0.05)
+
+        assert self.send_packet_fn.called
+        ack_packet = self.send_packet_fn.call_args.args[0]
+        assert ack_packet.get_payload_type() == PAYLOAD_TYPE_ACK
+        assert len(ack_packet.payload) == 6
+        assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
 
 
 # Advert Handler Tests

--- a/tests/test_packet_builder.py
+++ b/tests/test_packet_builder.py
@@ -26,6 +26,42 @@ def test_packet_builder_create_ack():
 
     assert ack_packet is not None
     assert ack_packet.get_payload_type() == PAYLOAD_TYPE_ACK
+    # Firmware-compatible ACKs are 6 bytes: 4-byte hash + ext-attempt + random byte
+    assert len(ack_packet.payload) == 6
+
+
+def test_calc_text_ack_hash_matches_firmware_layout():
+    """calc_text_ack_hash[:4] == sha256(timestamp || flags || text || pubkey)[:4]."""
+    import struct
+
+    identity = LocalIdentity()
+    pubkey = identity.get_public_key()
+    timestamp = 1234567890
+    flags_byte = 0x00  # TXT_TYPE_PLAIN, attempt 0
+    text = b"hello world"
+
+    frag1 = struct.pack("<I", timestamp) + bytes([flags_byte]) + text
+    expected_hash4 = CryptoUtils.sha256(frag1 + pubkey)[:4]
+
+    ack = PacketBuilder.calc_text_ack_hash(
+        pubkey, timestamp, flags_byte, text, ext_attempt=2, randomize=False
+    )
+    assert len(ack) == 6
+    assert ack[:4] == expected_hash4
+    assert ack[4] == 2  # ext-attempt byte
+    assert ack[5] == 0  # randomize=False → deterministic zero
+
+    # Randomized output keeps the same first 5 bytes, only the 6th differs
+    rand = PacketBuilder.calc_text_ack_hash(pubkey, timestamp, flags_byte, text, ext_attempt=2)
+    assert rand[:5] == ack[:5]
+
+
+def test_create_ack_from_bytes_wraps_raw_payload():
+    """create_ack_from_bytes copies raw bytes into an ACK packet payload."""
+    raw = bytes([0x78, 0x56, 0x34, 0x12, 0x00, 0xAB])
+    pkt = PacketBuilder.create_ack_from_bytes(raw)
+    assert pkt.get_payload_type() == PAYLOAD_TYPE_ACK
+    assert bytes(pkt.payload) == raw
 
 
 def test_packet_builder_create_advert():

--- a/tests/test_packet_builder.py
+++ b/tests/test_packet_builder.py
@@ -62,6 +62,48 @@ def test_create_ack_from_bytes_wraps_raw_payload():
     pkt = PacketBuilder.create_ack_from_bytes(raw)
     assert pkt.get_payload_type() == PAYLOAD_TYPE_ACK
     assert bytes(pkt.payload) == raw
+    # path-less by default
+    assert pkt.path_len == 0
+
+
+def test_create_ack_from_bytes_with_path():
+    """create_ack_from_bytes routes the ACK along a given out_path."""
+    raw = bytes([0x78, 0x56, 0x34, 0x12, 0x00, 0xAB])
+    out_path = bytes([0x11, 0x22])
+    out_path_len = PathUtils.encode_path_len(1, 2)
+    pkt = PacketBuilder.create_ack_from_bytes(raw, path=out_path, path_len_encoded=out_path_len)
+    assert pkt.get_payload_type() == PAYLOAD_TYPE_ACK
+    assert bytes(pkt.payload) == raw
+    assert bytes(pkt.path) == out_path
+    assert pkt.path_len == out_path_len
+
+
+def test_create_multi_ack_layout():
+    """create_multi_ack mirrors firmware createMultiAck byte layout."""
+    from pymc_core.protocol.constants import PAYLOAD_TYPE_MULTIPART
+
+    ack = bytes([0x78, 0x56, 0x34, 0x12, 0x07, 0xAB])
+    pkt = PacketBuilder.create_multi_ack(ack, remaining=1)
+    assert pkt.get_payload_type() == PAYLOAD_TYPE_MULTIPART
+    assert pkt.payload[0] == ((1 << 4) | PAYLOAD_TYPE_ACK)
+    assert bytes(pkt.payload[1:]) == ack
+    assert int.from_bytes(pkt.payload[1:5], "little") == 0x12345678
+
+    # remaining counter occupies the upper nibble
+    pkt3 = PacketBuilder.create_multi_ack(ack, remaining=3)
+    assert pkt3.payload[0] == ((3 << 4) | PAYLOAD_TYPE_ACK)
+
+
+def test_create_multi_ack_with_path():
+    """create_multi_ack carries the routing path for direct forwarding."""
+    ack = bytes([0x78, 0x56, 0x34, 0x12])
+    out_path = bytes([0x11, 0x22])
+    out_path_len = PathUtils.encode_path_len(1, 2)
+    pkt = PacketBuilder.create_multi_ack(
+        ack, remaining=1, path=out_path, path_len_encoded=out_path_len
+    )
+    assert bytes(pkt.path) == out_path
+    assert pkt.path_len == out_path_len
 
 
 def test_packet_builder_create_advert():


### PR DESCRIPTION
## Summary

Brings DM ACK handling in line with the MeshCore companion firmware pyMC_core
emulates, in two parts:

1. **ACK format fix** (the originally reported problem + a latent inbound bug).
2. **Multi-ack (`PAYLOAD_TYPE_MULTIPART`) support** — the optional reliability feature, opt-in via the existing `multi_acks` pref.

A companion PR in pyMC_Repeater [`fix/ack-compatibility`] adds bit-faithful multi-ack **forwarding** and depends on `PacketBuilder.create_multi_ack` from this branch. **The two ship together.**

## 1. ACK format

- **Emit:** firmware sends a **6-byte** ACK for `TXT_TYPE_PLAIN` — `sha256(timestamp ‖ flags ‖ text ‖ pubkey)[:4]` + an extended-attempt byte + a random byte (the random byte gives each ACK packet a unique hash so mesh dedup can't drop it). pyMC_core emitted only the 4-byte hash.
- **Accept:** `process_discrete_ack` rejected any payload that wasn't *exactly* 4 bytes, so pyMC_core **silently dropped every 6-byte firmware ACK** — DM and room-push confirmations from firmware peers never matched. Only the first 4
  bytes are ever compared (firmware does `memcmp(..., 4)`).

## 2. Multi-ack support (opt-in, default off)

- **Receive** — new `MultipartAckHandler` extracts the embedded ACK from a `PAYLOAD_TYPE_MULTIPART` packet and routes it through the same `_register_ack_received` path as discrete ACKs.
- **Emit** — the text handler now mirrors firmware `sendAckTo`: with a known `out_path` it routes the ACK along it, and when `multi_acks > 0` it emits a multi-ack ~300ms before the normal ACK so repeaters can forward the embedded
  ACK early. Unknown path keeps today's path-less ACK.
- **Pref wiring** — `multi_acks` is propagated into the text handler from `CompanionRadio`/`CompanionBridge` `set_other_params` overrides (matching the `set_path_hash_mode` convention) and re-applied at `start()`.

## Notable refactors

- New builders: `calc_text_ack_hash`, `create_ack_from_bytes` (raw payload, now with optional path routing), `create_multi_ack`.
- ACK emission extracted out of `TextMessageHandler.__call__` into `_build_ack_responses` / `_send_delayed_ack`.

## Out of scope

Repeater multi-ack **forwarding** (`forwardMultipartDirect` / `routeDirectRecvAcks`) lives in pyMC_Repeater, not here.

## Testing

- ACK byte-layout vs. an independent sha256; round-trip (receiver ACK[:4] == sender `ack_crc`); ≥4-byte inbound matching; multipart extraction + dispatcher routing; faithful direct/flood/multi-ack emit; pref propagation.
- **Full suite passes, ruff clean.**