### PR TITLE
feat(companion): add support for explicit message timestamps

### DIFF
--- a/src/pymc_core/companion/companion_base.py
+++ b/src/pymc_core/companion/companion_base.py
@@ -1357,6 +1357,7 @@ class CompanionBase(ABC):
         txt_type: int = TXT_TYPE_PLAIN,
         attempt: int = 1,
         wait_for_ack: bool = True,
+        timestamp: Optional[int] = None,
     ) -> SentResult:
         """Send a direct text message to a contact.
 
@@ -1386,6 +1387,7 @@ class CompanionBase(ABC):
                 attempt=attempt,
                 message_type=msg_type,
                 txt_type=txt_type,
+                timestamp=timestamp,
             )
             self._apply_flood_scope(pkt)
             self._apply_path_hash_mode(pkt)

--- a/src/pymc_core/companion/frame_server.py
+++ b/src/pymc_core/companion/frame_server.py
@@ -133,6 +133,7 @@ from .constants import (
     STATS_TYPE_CORE,
     STATS_TYPE_PACKETS,
     STATS_TYPE_RADIO,
+    TXT_TYPE_CLI_DATA,
 )
 from .models import Contact, QueuedMessage
 
@@ -1115,6 +1116,14 @@ class CompanionFrameServer:
             return
         txt_type = data[0]
         attempt = data[1]
+        # data[2:6] = host-supplied msg_timestamp (LE uint32). Used as-is for plain DMs so
+        # retries of the same message share a stable timestamp (mirrors firmware sendMessage).
+        # For CLI_DATA — or when the host omits it (0) — mint a fresh timestamp instead,
+        # matching firmware which overrides CLI_DATA with the RTC to avoid replay protection.
+        host_timestamp = int.from_bytes(data[2:6], "little")
+        use_timestamp = (
+            None if (txt_type == TXT_TYPE_CLI_DATA or host_timestamp == 0) else host_timestamp
+        )
         pubkey_prefix = data[6:12]
         text = data[12:].decode("utf-8", errors="replace").rstrip("\x00")
         contact = self.bridge.contacts.get_by_key_prefix(pubkey_prefix)
@@ -1127,7 +1136,12 @@ class CompanionFrameServer:
             else bytes.fromhex(contact.public_key)
         )
         result = await self.bridge.send_text_message(
-            pubkey, text, txt_type=txt_type, attempt=attempt + 1, wait_for_ack=False
+            pubkey,
+            text,
+            txt_type=txt_type,
+            attempt=attempt,
+            wait_for_ack=False,
+            timestamp=use_timestamp,
         )
         if result.success:
             ack = result.expected_ack or 0

--- a/src/pymc_core/protocol/packet_builder.py
+++ b/src/pymc_core/protocol/packet_builder.py
@@ -826,6 +826,7 @@ class PacketBuilder:
         message_type: str = "direct",
         out_path: Optional[list] = None,
         txt_type: int = 0,
+        timestamp: Optional[int] = None,
     ) -> tuple[Packet, int]:
         """
         Create a secure text message with encryption and CRC validation.
@@ -843,6 +844,11 @@ class PacketBuilder:
             txt_type: Text type in upper 6 bits of the flags byte (0=PLAIN, 1=CLI_DATA, …),
                 combined with attempt as ``(txt_type << 2) | (attempt & 3)``. Matches MeshCore
                 ``TXT_TYPE_*`` so repeaters skip delivery ACK for CLI_DATA.
+            timestamp: Optional message timestamp. When provided (e.g. the host-supplied
+                ``msg_timestamp`` from CMD_SEND_TXT_MSG), it is used as-is so that retries
+                of the same message share a stable timestamp — mirroring firmware
+                ``sendMessage``, which uses the app timestamp for plain DMs. When None a
+                fresh strictly-increasing timestamp is generated.
 
         Returns:
             tuple: (packet, crc) - The encrypted packet and CRC for ACK verification.
@@ -861,7 +867,7 @@ class PacketBuilder:
         attempt &= 0x03
         txt_type &= 0x3F
         flags_byte = (txt_type << 2) | attempt
-        timestamp = PacketBuilder._get_timestamp()
+        timestamp = timestamp if timestamp is not None else PacketBuilder._get_timestamp()
 
         # Use  timestamp+data packing
         plaintext = PacketBuilder._pack_timestamp_data(timestamp, flags_byte, message, b"\x00")

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1012,3 +1012,68 @@ def test_max_frame_size_is_176():
     assert MAX_FRAME_SIZE == 176
     assert MAX_PAYLOAD_SIZE == 173
     assert MAX_CHANNEL_DATA_LENGTH == 167
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_txt_msg_threads_host_timestamp():
+    """Plain DM: the host-supplied msg_timestamp (data[2:6]) is passed through verbatim so
+    retries share a stable timestamp (mirrors firmware sendMessage)."""
+    from unittest.mock import AsyncMock
+
+    from pymc_core.companion.companion_bridge import CompanionBridge
+    from pymc_core.companion.constants import TXT_TYPE_CLI_DATA, TXT_TYPE_PLAIN
+    from pymc_core.companion.models import Contact, SentResult
+    from pymc_core.protocol import LocalIdentity
+
+    bridge = CompanionBridge(LocalIdentity(), AsyncMock(return_value=True))
+    peer = LocalIdentity()
+    pubkey = peer.get_public_key()
+    bridge.contacts.add(Contact(public_key=pubkey, name="Peer"))
+    bridge.send_text_message = AsyncMock(
+        return_value=SentResult(
+            success=True, is_flood=False, expected_ack=0x11223344, timeout_ms=5000
+        )
+    )
+
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+
+    host_ts = 1700000000
+    # data: txt_type(1) + attempt(1) + msg_timestamp(4, LE) + pubkey_prefix(6) + text
+    data = bytes([TXT_TYPE_PLAIN, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"hello"
+    await server._cmd_send_txt_msg(data)
+
+    bridge.send_text_message.assert_awaited_once()
+    assert bridge.send_text_message.call_args.kwargs["timestamp"] == host_ts
+
+    # CLI_DATA mints a fresh timestamp (timestamp=None), matching firmware's RTC override.
+    bridge.send_text_message.reset_mock()
+    data_cli = bytes([TXT_TYPE_CLI_DATA, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"cmd"
+    await server._cmd_send_txt_msg(data_cli)
+    assert bridge.send_text_message.call_args.kwargs["timestamp"] is None
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_txt_msg_zero_host_timestamp_mints_fresh():
+    """A zero/omitted host timestamp falls back to a fresh timestamp (timestamp=None)."""
+    from unittest.mock import AsyncMock
+
+    from pymc_core.companion.companion_bridge import CompanionBridge
+    from pymc_core.companion.constants import TXT_TYPE_PLAIN
+    from pymc_core.companion.models import Contact, SentResult
+    from pymc_core.protocol import LocalIdentity
+
+    bridge = CompanionBridge(LocalIdentity(), AsyncMock(return_value=True))
+    peer = LocalIdentity()
+    pubkey = peer.get_public_key()
+    bridge.contacts.add(Contact(public_key=pubkey, name="Peer"))
+    bridge.send_text_message = AsyncMock(
+        return_value=SentResult(success=True, is_flood=False, expected_ack=0, timeout_ms=5000)
+    )
+
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+
+    data = bytes([TXT_TYPE_PLAIN, 0]) + struct.pack("<I", 0) + pubkey[:6] + b"hi"
+    await server._cmd_send_txt_msg(data)
+    assert bridge.send_text_message.call_args.kwargs["timestamp"] is None

--- a/tests/test_packet_builder.py
+++ b/tests/test_packet_builder.py
@@ -380,3 +380,43 @@ def test_login_then_stats_tags_strictly_increase():
     _, stats_ts = PacketBuilder.create_protocol_request(contact, local, 0x01, b"")
     login_ts = int.from_bytes(_decrypt_anon(login_pkt, local, other)[:4], "little")
     assert stats_ts > login_ts
+
+
+def test_create_text_message_uses_explicit_timestamp():
+    """An explicit timestamp is used verbatim (the host msg_timestamp), so retries of the
+    same message keep a stable timestamp — mirroring firmware sendMessage."""
+    import struct
+
+    sender = LocalIdentity()
+    recipient = LocalIdentity()
+    contact = _make_contact(recipient)
+    ts = 1700000000
+    attempt = 2
+    text = "retry me"
+
+    _, crc = PacketBuilder.create_text_message(
+        contact, sender, text, attempt=attempt, message_type="direct", timestamp=ts
+    )
+    flags_byte = attempt & 0x03
+    expected = int.from_bytes(
+        CryptoUtils.sha256(
+            struct.pack("<I", ts)
+            + bytes([flags_byte])
+            + text.encode("utf-8")
+            + sender.get_public_key()
+        )[:4],
+        "little",
+    )
+    assert crc == expected
+
+    # Same timestamp + attempt + text => identical ACK CRC (stable retry identity).
+    _, crc2 = PacketBuilder.create_text_message(
+        contact, sender, text, attempt=attempt, message_type="direct", timestamp=ts
+    )
+    assert crc2 == crc
+
+    # No explicit timestamp => a fresh one is minted => different CRC.
+    _, crc3 = PacketBuilder.create_text_message(
+        contact, sender, text, attempt=attempt, message_type="direct"
+    )
+    assert crc3 != crc


### PR DESCRIPTION
## Summary

Plain DM sends now honor the host-supplied `msg_timestamp` instead of minting a fresh one, so a host that retries a message (same timestamp, incremented attempt) produces packets with a **stable timestamp** — matching firmware `BaseChatMesh::sendMessage`.

Previously `_cmd_send_txt_msg` skipped the timestamp bytes and `create_text_message` always generated its own, so every retry got a new timestamp. The receiver keys its message id off the (normalized) timestamp, so retries showed up as **duplicate messages** instead of being coalesced.

## Changes

- `PacketBuilder.create_text_message` takes an optional `timestamp` (defaults to `_get_timestamp()` when `None`, so other callers are unchanged).
- `send_text_message` threads a `timestamp` param through to the builder.
- `_cmd_send_txt_msg` parses the host `msg_timestamp` (`data[2:6]`) and passes it through. Mirroring firmware, it falls back to a fresh timestamp for `TXT_TYPE_CLI_DATA` (RTC override to avoid replay protection) and when the host sends `0`.

## Tests

- Builder uses an explicit timestamp verbatim (verified against an independent sha256); same ts+attempt → identical ACK CRC; no timestamp → fresh/different CRC.
- `_cmd_send_txt_msg` threads the host timestamp for plain DMs; `CLI_DATA` and a zero timestamp both fall back to `None`.

Full suite passes; ruff clean.