### PR TITLE
Align flood-scope handling with firmware semantics

### DIFF
--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -352,9 +352,10 @@ For MeshCore v1.15 parity, the frame protocol also supports a persisted default 
 
 openhop-core resolves effective flood scope as:
 
-1. transient key set by `CMD_SET_FLOOD_SCOPE` / `set_flood_scope()`
-2. otherwise persisted default key (if configured)
-3. otherwise unscoped flood
+1. explicit unscoped mode (`CMD_SET_FLOOD_SCOPE` mode 1) until mode 0 sets/resets scope
+2. transient key set by `CMD_SET_FLOOD_SCOPE` mode 0 / `set_flood_scope()`
+3. otherwise persisted default key (if configured)
+4. otherwise unscoped flood
 
 When a flood scope is active, all flood packets are tagged with a 16-bit transport code
 (HMAC-SHA256 derived) and sent as `ROUTE_TYPE_TRANSPORT_FLOOD`. Direct-routed packets

--- a/src/openhop_core/companion/companion_base.py
+++ b/src/openhop_core/companion/companion_base.py
@@ -224,9 +224,8 @@ class CompanionBase(ABC):
         self._custom_vars: dict[str, str] = {}
         self._sign_buffer: Optional[bytearray] = None
         self._flood_transport_key: Optional[bytes] = None
-        self._flood_scope_disabled: bool = False
-        # One-shot "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
-        # when set, the next flood ignores the default scope and floods unscoped.
+        # Sticky "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
+        # when set, floods ignore the default scope until a scope override/reset.
         self._flood_unscoped: bool = False
         self._time_offset: float = 0.0
 
@@ -592,35 +591,25 @@ class CompanionBase(ABC):
     # -------------------------------------------------------------------------
 
     def set_flood_scope(self, transport_key: Optional[bytes] = None) -> None:
-        """Set, clear, or explicitly disable flood scoped routing.
+        """Set or clear the transient flood scope override.
 
         Also cancels any pending explicit-unscoped request (firmware sets
         ``send_unscoped = false`` whenever a scope override is set or reset).
-
-        ``meshcore_py`` sends mode 0 with a 16-byte all-zero key for an empty
-        flood scope. Treat that as persistently disabled scoping rather than a
-        valid transport key.
         """
         self._flood_unscoped = False
 
         if transport_key and len(transport_key) >= 16:
             key = bytes(transport_key[:16])
-            if key == ZERO_FLOOD_SCOPE_KEY:
-                self._flood_transport_key = None
-                self._flood_scope_disabled = True
-                return
-            self._flood_transport_key = key
-            self._flood_scope_disabled = False
+            self._flood_transport_key = None if key == ZERO_FLOOD_SCOPE_KEY else key
             return
 
         self._flood_transport_key = None
-        self._flood_scope_disabled = False
 
     def set_flood_unscoped(self) -> None:
-        """Force the next flood to be unscoped, bypassing the default scope.
+        """Force following floods to be unscoped, bypassing the default scope.
 
-        Mirrors firmware CMD_SET_FLOOD_SCOPE_KEY mode 1 (FW PR #2492): a one-shot
-        flag consumed by the next flood-routed packet in _apply_flood_scope.
+        Mirrors firmware CMD_SET_FLOOD_SCOPE_KEY mode 1 (FW PR #2492): a sticky
+        flag cleared by the next scope override/reset.
         """
         self._flood_unscoped = True
 
@@ -663,17 +652,15 @@ class CompanionBase(ABC):
             if not region_name.startswith("#"):
                 region_name = f"#{region_name}"
             self._flood_transport_key = get_auto_key_for(region_name)
-            self._flood_scope_disabled = False
+            self._flood_unscoped = False
         else:
             self._flood_transport_key = None
-            self._flood_scope_disabled = False
+            self._flood_unscoped = False
 
     def _resolve_flood_transport_key(self) -> Optional[bytes]:
-        """Resolve effective flood key: transient first, disabled next, then default."""
+        """Resolve effective flood key: transient override first, then default."""
         if self._flood_transport_key is not None:
             return self._flood_transport_key
-        if getattr(self, "_flood_scope_disabled", False):
-            return None
         default_scope = self.get_default_flood_scope()
         if default_scope is None:
             return None
@@ -693,9 +680,7 @@ class CompanionBase(ABC):
             return  # only scope flood packets, not direct
         if self._flood_unscoped:
             # App explicitly requested unscoped (FW #2492): leave as plain flood,
-            # ignoring any default scope. One-shot — consumed here, as firmware
-            # resets send_unscoped after each flood.
-            self._flood_unscoped = False
+            # ignoring any default scope until a scope override/reset.
             return
         effective_key = self._resolve_flood_transport_key()
         if effective_key is None:

--- a/src/openhop_core/companion/companion_base.py
+++ b/src/openhop_core/companion/companion_base.py
@@ -82,6 +82,8 @@ from .timing import DEFAULT_MAX_ATTEMPTS, response_timeout_ms
 
 logger = logging.getLogger("CompanionBase")
 
+ZERO_FLOOD_SCOPE_KEY = b"\x00" * 16
+
 
 def _fmt_path(out_path_len: int, out_path: Any) -> str:
     """Format a contact's out_path for [PATHDIAG] logs without ambiguity.
@@ -222,6 +224,7 @@ class CompanionBase(ABC):
         self._custom_vars: dict[str, str] = {}
         self._sign_buffer: Optional[bytearray] = None
         self._flood_transport_key: Optional[bytes] = None
+        self._flood_scope_disabled: bool = False
         # One-shot "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
         # when set, the next flood ignores the default scope and floods unscoped.
         self._flood_unscoped: bool = False
@@ -589,16 +592,29 @@ class CompanionBase(ABC):
     # -------------------------------------------------------------------------
 
     def set_flood_scope(self, transport_key: Optional[bytes] = None) -> None:
-        """Set or clear the flood transport key for scoped flooding.
+        """Set, clear, or explicitly disable flood scoped routing.
 
         Also cancels any pending explicit-unscoped request (firmware sets
         ``send_unscoped = false`` whenever a scope override is set or reset).
+
+        ``meshcore_py`` sends mode 0 with a 16-byte all-zero key for an empty
+        flood scope. Treat that as persistently disabled scoping rather than a
+        valid transport key.
         """
-        if transport_key and len(transport_key) >= 16:
-            self._flood_transport_key = transport_key[:16]
-        else:
-            self._flood_transport_key = None
         self._flood_unscoped = False
+
+        if transport_key and len(transport_key) >= 16:
+            key = bytes(transport_key[:16])
+            if key == ZERO_FLOOD_SCOPE_KEY:
+                self._flood_transport_key = None
+                self._flood_scope_disabled = True
+                return
+            self._flood_transport_key = key
+            self._flood_scope_disabled = False
+            return
+
+        self._flood_transport_key = None
+        self._flood_scope_disabled = False
 
     def set_flood_unscoped(self) -> None:
         """Force the next flood to be unscoped, bypassing the default scope.
@@ -641,19 +657,23 @@ class CompanionBase(ABC):
 
         Derives the 16-byte transport key automatically via SHA-256 of the
         region name.  A leading ``#`` is added if not already present.
-        Pass ``None`` to clear the scope (flood to all).
+        Pass ``None`` to clear this transient region override.
         """
         if region_name:
             if not region_name.startswith("#"):
                 region_name = f"#{region_name}"
             self._flood_transport_key = get_auto_key_for(region_name)
+            self._flood_scope_disabled = False
         else:
             self._flood_transport_key = None
+            self._flood_scope_disabled = False
 
     def _resolve_flood_transport_key(self) -> Optional[bytes]:
-        """Resolve effective flood key: transient key first, then persisted default."""
+        """Resolve effective flood key: transient first, disabled next, then default."""
         if self._flood_transport_key is not None:
             return self._flood_transport_key
+        if getattr(self, "_flood_scope_disabled", False):
+            return None
         default_scope = self.get_default_flood_scope()
         if default_scope is None:
             return None

--- a/src/openhop_core/companion/frame_server.py
+++ b/src/openhop_core/companion/frame_server.py
@@ -1829,18 +1829,23 @@ class CompanionFrameServer:
         The firmware (MyMesh.cpp:1909) treats data[0] as a mode selector:
           * mode 0: set the scope override key (data[1:17]) when present, else
             reset the override; cancels any pending explicit-unscoped request.
-          * mode 1 (FIRMWARE_VER_CODE 12+, PR #2492): force the next flood to be
-            unscoped, ignoring the configured default scope.
+          * mode 1 (FIRMWARE_VER_CODE 12+, PR #2492): force following floods to
+            be unscoped, ignoring the configured default scope until mode 0.
         Older apps always sent mode 0, so this is backward compatible.
         """
         mode = data[0] if len(data) >= 1 else 0
         if mode == 1:
             self.bridge.set_flood_unscoped()
-        elif len(data) >= 17:
-            self.bridge.set_flood_scope(data[1:17])
-        else:
-            self.bridge.set_flood_scope(None)
-        self._write_ok()
+            self._write_ok()
+            return
+        if mode == 0:
+            if len(data) >= 17:
+                self.bridge.set_flood_scope(data[1:17])
+            else:
+                self.bridge.set_flood_scope(None)
+            self._write_ok()
+            return
+        self._write_err(ERR_CODE_UNSUPPORTED_CMD)
 
     async def _cmd_set_default_flood_scope(self, data: bytes) -> None:
         """Handle CMD_SET_DEFAULT_FLOOD_SCOPE (63)."""

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -326,9 +326,11 @@ def test_apply_flood_scope_uses_default_scope_when_transient_unset():
     assert pkt.transport_codes[0] != 0
 
 
-def test_set_flood_scope_zero_key_disables_scope():
-    """An all-zero key is Remote Terminal's disabled scope, not a transport key."""
+def test_set_flood_scope_zero_key_resets_to_default_scope():
+    """An all-zero key is firmware's null override, so default scope still applies."""
     bridge = _make_bridge(path_hash_mode=0)
+    default_key = b"\x22" * 16
+    assert bridge.set_default_flood_scope("region1", default_key) is True
     key = b"\x11" * 16
     bridge.set_flood_scope(key)
     assert bridge._resolve_flood_transport_key() == key
@@ -336,37 +338,38 @@ def test_set_flood_scope_zero_key_disables_scope():
     bridge.set_flood_scope(b"\x00" * 16)
 
     assert bridge._flood_transport_key is None
-    assert bridge._resolve_flood_transport_key() is None
+    assert bridge._resolve_flood_transport_key() == default_key
 
     pkt = _make_flood_pkt()
     bridge._apply_flood_scope(pkt)
-    assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
-    assert pkt.transport_codes[0] == 0
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
 
 
-def test_zero_key_persistently_bypasses_default_flood_scope():
-    """Remote Terminal's empty scope disables default scoping beyond one packet."""
+def test_set_flood_scope_none_after_zero_key_uses_default_scope():
+    """Mode 0 without a key resets the null override and lets default scope apply."""
     bridge = _make_bridge(path_hash_mode=0)
     assert bridge.set_default_flood_scope("region1", b"\x22" * 16) is True
     assert bridge._resolve_flood_transport_key() == b"\x22" * 16
 
     bridge.set_flood_scope(b"\x00" * 16)
-    assert bridge._resolve_flood_transport_key() is None
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
+    bridge.set_flood_scope(None)
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
 
     pkt = _make_flood_pkt()
     bridge._apply_flood_scope(pkt)
-    assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
 
     pkt2 = _make_flood_pkt()
     bridge._apply_flood_scope(pkt2)
-    assert pkt2.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
 
 
-def test_set_flood_scope_none_clears_zero_key_disabled_state():
+def test_set_flood_scope_none_clears_sticky_unscoped_state():
     """Mode 0 without a key resets the override and lets default scope apply."""
     bridge = _make_bridge(path_hash_mode=0)
     assert bridge.set_default_flood_scope("region1", b"\x33" * 16) is True
-    bridge.set_flood_scope(b"\x00" * 16)
+    bridge.set_flood_unscoped()
 
     bridge.set_flood_scope(None)
 
@@ -386,7 +389,7 @@ def _make_flood_pkt() -> Packet:
     return pkt
 
 
-def test_set_flood_unscoped_overrides_default_scope_one_shot():
+def test_set_flood_unscoped_overrides_default_scope_sticky():
     """FW #2492: explicit unscoped forces a plain flood, bypassing the default scope."""
     bridge = _make_bridge(path_hash_mode=0)
     assert bridge.set_default_flood_scope("region1", bytes(range(16))) is True
@@ -398,11 +401,11 @@ def test_set_flood_unscoped_overrides_default_scope_one_shot():
     assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
     assert pkt.transport_codes[0] == 0
 
-    # One-shot: the next flood falls back to the default scope.
+    # Sticky: following floods stay plain until mode 0 sets/resets scope.
     pkt2 = _make_flood_pkt()
     bridge._apply_flood_scope(pkt2)
-    assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
-    assert pkt2.transport_codes[0] != 0
+    assert pkt2.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt2.transport_codes[0] == 0
 
 
 def test_set_flood_scope_cancels_pending_unscoped():

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -326,6 +326,56 @@ def test_apply_flood_scope_uses_default_scope_when_transient_unset():
     assert pkt.transport_codes[0] != 0
 
 
+def test_set_flood_scope_zero_key_disables_scope():
+    """An all-zero key is Remote Terminal's disabled scope, not a transport key."""
+    bridge = _make_bridge(path_hash_mode=0)
+    key = b"\x11" * 16
+    bridge.set_flood_scope(key)
+    assert bridge._resolve_flood_transport_key() == key
+
+    bridge.set_flood_scope(b"\x00" * 16)
+
+    assert bridge._flood_transport_key is None
+    assert bridge._resolve_flood_transport_key() is None
+
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt.transport_codes[0] == 0
+
+
+def test_zero_key_persistently_bypasses_default_flood_scope():
+    """Remote Terminal's empty scope disables default scoping beyond one packet."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", b"\x22" * 16) is True
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
+
+    bridge.set_flood_scope(b"\x00" * 16)
+    assert bridge._resolve_flood_transport_key() is None
+
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+
+    pkt2 = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt2)
+    assert pkt2.get_route_type() == ROUTE_TYPE_FLOOD
+
+
+def test_set_flood_scope_none_clears_zero_key_disabled_state():
+    """Mode 0 without a key resets the override and lets default scope apply."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", b"\x33" * 16) is True
+    bridge.set_flood_scope(b"\x00" * 16)
+
+    bridge.set_flood_scope(None)
+
+    assert bridge._resolve_flood_transport_key() == b"\x33" * 16
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+
 def _make_flood_pkt() -> Packet:
     pkt = Packet()
     pkt.header = (PAYLOAD_TYPE_TRACE << 2) | 0x01  # route type FLOOD

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1067,6 +1067,7 @@ async def test_cmd_set_flood_scope_dispatches_mode_byte():
     bridge = Mock()
     server = CompanionFrameServer(bridge, "hash", port=0)
     server._write_ok = Mock()
+    server._write_err = Mock()
 
     # mode 1 (v12+): force unscoped
     await server._cmd_set_flood_scope(bytes([0x01]))
@@ -1084,6 +1085,15 @@ async def test_cmd_set_flood_scope_dispatches_mode_byte():
     bridge.reset_mock()
     await server._cmd_set_flood_scope(bytes([0x00]))
     bridge.set_flood_scope.assert_called_once_with(None)
+
+    # unknown mode: firmware falls through to unsupported command
+    bridge.reset_mock()
+    server._write_ok.reset_mock()
+    await server._cmd_set_flood_scope(bytes([0x02]) + bytes(range(16)))
+    bridge.set_flood_scope.assert_not_called()
+    bridge.set_flood_unscoped.assert_not_called()
+    server._write_ok.assert_not_called()
+    server._write_err.assert_called_once_with(ERR_CODE_UNSUPPORTED_CMD)
 
 
 def test_max_frame_size_is_176():


### PR DESCRIPTION
## Summary

This updates flood-scope handling to match the firmware semantics for `SET_FLOOD_SCOPE`.

`SET_FLOOD_SCOPE` mode 0 with a 16-byte all-zero key is now treated as a null override rather than as an explicit request to send unscoped. This means it falls back to the configured default scope when one is present, matching firmware behavior.

Explicit unscoped sending is now handled through mode 1 and remains sticky until a subsequent mode 0 set/reset. This matches the behavior used by Companion v12.

## Changes

- Treat mode 0 with an all-zero key as a null override.
- Fall back to the configured default scope instead of forcing plain flood.
- Handle explicit unscoped sending through mode 1.
- Make mode 1 sticky until a mode 0 set/reset.
- Tighten unsupported mode handling.
- Add and update tests for:
  - zero-key fallback to default scope
  - sticky unscoped mode behavior
  - unsupported mode handling

## Testing

Full test suite passes locally:

```text
900 passed
```