### PR TITLE
Preserve app-supplied timestamp for channel messages

### DIFF
--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -404,7 +404,9 @@ class _SendOpsMixin:
             self.stats.record_tx_error()
             return SentResult(success=False)
 
-    async def send_channel_message(self, channel_idx: int, text: str) -> bool:
+    async def send_channel_message(
+        self, channel_idx: int, text: str, timestamp: Optional[int] = None
+    ) -> bool:
         """Send a message to a channel."""
         channel = self.channels.get(channel_idx)
         if not channel:
@@ -417,6 +419,7 @@ class _SendOpsMixin:
                 message=text,
                 sender_name=self.prefs.node_name,
                 channels_config=self.channels.get_channels(),
+                timestamp=timestamp,
             )
             self._apply_flood_scope(pkt)
             self._apply_path_hash_mode(pkt)

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -84,6 +84,7 @@ class _MessagingCommandsMixin:
             return
         txt_type = data[0]
         channel_idx = data[1]
+        msg_timestamp = struct.unpack("<I", data[2:6])[0]
         text = data[6:].decode("utf-8", errors="replace").rstrip("\x00")
         if txt_type != 0:
             self._write_err(ERR_CODE_UNSUPPORTED_CMD)
@@ -91,7 +92,7 @@ class _MessagingCommandsMixin:
         if self.bridge.get_channel(channel_idx) is None:
             self._write_err(ERR_CODE_NOT_FOUND)
             return
-        ok = await self.bridge.send_channel_message(channel_idx, text)
+        ok = await self.bridge.send_channel_message(channel_idx, text, timestamp=msg_timestamp)
         self._write_ok() if ok else self._write_err(ERR_CODE_BAD_STATE)
 
     async def _cmd_send_channel_data(self, data: bytes) -> None:

--- a/src/openhop_core/protocol/packet_builder.py
+++ b/src/openhop_core/protocol/packet_builder.py
@@ -719,6 +719,7 @@ class PacketBuilder:
         message: str,
         sender_name: str = "Unknown",
         channels_config: Optional[Any] = None,
+        timestamp: Optional[int] = None,
     ) -> Packet:
         """
         Create an encrypted group message for a specified channel.
@@ -779,7 +780,7 @@ class PacketBuilder:
         channel_hash = hashlib.sha256(hash_input).digest()[0]
         secret_bytes = (secret_bytes + b"\x00" * 32)[:32]
 
-        timestamp, flags = PacketBuilder._get_timestamp(), 0x00
+        timestamp, flags = (timestamp if timestamp is not None else PacketBuilder._get_timestamp()), 0x00
         content = f"{sender_name}: {message}".encode("utf-8")
         plaintext = PacketBuilder._pack_timestamp_data(timestamp, flags, content)
 


### PR DESCRIPTION
`CMD_SEND_CHANNEL_TXT_MSG` was discarding the `msg_timestamp` the companion app sends, and re-generating a fresh timestamp server-side in `create_group_datagram`. Real firmware preserves the app's timestamp end-to-end so the app can match a later flood-repeat RX against its own sent message and show the "repeated" indicator. Since ours didn't, that match silently failed and repeats showed correctly in raw RX logs but the channel conversation tick never lit up.
