### PR TITLE
Stop FLOODing RESPONSE for 0 hop cached paths

### DIFF
--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -304,7 +304,6 @@ class ProtocolRequestHandler:
                 hasattr(client, "out_path_len")
                 and client.out_path_len >= 0
                 and hasattr(client, "out_path")
-                and len(client.out_path) > 0
                 and PathUtils.is_valid_path_len(client.out_path_len)
             ):
                 route_type = "direct"


### PR DESCRIPTION
Found this while looking at the live packets view: `REQUEST` packets sent to the repeater with 0 hop always got a `FLOOD` `RESPONSE` back, even though there was a `PATH` exchange after logging in to the repeater.

Now matches the official firmware behavior.