### PR TITLE
fix(hardware): resolve permanent RX lockup on SX1262 with gpiod backend

### DIFF
--- a/src/openhop_core/hardware/gpio_manager.py
+++ b/src/openhop_core/hardware/gpio_manager.py
@@ -199,6 +199,9 @@ class GPIOPinManager:
         self._edge_stop_events: Dict[
             int, threading.Event
         ] = {}  # Stop events for edge threads
+        self._edge_baseline_resets: Dict[
+            int, threading.Event
+        ] = {}  # Signal polling thread to reset last_state to LOW
 
         logger.debug(
             f"GPIO Manager initialized with chip: {self._gpio_chip} using backend: {self._backend}"
@@ -485,6 +488,15 @@ class GPIOPinManager:
         self._edge_threads[pin_number] = thread
         logger.debug(f"Edge detection thread started for pin {pin_number}")
 
+    def reset_edge_baseline(self, pin_number: int) -> None:
+        """Tell the polling thread to reset last_state to LOW on its next tick.
+
+        Call this after clearIrqStatus() so the polling thread can detect the
+        next rising edge even if last_state was left HIGH from the previous one.
+        """
+        if pin_number in self._edge_baseline_resets:
+            self._edge_baseline_resets[pin_number].set()
+
     def _start_polling_detection(self, pin_number: int, interval: float = 0.02) -> None:
         """Start a polling thread to detect rising edges for GPIO lines.
 
@@ -492,6 +504,7 @@ class GPIOPinManager:
         """
         stop_event = threading.Event()
         self._edge_stop_events[pin_number] = stop_event
+        self._edge_baseline_resets[pin_number] = threading.Event()
 
         thread = threading.Thread(
             target=self._monitor_polling,
@@ -514,13 +527,19 @@ class GPIOPinManager:
             if not gpio:
                 return
 
-            # initialize last_state
+            reset_event = self._edge_baseline_resets.get(pin_number)
+
             try:
                 last_state = bool(gpio.read())
             except Exception:
                 last_state = False
 
             while not stop_event.is_set() and pin_number in self._pins:
+                # If the IRQ was cleared externally, reset baseline so the next
+                # rising edge is always detected regardless of last_state.
+                if reset_event and reset_event.is_set():
+                    last_state = False
+                    reset_event.clear()
                 try:
                     current = bool(self._pins[pin_number].read())
                     if current and not last_state:

--- a/src/openhop_core/hardware/gpio_manager.py
+++ b/src/openhop_core/hardware/gpio_manager.py
@@ -649,9 +649,11 @@ class GPIOPinManager:
         if pin_number in self._edge_stop_events:
             del self._edge_stop_events[pin_number]
 
-        # Remove callback
+        # Remove callback and baseline reset event
         if pin_number in self._input_callbacks:
             del self._input_callbacks[pin_number]
+        if pin_number in self._edge_baseline_resets:
+            del self._edge_baseline_resets[pin_number]
 
         # Close GPIO pin
         if pin_number in self._pins:
@@ -680,8 +682,9 @@ class GPIOPinManager:
         self._edge_threads.clear()
         self._edge_stop_events.clear()
 
-        # Clear callbacks
+        # Clear callbacks and baseline reset events
         self._input_callbacks.clear()
+        self._edge_baseline_resets.clear()
 
         # Clean up all pins
         for pin_number in list(self._pins.keys()):

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -536,6 +536,8 @@ class SX1262Radio(LoRaRadio):
                                     # Read before clearing to catch a packet that arrived during processing.
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
+                                    # Re-read after clearing to catch anything that arrived in the read-clear gap.
+                                    pending_irq |= self.lora.getIrqStatus()
                                     if not (pending_irq & terminal_irqs):
                                         await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                         logger.debug(

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -517,7 +517,19 @@ class SX1262Radio(LoRaRadio):
                             if not self._tx_lock.locked():
                                 try:
                                     self.lora.request(self.lora.RX_CONTINUOUS)
+                                    # Read before clearing to catch back-to-back packets that arrived during processing.
+                                    pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
+                                    terminal_irqs = (
+                                        self.lora.IRQ_RX_DONE
+                                        | self.lora.IRQ_CRC_ERR
+                                        | self.lora.IRQ_TIMEOUT
+                                        | self.lora.IRQ_HEADER_ERR
+                                    )
+                                    if pending_irq & terminal_irqs:
+                                        logger.debug(f"[RX] Back-to-back packet queued (IRQ 0x{pending_irq:04X})")
+                                        self._last_irq_status = pending_irq
+                                        self._rx_done_event.set()
                                     await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                     logger.debug(
                                         f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
@@ -541,6 +553,21 @@ class SX1262Radio(LoRaRadio):
 
                         # Sample noise floor during quiet periods
                         self._sample_noise_floor()
+
+                        # Watchdog: gpiod polling can miss an edge if IRQ goes HIGH then LOW within
+                        # the 20ms poll window. Recover by driving _handle_interrupt directly.
+                        if (
+                            self.use_gpiod_backend
+                            and not self._tx_lock.locked()
+                            and not self._is_receiving_packet
+                        ):
+                            try:
+                                pin_state = self._gpio_manager.read_pin(self.irq_pin_number)
+                                if pin_state:
+                                    logger.warning("[RX] IRQ pin stuck HIGH (gpiod polling gap) — recovering")
+                                    self._handle_interrupt()
+                            except Exception as e:
+                                logger.debug(f"[RX] IRQ watchdog read failed: {e}")
 
                         # Log every 500 checks (roughly every 5 seconds) to show RX task is alive
                         if rx_check_count % 500 == 0:

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -419,132 +419,127 @@ class SX1262Radio(LoRaRadio):
                         self._last_packet_activity = time.time()
 
                         try:
-                            # Drain back-to-back packets that arrive while we're still
-                            # handling the previous one, instead of paying a settle
-                            # sleep per packet in the burst.
-                            terminal_irqs = (
-                                self.lora.IRQ_RX_DONE
-                                | self.lora.IRQ_CRC_ERR
-                                | self.lora.IRQ_TIMEOUT
-                                | self.lora.IRQ_HEADER_ERR
-                            )
-                            pending_irq = self._last_irq_status
+                            irqStat = self._last_irq_status
 
-                            while pending_irq & terminal_irqs:
-                                irqStat = pending_irq
-                                if irqStat & self.lora.IRQ_CRC_ERR:
-                                    self.crc_error_count += 1
+                            if irqStat & self.lora.IRQ_CRC_ERR:
+                                self.crc_error_count += 1
 
-                                    try:
-                                        packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
-                                        payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
-                                        device_errors = self.lora.getDeviceErrors()
-                                        noise_floor = self.get_noise_floor()
-                                        raw_packet_hex = ""
-                                        if payloadLengthRx > 0 and payloadLengthRx < 256:
-                                            try:
-                                                buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
-                                                raw_packet_hex = bytes(buffer).hex()
-                                            except Exception:
-                                                raw_packet_hex = "(read failed)"
+                                try:
+                                    packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
+                                    payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
+                                    device_errors = self.lora.getDeviceErrors()
+                                    noise_floor = self.get_noise_floor()
+                                    raw_packet_hex = ""
+                                    if payloadLengthRx > 0 and payloadLengthRx < 256:
+                                        try:
+                                            buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
+                                            raw_packet_hex = bytes(buffer).hex()
+                                        except Exception:
+                                            raw_packet_hex = "(read failed)"
 
-                                        logger.warning(
-                                            "[RX] CRC error #%d - RSSI=%ddBm, SNR=%.1fdB, SignalRSSI=%ddBm, "
-                                            "Length=%d, NoiseFloor=%.1fdBm, DeviceErrors=0x%04X, IRQ=0x%04X, "
-                                            "RawData=%s",
-                                            self.crc_error_count,
-                                            int(packet_rssi_dbm), snr_db, int(signal_rssi_dbm),
-                                            payloadLengthRx, noise_floor, device_errors, irqStat,
-                                            raw_packet_hex
-                                        )
-                                    except Exception as diag_err:
-                                        # Fallback if diagnostic collection fails
-                                        logger.warning(
-                                            "[RX] CRC error #%d - Unable to collect diagnostics: %s",
-                                            self.crc_error_count, diag_err
-                                        )
-                                elif irqStat & self.lora.IRQ_RX_DONE:
-                                    (
-                                        payloadLengthRx,
-                                        rxStartBufferPointer,
-                                    ) = self.lora.getRxBufferStatus()
-                                    (
-                                        packet_rssi_dbm,
-                                        snr_db,
-                                        signal_rssi_dbm,
-                                    ) = self.lora.getSignalMetrics()
-                                    self.last_rssi = int(packet_rssi_dbm)
-                                    self.last_snr = snr_db
-                                    self.last_signal_rssi = int(signal_rssi_dbm)
-
-                                    logger.debug(
-                                        f"[RX] Packet received: length={payloadLengthRx}, "
-                                        f"RSSI={self.last_rssi}dBm, SNR={self.last_snr}dB"
-                                    )
-
-                                    # Trigger RX LED
-                                    self._gpio_manager.blink_led(self.rxled_pin)
-
-                                    if payloadLengthRx > 0:
-                                        buffer = self.lora.readBuffer(
-                                            rxStartBufferPointer, payloadLengthRx
-                                        )
-                                        packet_data = bytes(buffer)
-                                        logger.debug(
-                                            f"[RX] Packet data: {packet_data.hex()[:32]}... "
-                                            f"({len(packet_data)} bytes)"
-                                        )
-
-                                        # Call user RX callback if set
-                                        if self.rx_callback:
-                                            try:
-                                                self.rx_callback(packet_data)
-                                            except Exception as cb_exc:
-                                                logger.error(f"RX callback error: {cb_exc}")
-                                        else:
-                                            logger.warning("[RX] No RX callback registered!")
-                                    else:
-                                        logger.warning("[RX] Empty packet received")
-                                elif irqStat & self.lora.IRQ_TIMEOUT:
-                                    logger.warning("[RX] RX timeout detected")
-                                elif irqStat & self.lora.IRQ_HEADER_ERR:
                                     logger.warning(
-                                        f"[RX] Header error detected (0x{irqStat:04X}) - "
-                                        "corrupted header, restoring RX mode"
+                                        "[RX] CRC error #%d - RSSI=%ddBm, SNR=%.1fdB, SignalRSSI=%ddBm, "
+                                        "Length=%d, NoiseFloor=%.1fdBm, DeviceErrors=0x%04X, IRQ=0x%04X, "
+                                        "RawData=%s",
+                                        self.crc_error_count,
+                                        int(packet_rssi_dbm), snr_db, int(signal_rssi_dbm),
+                                        payloadLengthRx, noise_floor, device_errors, irqStat,
+                                        raw_packet_hex
                                     )
-                                elif irqStat & self.lora.IRQ_PREAMBLE_DETECTED:
-                                    logger.debug("[RX] Preamble detected - packet incoming")
-                                elif irqStat & self.lora.IRQ_SYNC_WORD_VALID:
-                                    logger.debug("[RX] Sync word valid - receiving packet data")
-                                elif irqStat & self.lora.IRQ_HEADER_VALID:
+                                except Exception as diag_err:
+                                    logger.warning(
+                                        "[RX] CRC error #%d - Unable to collect diagnostics: %s",
+                                        self.crc_error_count, diag_err
+                                    )
+                            elif irqStat & self.lora.IRQ_RX_DONE:
+                                (
+                                    payloadLengthRx,
+                                    rxStartBufferPointer,
+                                ) = self.lora.getRxBufferStatus()
+                                (
+                                    packet_rssi_dbm,
+                                    snr_db,
+                                    signal_rssi_dbm,
+                                ) = self.lora.getSignalMetrics()
+                                self.last_rssi = int(packet_rssi_dbm)
+                                self.last_snr = snr_db
+                                self.last_signal_rssi = int(signal_rssi_dbm)
+
+                                logger.debug(
+                                    f"[RX] Packet received: length={payloadLengthRx}, "
+                                    f"RSSI={self.last_rssi}dBm, SNR={self.last_snr}dB"
+                                )
+
+                                # Trigger RX LED
+                                self._gpio_manager.blink_led(self.rxled_pin)
+
+                                if payloadLengthRx > 0:
+                                    buffer = self.lora.readBuffer(
+                                        rxStartBufferPointer, payloadLengthRx
+                                    )
+                                    packet_data = bytes(buffer)
                                     logger.debug(
-                                        "[RX] Header valid - packet header received, payload coming"
+                                        f"[RX] Packet data: {packet_data.hex()[:32]}... "
+                                        f"({len(packet_data)} bytes)"
                                     )
+
+                                    if self.rx_callback:
+                                        try:
+                                            self.rx_callback(packet_data)
+                                        except Exception as cb_exc:
+                                            logger.error(f"RX callback error: {cb_exc}")
+                                    else:
+                                        logger.warning("[RX] No RX callback registered!")
                                 else:
-                                    logger.debug(f"[RX] Other interrupt: 0x{irqStat:04X}")
+                                    logger.warning("[RX] Empty packet received")
+                            elif irqStat & self.lora.IRQ_TIMEOUT:
+                                logger.warning("[RX] RX timeout detected")
+                            elif irqStat & self.lora.IRQ_HEADER_ERR:
+                                logger.warning(
+                                    f"[RX] Header error detected (0x{irqStat:04X}) - "
+                                    "corrupted header, restoring RX mode"
+                                )
+                            elif irqStat & self.lora.IRQ_PREAMBLE_DETECTED:
+                                logger.debug("[RX] Preamble detected - packet incoming")
+                            elif irqStat & self.lora.IRQ_SYNC_WORD_VALID:
+                                logger.debug("[RX] Sync word valid - receiving packet data")
+                            elif irqStat & self.lora.IRQ_HEADER_VALID:
+                                logger.debug(
+                                    "[RX] Header valid - packet header received, payload coming"
+                                )
+                            else:
+                                logger.debug(f"[RX] Other interrupt: 0x{irqStat:04X}")
 
-                                if self._tx_lock.locked():
-                                    logger.debug(
-                                        f"[RX] Skipped RX restore after IRQ 0x{irqStat:04X}"
-                                        " — TX lock held, send() will restore RX on completion"
-                                    )
-                                    break
-
+                            if not self._tx_lock.locked():
                                 try:
                                     self.lora.request(self.lora.RX_CONTINUOUS)
                                     # Read before clearing to catch a packet that arrived during processing.
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
-                                    if not (pending_irq & terminal_irqs):
+                                    terminal_irqs = (
+                                        self.lora.IRQ_RX_DONE
+                                        | self.lora.IRQ_CRC_ERR
+                                        | self.lora.IRQ_TIMEOUT
+                                        | self.lora.IRQ_HEADER_ERR
+                                    )
+                                    if pending_irq & terminal_irqs:
+                                        logger.debug(f"[RX] Back-to-back packet queued (IRQ 0x{pending_irq:04X})")
+                                        self._last_irq_status = pending_irq
+                                        self._rx_done_event.set()
+                                    else:
                                         if self._gpio_manager._backend == "gpiod":
                                             self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
-                                        await asyncio.sleep(self.RADIO_TIMING_DELAY)
-                                        logger.debug(
-                                            f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
-                                        )
+                                    await asyncio.sleep(self.RADIO_TIMING_DELAY)
+                                    logger.debug(
+                                        f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
+                                    )
                                 except Exception as e:
                                     logger.error(f"Failed to restore RX mode: {e}")
-                                    break
+                            else:
+                                logger.debug(
+                                    f"[RX] Skipped RX restore after IRQ 0x{irqStat:04X}"
+                                    " — TX lock held, send() will restore RX on completion"
+                                )
                         except Exception as e:
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -536,9 +536,8 @@ class SX1262Radio(LoRaRadio):
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
                                     if not (pending_irq & terminal_irqs):
-                                        # Reset polling thread's edge baseline so last_state=HIGH
-                                        # from this IRQ cannot mask the next packet's rising edge.
-                                        self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
+                                        if self._gpio_manager._backend == "gpiod":
+                                            self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
                                         await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                         logger.debug(
                                             f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -429,6 +429,7 @@ class SX1262Radio(LoRaRadio):
                                 | self.lora.IRQ_HEADER_ERR
                             )
                             pending_irq = self._last_irq_status
+                            irqStat = pending_irq
 
                             while pending_irq & terminal_irqs:
                                 irqStat = pending_irq
@@ -535,18 +536,14 @@ class SX1262Radio(LoRaRadio):
                                     # Read before clearing to catch a packet that arrived during processing.
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
+                                    if not (pending_irq & terminal_irqs):
+                                        await asyncio.sleep(self.RADIO_TIMING_DELAY)
+                                        logger.debug(
+                                            f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
+                                        )
                                 except Exception as e:
                                     logger.error(f"Failed to restore RX mode: {e}")
                                     break
-
-                                if pending_irq & terminal_irqs:
-                                    logger.debug(f"[RX] Draining back-to-back packet (IRQ 0x{pending_irq:04X})")
-                                    continue
-
-                                await asyncio.sleep(self.RADIO_TIMING_DELAY)
-                                logger.debug(
-                                    f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
-                                )
                         except Exception as e:
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -422,9 +422,16 @@ class SX1262Radio(LoRaRadio):
                             # Drain back-to-back packets that arrive while we're still
                             # handling the previous one, instead of paying a settle
                             # sleep per packet in the burst.
-                            irqStat = self._last_irq_status
+                            terminal_irqs = (
+                                self.lora.IRQ_RX_DONE
+                                | self.lora.IRQ_CRC_ERR
+                                | self.lora.IRQ_TIMEOUT
+                                | self.lora.IRQ_HEADER_ERR
+                            )
+                            pending_irq = self._last_irq_status
 
-                            while True:
+                            while pending_irq & terminal_irqs:
+                                irqStat = pending_irq
                                 if irqStat & self.lora.IRQ_CRC_ERR:
                                     self.crc_error_count += 1
 
@@ -532,22 +539,14 @@ class SX1262Radio(LoRaRadio):
                                     logger.error(f"Failed to restore RX mode: {e}")
                                     break
 
-                                terminal_irqs = (
-                                    self.lora.IRQ_RX_DONE
-                                    | self.lora.IRQ_CRC_ERR
-                                    | self.lora.IRQ_TIMEOUT
-                                    | self.lora.IRQ_HEADER_ERR
-                                )
                                 if pending_irq & terminal_irqs:
                                     logger.debug(f"[RX] Draining back-to-back packet (IRQ 0x{pending_irq:04X})")
-                                    irqStat = pending_irq
                                     continue
 
                                 await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                 logger.debug(
                                     f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
                                 )
-                                break
                         except Exception as e:
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -538,6 +538,9 @@ class SX1262Radio(LoRaRadio):
                                     self.lora.clearIrqStatus(0xFFFF)
                                     # Re-read after clearing to catch anything that arrived in the read-clear gap.
                                     pending_irq |= self.lora.getIrqStatus()
+                                    # Reset polling thread's edge baseline so last_state=HIGH
+                                    # from this IRQ cannot mask the next packet's rising edge.
+                                    self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
                                     if not (pending_irq & terminal_irqs):
                                         await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                         logger.debug(
@@ -555,6 +558,11 @@ class SX1262Radio(LoRaRadio):
                     except asyncio.TimeoutError:
                         # No RX event within timeout - normal operation
                         rx_check_count += 1
+
+                        # Watchdog: if DIO1 is HIGH but no event arrived, the polling
+                        # thread missed the rising edge — recover immediately.
+                        if self._gpio_manager.read_pin(self.irq_pin_number):
+                            self._handle_interrupt()
 
                         # Sample noise floor during quiet periods
                         self._sample_noise_floor()

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -429,7 +429,6 @@ class SX1262Radio(LoRaRadio):
                                 | self.lora.IRQ_HEADER_ERR
                             )
                             pending_irq = self._last_irq_status
-                            irqStat = pending_irq
 
                             while pending_irq & terminal_irqs:
                                 irqStat = pending_irq
@@ -536,12 +535,10 @@ class SX1262Radio(LoRaRadio):
                                     # Read before clearing to catch a packet that arrived during processing.
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
-                                    # Re-read after clearing to catch anything that arrived in the read-clear gap.
-                                    pending_irq |= self.lora.getIrqStatus()
-                                    # Reset polling thread's edge baseline so last_state=HIGH
-                                    # from this IRQ cannot mask the next packet's rising edge.
-                                    self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
                                     if not (pending_irq & terminal_irqs):
+                                        # Reset polling thread's edge baseline so last_state=HIGH
+                                        # from this IRQ cannot mask the next packet's rising edge.
+                                        self._gpio_manager.reset_edge_baseline(self.irq_pin_number)
                                         await asyncio.sleep(self.RADIO_TIMING_DELAY)
                                         logger.debug(
                                             f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
@@ -559,9 +556,8 @@ class SX1262Radio(LoRaRadio):
                         # No RX event within timeout - normal operation
                         rx_check_count += 1
 
-                        # Watchdog: if DIO1 is HIGH but no event arrived, the polling
-                        # thread missed the rising edge — recover immediately.
-                        if self._gpio_manager.read_pin(self.irq_pin_number):
+                        # Watchdog: gpiod polling can miss a rising edge; recover immediately.
+                        if self._gpio_manager._backend == "gpiod" and self._gpio_manager.read_pin(self.irq_pin_number):
                             self._handle_interrupt()
 
                         # Sample noise floor during quiet periods

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -419,128 +419,135 @@ class SX1262Radio(LoRaRadio):
                         self._last_packet_activity = time.time()
 
                         try:
-                            # Use the IRQ status stored by the interrupt handler
+                            # Drain back-to-back packets that arrive while we're still
+                            # handling the previous one, instead of paying a settle
+                            # sleep per packet in the burst.
                             irqStat = self._last_irq_status
 
-                            if irqStat & self.lora.IRQ_CRC_ERR:
-                                self.crc_error_count += 1
-                                
-                                try:
+                            while True:
+                                if irqStat & self.lora.IRQ_CRC_ERR:
+                                    self.crc_error_count += 1
 
-                                    packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
-                                    payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
-                                    device_errors = self.lora.getDeviceErrors()
-                                    noise_floor = self.get_noise_floor()
-                                    raw_packet_hex = ""
-                                    if payloadLengthRx > 0 and payloadLengthRx < 256:
-                                        try:
-                                            buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
-                                            raw_packet_hex = bytes(buffer).hex()
-                                        except Exception:
-                                            raw_packet_hex = "(read failed)"
-                                    
-                                    logger.warning(
-                                        "[RX] CRC error #%d - RSSI=%ddBm, SNR=%.1fdB, SignalRSSI=%ddBm, "
-                                        "Length=%d, NoiseFloor=%.1fdBm, DeviceErrors=0x%04X, IRQ=0x%04X, "
-                                        "RawData=%s",
-                                        self.crc_error_count,
-                                        int(packet_rssi_dbm), snr_db, int(signal_rssi_dbm),
-                                        payloadLengthRx, noise_floor, device_errors, irqStat,
-                                        raw_packet_hex
-                                    )
-                                except Exception as diag_err:
-                                    # Fallback if diagnostic collection fails
-                                    logger.warning(
-                                        "[RX] CRC error #%d - Unable to collect diagnostics: %s", 
-                                        self.crc_error_count, diag_err
-                                    )
-                            elif irqStat & self.lora.IRQ_RX_DONE:
-                                (
-                                    payloadLengthRx,
-                                    rxStartBufferPointer,
-                                ) = self.lora.getRxBufferStatus()
-                                (
-                                    packet_rssi_dbm,
-                                    snr_db,
-                                    signal_rssi_dbm,
-                                ) = self.lora.getSignalMetrics()
-                                self.last_rssi = int(packet_rssi_dbm)
-                                self.last_snr = snr_db
-                                self.last_signal_rssi = int(signal_rssi_dbm)
+                                    try:
+                                        packet_rssi_dbm, snr_db, signal_rssi_dbm = self.lora.getSignalMetrics()
+                                        payloadLengthRx, rxStartBufferPointer = self.lora.getRxBufferStatus()
+                                        device_errors = self.lora.getDeviceErrors()
+                                        noise_floor = self.get_noise_floor()
+                                        raw_packet_hex = ""
+                                        if payloadLengthRx > 0 and payloadLengthRx < 256:
+                                            try:
+                                                buffer = self.lora.readBuffer(rxStartBufferPointer, payloadLengthRx)
+                                                raw_packet_hex = bytes(buffer).hex()
+                                            except Exception:
+                                                raw_packet_hex = "(read failed)"
 
-                                logger.debug(
-                                    f"[RX] Packet received: length={payloadLengthRx}, "
-                                    f"RSSI={self.last_rssi}dBm, SNR={self.last_snr}dB"
-                                )
+                                        logger.warning(
+                                            "[RX] CRC error #%d - RSSI=%ddBm, SNR=%.1fdB, SignalRSSI=%ddBm, "
+                                            "Length=%d, NoiseFloor=%.1fdBm, DeviceErrors=0x%04X, IRQ=0x%04X, "
+                                            "RawData=%s",
+                                            self.crc_error_count,
+                                            int(packet_rssi_dbm), snr_db, int(signal_rssi_dbm),
+                                            payloadLengthRx, noise_floor, device_errors, irqStat,
+                                            raw_packet_hex
+                                        )
+                                    except Exception as diag_err:
+                                        # Fallback if diagnostic collection fails
+                                        logger.warning(
+                                            "[RX] CRC error #%d - Unable to collect diagnostics: %s",
+                                            self.crc_error_count, diag_err
+                                        )
+                                elif irqStat & self.lora.IRQ_RX_DONE:
+                                    (
+                                        payloadLengthRx,
+                                        rxStartBufferPointer,
+                                    ) = self.lora.getRxBufferStatus()
+                                    (
+                                        packet_rssi_dbm,
+                                        snr_db,
+                                        signal_rssi_dbm,
+                                    ) = self.lora.getSignalMetrics()
+                                    self.last_rssi = int(packet_rssi_dbm)
+                                    self.last_snr = snr_db
+                                    self.last_signal_rssi = int(signal_rssi_dbm)
 
-                                # Trigger RX LED
-                                self._gpio_manager.blink_led(self.rxled_pin)
-
-                                if payloadLengthRx > 0:
-                                    buffer = self.lora.readBuffer(
-                                        rxStartBufferPointer, payloadLengthRx
-                                    )
-                                    packet_data = bytes(buffer)
                                     logger.debug(
-                                        f"[RX] Packet data: {packet_data.hex()[:32]}... "
-                                        f"({len(packet_data)} bytes)"
+                                        f"[RX] Packet received: length={payloadLengthRx}, "
+                                        f"RSSI={self.last_rssi}dBm, SNR={self.last_snr}dB"
                                     )
 
-                                    # Call user RX callback if set
-                                    if self.rx_callback:
-                                        try:
-                                            self.rx_callback(packet_data)
-                                        except Exception as cb_exc:
-                                            logger.error(f"RX callback error: {cb_exc}")
-                                    else:
-                                        logger.warning("[RX] No RX callback registered!")
-                                else:
-                                    logger.warning("[RX] Empty packet received")
-                            elif irqStat & self.lora.IRQ_TIMEOUT:
-                                logger.warning("[RX] RX timeout detected")
-                            elif irqStat & self.lora.IRQ_HEADER_ERR:
-                                logger.warning(
-                                    f"[RX] Header error detected (0x{irqStat:04X}) - "
-                                    "corrupted header, restoring RX mode"
-                                )
-                            elif irqStat & self.lora.IRQ_PREAMBLE_DETECTED:
-                                logger.debug("[RX] Preamble detected - packet incoming")
-                            elif irqStat & self.lora.IRQ_SYNC_WORD_VALID:
-                                logger.debug("[RX] Sync word valid - receiving packet data")
-                            elif irqStat & self.lora.IRQ_HEADER_VALID:
-                                logger.debug(
-                                    "[RX] Header valid - packet header received, payload coming"
-                                )
-                            else:
-                                logger.debug(f"[RX] Other interrupt: 0x{irqStat:04X}")
+                                    # Trigger RX LED
+                                    self._gpio_manager.blink_led(self.rxled_pin)
 
-                            if not self._tx_lock.locked():
+                                    if payloadLengthRx > 0:
+                                        buffer = self.lora.readBuffer(
+                                            rxStartBufferPointer, payloadLengthRx
+                                        )
+                                        packet_data = bytes(buffer)
+                                        logger.debug(
+                                            f"[RX] Packet data: {packet_data.hex()[:32]}... "
+                                            f"({len(packet_data)} bytes)"
+                                        )
+
+                                        # Call user RX callback if set
+                                        if self.rx_callback:
+                                            try:
+                                                self.rx_callback(packet_data)
+                                            except Exception as cb_exc:
+                                                logger.error(f"RX callback error: {cb_exc}")
+                                        else:
+                                            logger.warning("[RX] No RX callback registered!")
+                                    else:
+                                        logger.warning("[RX] Empty packet received")
+                                elif irqStat & self.lora.IRQ_TIMEOUT:
+                                    logger.warning("[RX] RX timeout detected")
+                                elif irqStat & self.lora.IRQ_HEADER_ERR:
+                                    logger.warning(
+                                        f"[RX] Header error detected (0x{irqStat:04X}) - "
+                                        "corrupted header, restoring RX mode"
+                                    )
+                                elif irqStat & self.lora.IRQ_PREAMBLE_DETECTED:
+                                    logger.debug("[RX] Preamble detected - packet incoming")
+                                elif irqStat & self.lora.IRQ_SYNC_WORD_VALID:
+                                    logger.debug("[RX] Sync word valid - receiving packet data")
+                                elif irqStat & self.lora.IRQ_HEADER_VALID:
+                                    logger.debug(
+                                        "[RX] Header valid - packet header received, payload coming"
+                                    )
+                                else:
+                                    logger.debug(f"[RX] Other interrupt: 0x{irqStat:04X}")
+
+                                if self._tx_lock.locked():
+                                    logger.debug(
+                                        f"[RX] Skipped RX restore after IRQ 0x{irqStat:04X}"
+                                        " — TX lock held, send() will restore RX on completion"
+                                    )
+                                    break
+
                                 try:
                                     self.lora.request(self.lora.RX_CONTINUOUS)
-                                    # Read before clearing to catch back-to-back packets that arrived during processing.
+                                    # Read before clearing to catch a packet that arrived during processing.
                                     pending_irq = self.lora.getIrqStatus()
                                     self.lora.clearIrqStatus(0xFFFF)
-                                    terminal_irqs = (
-                                        self.lora.IRQ_RX_DONE
-                                        | self.lora.IRQ_CRC_ERR
-                                        | self.lora.IRQ_TIMEOUT
-                                        | self.lora.IRQ_HEADER_ERR
-                                    )
-                                    if pending_irq & terminal_irqs:
-                                        logger.debug(f"[RX] Back-to-back packet queued (IRQ 0x{pending_irq:04X})")
-                                        self._last_irq_status = pending_irq
-                                        self._rx_done_event.set()
-                                    await asyncio.sleep(self.RADIO_TIMING_DELAY)
-                                    logger.debug(
-                                        f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
-                                    )
                                 except Exception as e:
                                     logger.error(f"Failed to restore RX mode: {e}")
-                            else:
-                                logger.debug(
-                                    f"[RX] Skipped RX restore after IRQ 0x{irqStat:04X}"
-                                    " — TX lock held, send() will restore RX on completion"
+                                    break
+
+                                terminal_irqs = (
+                                    self.lora.IRQ_RX_DONE
+                                    | self.lora.IRQ_CRC_ERR
+                                    | self.lora.IRQ_TIMEOUT
+                                    | self.lora.IRQ_HEADER_ERR
                                 )
+                                if pending_irq & terminal_irqs:
+                                    logger.debug(f"[RX] Draining back-to-back packet (IRQ 0x{pending_irq:04X})")
+                                    irqStat = pending_irq
+                                    continue
+
+                                await asyncio.sleep(self.RADIO_TIMING_DELAY)
+                                logger.debug(
+                                    f"[RX] Restored RX continuous mode after IRQ 0x{irqStat:04X}"
+                                )
+                                break
                         except Exception as e:
                             logger.error(f"[IRQ RX] Error processing received packet: {e}")
                         finally:
@@ -553,21 +560,6 @@ class SX1262Radio(LoRaRadio):
 
                         # Sample noise floor during quiet periods
                         self._sample_noise_floor()
-
-                        # Watchdog: gpiod polling can miss an edge if IRQ goes HIGH then LOW within
-                        # the 20ms poll window. Recover by driving _handle_interrupt directly.
-                        if (
-                            self.use_gpiod_backend
-                            and not self._tx_lock.locked()
-                            and not self._is_receiving_packet
-                        ):
-                            try:
-                                pin_state = self._gpio_manager.read_pin(self.irq_pin_number)
-                                if pin_state:
-                                    logger.warning("[RX] IRQ pin stuck HIGH (gpiod polling gap) — recovering")
-                                    self._handle_interrupt()
-                            except Exception as e:
-                                logger.debug(f"[RX] IRQ watchdog read failed: {e}")
 
                         # Log every 500 checks (roughly every 5 seconds) to show RX task is alive
                         if rx_check_count % 500 == 0:


### PR DESCRIPTION
## The Problem

On LuckFox hardware (RockChip RV1106, kernel 5.10.160) using the gpiod GPIO backend, the SX1262 radio would permanently stop receiving after consecutive CRC errors on a busy mesh. The radio appeared healthy but was completely deaf — the only recovery was a process restart.

## Root Cause

The gpiod backend uses a software polling thread (`_monitor_polling`) at 20ms intervals to emulate rising-edge detection by tracking `last_state`. The SX1262 DIO1 IRQ pin is level-triggered HIGH until `clearIrqStatus()` is called over SPI.

The race condition:
1. A CRC error arrives — polling thread detects the rising edge and sets `last_state=HIGH`
2. Background task spends 30–80ms collecting CRC diagnostics over SPI
3. A second packet arrives during this window — DIO1 goes HIGH again
4. `clearIrqStatus()` is called — DIO1 goes LOW, then immediately HIGH again for the new packet
5. Polling thread sees `current=HIGH, last_state=HIGH` → no edge detected → radio permanently deaf

The 20ms polling interval is shorter than the diagnostic window, making this race consistently reproducible on SF7/62.5kHz mesh traffic. This matches the documented failure pattern in LoRaMac-node Issue #1060 and RadioLib Issue #703.

## What Changed

Three targeted fixes, all gpiod-specific except the read-before-clear which benefits both backends:

**1. Read-before-clear (both backends)** — `getIrqStatus()` is called before `clearIrqStatus()` in the RX restore block. If a packet arrived during processing (Window 1 — the diagnostic SPI block), it is detected and re-queued for the next background task cycle rather than being silently lost.

**2. Baseline reset (gpiod only)** — After `clearIrqStatus()` with no pending packet, `reset_edge_baseline()` signals the polling thread to reset `last_state=False` on its next tick. This guarantees the next rising edge is detected regardless of the previous pin state, closing the ~20ms polling race window (Window 2).

**3. Watchdog (gpiod only)** — On each 10ms background task timeout, if DIO1 is HIGH, `_handle_interrupt()` is called directly. This recovers from any edge missed due to polling thread exceptions or timing anomalies.

The RX background task remains single-pass (one IRQ event per event loop cycle). Back-to-back packets detected via read-before-clear are re-queued asynchronously rather than processed inline, ensuring TX can be scheduled between received packets and cannot be starved by a burst of incoming traffic.

## Why This Is Better

The previous approach had no protection against the `last_state` race on gpiod. The periphery backend was unaffected because it uses kernel-level hardware edge detection. The fixes are layered (defence in depth): read-before-clear handles the high-probability window, baseline reset handles the residual polling race, and the watchdog catches anything that slips through both. No changes to the GPIO processing architecture, no regressions on the periphery backend.
