### PR TITLE
fix: align flood scope, channel/DM error codes, and group text cap with firmware semantics

### DIFF
--- a/docs/docs/companion.md
+++ b/docs/docs/companion.md
@@ -352,9 +352,10 @@ For MeshCore v1.15 parity, the frame protocol also supports a persisted default 
 
 openhop-core resolves effective flood scope as:
 
-1. transient key set by `CMD_SET_FLOOD_SCOPE` / `set_flood_scope()`
-2. otherwise persisted default key (if configured)
-3. otherwise unscoped flood
+1. explicit unscoped mode (`CMD_SET_FLOOD_SCOPE` mode 1) until mode 0 sets/resets scope
+2. transient key set by `CMD_SET_FLOOD_SCOPE` mode 0 / `set_flood_scope()`
+3. otherwise persisted default key (if configured)
+4. otherwise unscoped flood
 
 When a flood scope is active, all flood packets are tagged with a 16-bit transport code
 (HMAC-SHA256 derived) and sent as `ROUTE_TYPE_TRANSPORT_FLOOD`. Direct-routed packets

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -10,7 +10,13 @@ from typing import Any, Optional
 from ..protocol import Packet
 from ..protocol.constants import ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD
 from ..protocol.transport_keys import calc_transport_code, get_auto_key_for
-from .constants import MAX_SIGN_DATA_SIZE, STATS_TYPE_CORE, STATS_TYPE_PACKETS, STATS_TYPE_RADIO
+from .constants import (
+    MAX_SIGN_DATA_SIZE,
+    STATS_TYPE_CORE,
+    STATS_TYPE_PACKETS,
+    STATS_TYPE_RADIO,
+    ZERO_FLOOD_SCOPE_KEY,
+)
 from .models import NodePrefs
 
 logger = logging.getLogger("CompanionBase")
@@ -181,22 +187,25 @@ class _DeviceConfigMixin:
     # -------------------------------------------------------------------------
 
     def set_flood_scope(self, transport_key: Optional[bytes] = None) -> None:
-        """Set or clear the flood transport key for scoped flooding.
+        """Set or clear the transient flood scope override.
 
         Also cancels any pending explicit-unscoped request (firmware sets
         ``send_unscoped = false`` whenever a scope override is set or reset).
         """
-        if transport_key and len(transport_key) >= 16:
-            self._flood_transport_key = transport_key[:16]
-        else:
-            self._flood_transport_key = None
         self._flood_unscoped = False
 
-    def set_flood_unscoped(self) -> None:
-        """Force the next flood to be unscoped, bypassing the default scope.
+        if transport_key and len(transport_key) >= 16:
+            key = bytes(transport_key[:16])
+            self._flood_transport_key = None if key == ZERO_FLOOD_SCOPE_KEY else key
+            return
 
-        Mirrors firmware CMD_SET_FLOOD_SCOPE_KEY mode 1 (FW PR #2492): a one-shot
-        flag consumed by the next flood-routed packet in _apply_flood_scope.
+        self._flood_transport_key = None
+
+    def set_flood_unscoped(self) -> None:
+        """Force following floods to be unscoped, bypassing the default scope.
+
+        Mirrors firmware CMD_SET_FLOOD_SCOPE_KEY mode 1 (FW PR #2492): a sticky
+        flag cleared by the next scope override/reset.
         """
         self._flood_unscoped = True
 
@@ -233,17 +242,19 @@ class _DeviceConfigMixin:
 
         Derives the 16-byte transport key automatically via SHA-256 of the
         region name.  A leading ``#`` is added if not already present.
-        Pass ``None`` to clear the scope (flood to all).
+        Pass ``None`` to clear this transient region override.
         """
         if region_name:
             if not region_name.startswith("#"):
                 region_name = f"#{region_name}"
             self._flood_transport_key = get_auto_key_for(region_name)
+            self._flood_unscoped = False
         else:
             self._flood_transport_key = None
+            self._flood_unscoped = False
 
     def _resolve_flood_transport_key(self) -> Optional[bytes]:
-        """Resolve effective flood key: transient key first, then persisted default."""
+        """Resolve effective flood key: transient override first, then default."""
         if self._flood_transport_key is not None:
             return self._flood_transport_key
         default_scope = self.get_default_flood_scope()
@@ -265,9 +276,7 @@ class _DeviceConfigMixin:
             return  # only scope flood packets, not direct
         if self._flood_unscoped:
             # App explicitly requested unscoped (FW #2492): leave as plain flood,
-            # ignoring any default scope. One-shot — consumed here, as firmware
-            # resets send_unscoped after each flood.
-            self._flood_unscoped = False
+            # ignoring any default scope until a scope override/reset.
             return
         effective_key = self._resolve_flood_transport_key()
         if effective_key is None:

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -278,11 +278,15 @@ class _DeviceConfigMixin:
         calculates the transport code, attaches it to the packet, and changes
         the route type to ``ROUTE_TYPE_TRANSPORT_FLOOD``.
 
-        Matches firmware ``sendFloodScoped()`` in ``BaseChatMesh.cpp``.
+        Matches firmware ``sendFloodScoped()`` in ``BaseChatMesh.cpp``.  Marks
+        the packet scope-applied even when it stays a plain flood (unscoped
+        request, or no key configured) so the dispatcher's node-level scope
+        cannot override that decision.
         """
         route_type = pkt.get_route_type()
         if route_type != ROUTE_TYPE_FLOOD:
             return  # only scope flood packets, not direct
+        pkt._flood_scope_applied = True
         if self._flood_unscoped:
             # App explicitly requested unscoped (FW #2492): leave as plain flood,
             # ignoring any default scope until a scope override/reset.

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -229,13 +229,18 @@ class _DeviceConfigMixin:
         return True
 
     def get_default_flood_scope(self) -> Optional[tuple[str, bytes]]:
-        """Return (name, key) for persisted default scope, or None if unset."""
+        """Return (name, key) for persisted default scope, or None if unset.
+
+        A non-empty name means "set" even when the key is all zeros: firmware
+        CMD_GET_DEFAULT_FLOOD_SCOPE checks only ``strlen(default_scope_name)``
+        and echoes the stored key as-is.  The null-key check happens at send
+        time instead (``TransportKey::isNull()``).
+        """
         name = (getattr(self.prefs, "default_scope_name", "") or "").strip()
-        key = getattr(self.prefs, "default_scope_key", b"") or b""
-        key = bytes(key[:16]).ljust(16, b"\x00") if key else b""
-        if not name or key == b"\x00" * 16:
+        if not name:
             return None
-        return (name, key)
+        key = getattr(self.prefs, "default_scope_key", b"") or b""
+        return (name, bytes(key[:16]).ljust(16, b"\x00"))
 
     def set_flood_region(self, region_name: Optional[str] = None) -> None:
         """Set flood scope from a region name (e.g., ``'#usa'``) or clear it.
@@ -253,14 +258,18 @@ class _DeviceConfigMixin:
             self._flood_transport_key = None
             self._flood_unscoped = False
 
+    def _default_scope_key(self) -> Optional[bytes]:
+        """Default scope key for sends, or None when unset or null (all zeros)."""
+        default_scope = self.get_default_flood_scope()
+        if default_scope is None or default_scope[1] == ZERO_FLOOD_SCOPE_KEY:
+            return None
+        return default_scope[1]
+
     def _resolve_flood_transport_key(self) -> Optional[bytes]:
         """Resolve effective flood key: transient override first, then default."""
         if self._flood_transport_key is not None:
             return self._flood_transport_key
-        default_scope = self.get_default_flood_scope()
-        if default_scope is None:
-            return None
-        return default_scope[1]
+        return self._default_scope_key()
 
     def _apply_flood_scope(self, pkt: Packet) -> None:
         """Apply flood scope transport codes to a packet in-place.

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -271,6 +271,12 @@ class _DeviceConfigMixin:
             return self._flood_transport_key
         return self._default_scope_key()
 
+    def _scope_packet(self, pkt: Packet, key: bytes) -> None:
+        """Attach transport codes for ``key`` and switch FLOOD -> TRANSPORT_FLOOD."""
+        pkt.transport_codes[0] = calc_transport_code(key, pkt)
+        pkt.transport_codes[1] = 0  # reserved for home region (firmware TODO)
+        pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD
+
     def _apply_flood_scope(self, pkt: Packet) -> None:
         """Apply flood scope transport codes to a packet in-place.
 
@@ -294,11 +300,22 @@ class _DeviceConfigMixin:
         effective_key = self._resolve_flood_transport_key()
         if effective_key is None:
             return
-        code = calc_transport_code(effective_key, pkt)
-        pkt.transport_codes[0] = code
-        pkt.transport_codes[1] = 0  # reserved for home region (firmware TODO)
-        # Switch route type from FLOOD -> TRANSPORT_FLOOD
-        pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD
+        self._scope_packet(pkt, effective_key)
+
+    def _apply_default_flood_scope(self, pkt: Packet) -> None:
+        """Scope a flood packet with the persisted default scope only.
+
+        Firmware CMD_SEND_SELF_ADVERT builds the scope directly from
+        ``prefs.default_scope_key``, bypassing both the transient send_scope
+        override and the send_unscoped flag; a null default means plain flood.
+        """
+        if pkt.get_route_type() != ROUTE_TYPE_FLOOD:
+            return
+        pkt._flood_scope_applied = True
+        key = self._default_scope_key()
+        if key is None:
+            return
+        self._scope_packet(pkt, key)
 
     def _apply_path_hash_mode(self, pkt: Packet) -> None:
         """Encode the device's path_hash_mode in originated packets.

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -70,7 +70,9 @@ class _SendOpsMixin:
             flags=flags,
             route_type=route,
         )
-        self._apply_flood_scope(pkt)
+        # Firmware CMD_SEND_SELF_ADVERT always scopes flood adverts with the
+        # persisted default scope, never the transient send_scope override.
+        self._apply_default_flood_scope(pkt)
         self._apply_path_hash_mode(pkt)
         success = await self._send_packet(pkt, wait_for_ack=False)
         if success:

--- a/src/openhop_core/companion/companion_base.py
+++ b/src/openhop_core/companion/companion_base.py
@@ -101,8 +101,8 @@ class CompanionBase(
         self._custom_vars: dict[str, str] = {}
         self._sign_buffer: Optional[bytearray] = None
         self._flood_transport_key: Optional[bytes] = None
-        # One-shot "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
-        # when set, the next flood ignores the default scope and floods unscoped.
+        # Sticky "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):
+        # when set, floods ignore the default scope until a scope override/reset.
         self._flood_unscoped: bool = False
         self._time_offset: float = 0.0
 

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -168,6 +168,16 @@ class CompanionRadio(CompanionBase):
         super().set_flood_region(region_name)
         self.node.dispatcher.flood_transport_key = self._flood_transport_key
 
+    def set_flood_unscoped(self) -> None:
+        """Force unscoped floods; clear the dispatcher's scope mirror too.
+
+        Firmware's send_unscoped flag suppresses scoping on every flood send,
+        so the node-level mirror must not keep applying a stale override key.
+        The next set_flood_scope()/set_flood_region() re-syncs the mirror.
+        """
+        super().set_flood_unscoped()
+        self.node.dispatcher.flood_transport_key = None
+
     def set_path_hash_mode(self, mode: int) -> None:
         """Set path hash mode and sync to dispatcher default."""
         super().set_path_hash_mode(mode)

--- a/src/openhop_core/companion/constants.py
+++ b/src/openhop_core/companion/constants.py
@@ -123,6 +123,7 @@ CONTACT_NAME_SIZE = 32
 CHANNEL_NAME_SIZE = 32  # channel name field width (CHANNEL_INFO / SET_CHANNEL)
 MAX_SIGN_DATA_SIZE = 8192  # 8KB signing buffer (matches firmware)
 MAX_PENDING_ACK_CRCS = 64
+ZERO_FLOOD_SCOPE_KEY = b"\x00" * 16  # firmware's null scope override (send_scope.isNull())
 
 # ---------------------------------------------------------------------------
 # Response-timeout hints (ms) returned in RESP_CODE_SENT frames. The firmware

--- a/src/openhop_core/companion/frame_server/commands_device.py
+++ b/src/openhop_core/companion/frame_server/commands_device.py
@@ -11,6 +11,7 @@ from ..constants import (
     ADV_TYPE_CHAT,
     ERR_CODE_BAD_STATE,
     ERR_CODE_ILLEGAL_ARG,
+    ERR_CODE_UNSUPPORTED_CMD,
     FIRMWARE_VER_CODE,
     RESP_CODE_ALLOWED_REPEAT_FREQ,
     RESP_CODE_AUTOADD_CONFIG,
@@ -211,18 +212,23 @@ class _DeviceCommandsMixin:
         The firmware (MyMesh.cpp:1909) treats data[0] as a mode selector:
           * mode 0: set the scope override key (data[1:17]) when present, else
             reset the override; cancels any pending explicit-unscoped request.
-          * mode 1 (FIRMWARE_VER_CODE 12+, PR #2492): force the next flood to be
-            unscoped, ignoring the configured default scope.
+          * mode 1 (FIRMWARE_VER_CODE 12+, PR #2492): force following floods to
+            be unscoped, ignoring the configured default scope until mode 0.
         Older apps always sent mode 0, so this is backward compatible.
         """
         mode = data[0] if len(data) >= 1 else 0
         if mode == 1:
             self.bridge.set_flood_unscoped()
-        elif len(data) >= 17:
-            self.bridge.set_flood_scope(data[1:17])
-        else:
-            self.bridge.set_flood_scope(None)
-        self._write_ok()
+            self._write_ok()
+            return
+        if mode == 0:
+            if len(data) >= 17:
+                self.bridge.set_flood_scope(data[1:17])
+            else:
+                self.bridge.set_flood_scope(None)
+            self._write_ok()
+            return
+        self._write_err(ERR_CODE_UNSUPPORTED_CMD)
 
     async def _cmd_set_default_flood_scope(self, data: bytes) -> None:
         """Handle CMD_SET_DEFAULT_FLOOD_SCOPE (63)."""

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -93,7 +93,9 @@ class _MessagingCommandsMixin:
             self._write_err(ERR_CODE_NOT_FOUND)
             return
         ok = await self.bridge.send_channel_message(channel_idx, text, timestamp=msg_timestamp)
-        self._write_ok() if ok else self._write_err(ERR_CODE_BAD_STATE)
+        # Firmware reports any channel-send failure as NOT_FOUND (MyMesh.cpp
+        # CMD_SEND_CHANNEL_TXT_MSG), so strictly-compatible clients expect it.
+        self._write_ok() if ok else self._write_err(ERR_CODE_NOT_FOUND)
 
     async def _cmd_send_channel_data(self, data: bytes) -> None:
         """Handle CMD_SEND_CHANNEL_DATA (62)."""

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -8,7 +8,6 @@ import struct
 from ...protocol.constants import TELEM_PERM_BASE, TELEM_PERM_ENVIRONMENT, TELEM_PERM_LOCATION
 from ...protocol.packet_utils import PathUtils
 from ..constants import (
-    ERR_CODE_BAD_STATE,
     ERR_CODE_ILLEGAL_ARG,
     ERR_CODE_NOT_FOUND,
     ERR_CODE_TABLE_FULL,
@@ -76,7 +75,9 @@ class _MessagingCommandsMixin:
         if result.success:
             self._write_sent_result(result, default_timeout_ms=TXT_MSG_TIMEOUT_HINT_MS)
         else:
-            self._write_err(ERR_CODE_BAD_STATE)
+            # Firmware maps MSG_SEND_FAILED to TABLE_FULL (MyMesh.cpp
+            # CMD_SEND_TXT_MSG), so strictly-compatible clients expect it.
+            self._write_err(ERR_CODE_TABLE_FULL)
 
     async def _cmd_send_channel_txt_msg(self, data: bytes) -> None:
         if len(data) < 6:

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -475,8 +475,14 @@ class Dispatcher:
         If ``flood_transport_key`` is set and the packet uses flood routing,
         calculates the transport code, attaches it to the packet, and
         switches the route type to ``ROUTE_TYPE_TRANSPORT_FLOOD``.
+
+        Packets the companion layer already scoped (or deliberately left as
+        plain flood, e.g. explicit-unscoped mode or default-scoped adverts)
+        are marked ``_flood_scope_applied`` and skipped here.
         """
         if self.flood_transport_key is None:
+            return
+        if getattr(pkt, "_flood_scope_applied", False):
             return
         route_type = pkt.get_route_type()
         if route_type != ROUTE_TYPE_FLOOD:

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -67,27 +67,17 @@ class Dispatcher:
         self.tx_delay = tx_delay
         self.state: DispatcherState = DispatcherState.IDLE
 
-        self.packet_received_callback: Optional[
-            Callable[[Packet], Awaitable[None] | None]
-        ] = None
-        self.packet_sent_callback: Optional[
-            Callable[[Packet], Awaitable[None] | None]
-        ] = None
+        self.packet_received_callback: Optional[Callable[[Packet], Awaitable[None] | None]] = None
+        self.packet_sent_callback: Optional[Callable[[Packet], Awaitable[None] | None]] = None
 
         # Optional listener for ACK received (e.g. companion send_confirmed)
-        self._ack_received_listener: Optional[
-            Callable[[int], Awaitable[None] | None]
-        ] = None
+        self._ack_received_listener: Optional[Callable[[int], Awaitable[None] | None]] = None
 
         # Optional callback for PAYLOAD_TYPE_RAW_CUSTOM (companion raw_data_received)
-        self.raw_data_received_callback: Optional[
-            Callable[[Packet], Awaitable[None]]
-        ] = None
+        self.raw_data_received_callback: Optional[Callable[[Packet], Awaitable[None]]] = None
 
         # Raw packet callbacks: single callback (legacy) and list of subscribers (after parse)
-        self.raw_packet_callback: Optional[
-            Callable[[Packet, bytes], Awaitable[None] | None]
-        ] = None
+        self.raw_packet_callback: Optional[Callable[[Packet, bytes], Awaitable[None] | None]] = None
         self._raw_packet_subscribers: List[Callable[..., Any]] = []
         # Raw RX subscribers: notified for every reception (data, rssi, snr) before duplicate/parse
         self._raw_rx_subscribers: List[Callable[..., Any]] = []
@@ -450,9 +440,7 @@ class Dispatcher:
         for callback in self._raw_packet_subscribers:
             await self._invoke_enhanced_raw_callback(callback, pkt, data, analysis)
         if self.raw_packet_callback:
-            await self._invoke_enhanced_raw_callback(
-                self.raw_packet_callback, pkt, data, {}
-            )
+            await self._invoke_enhanced_raw_callback(self.raw_packet_callback, pkt, data, {})
         if self._raw_packet_subscribers or self.raw_packet_callback:
             self._log("[RX DEBUG] Raw packet callback completed")
 
@@ -471,9 +459,7 @@ class Dispatcher:
             self._log(
                 "   This suggests your packet was repeated by another node and came back to you!"
             )
-            self._log(
-                f"Ignoring own packet (type={pkt.get_payload_type():02X}) to prevent loops"
-            )
+            self._log(f"Ignoring own packet (type={pkt.get_payload_type():02X}) to prevent loops")
             return
 
         # Handle ACK matching for waiting senders
@@ -581,12 +567,8 @@ class Dispatcher:
             return False
         # Log what we sent
         type_name = PAYLOAD_TYPES.get(payload_type, f"UNKNOWN_{payload_type}")
-        route_name = ROUTE_TYPES.get(
-            packet.get_route_type(), f"UNKNOWN_{packet.get_route_type()}"
-        )
-        self._log(
-            f"TX {packet.get_raw_length()} bytes (type={type_name}, route={route_name})"
-        )
+        route_name = ROUTE_TYPES.get(packet.get_route_type(), f"UNKNOWN_{packet.get_route_type()}")
+        self._log(f"TX {packet.get_raw_length()} bytes (type={type_name}, route={route_name})")
 
         # Store metadata on packet for access by handlers
         if tx_metadata:
@@ -618,9 +600,7 @@ class Dispatcher:
 
         try:
             # Wait for the ACK using the event-based system
-            ack_received = await self.wait_for_ack(
-                self._current_expected_crc, ACK_TIMEOUT
-            )
+            ack_received = await self.wait_for_ack(self._current_expected_crc, ACK_TIMEOUT)
             if ack_received:
                 self._log(f"[>>acK] received for CRC {self._current_expected_crc:08X}")
                 return True
@@ -673,13 +653,9 @@ class Dispatcher:
         else:
             self._log(f"RX {type_name} ({payload_type}) len={pkt.payload_len}")
 
-        self._logger.debug(
-            f"Received packet type {type_name}, payload length: {pkt.payload_len}"
-        )
+        self._logger.debug(f"Received packet type {type_name}, payload length: {pkt.payload_len}")
         if pkt.payload_len > 0:
-            self._logger.debug(
-                f"Payload preview: {pkt.payload[: min(10, pkt.payload_len)].hex()}"
-            )
+            self._logger.debug(f"Payload preview: {pkt.payload[: min(10, pkt.payload_len)].hex()}")
 
         handler = self._get_handler(payload_type)
         if not handler:
@@ -719,9 +695,7 @@ class Dispatcher:
         while True:
             # Clean out old ACK CRCs (older than 5 seconds)
             now = asyncio.get_running_loop().time()
-            self._recent_acks = {
-                crc: ts for crc, ts in self._recent_acks.items() if now - ts < 5
-            }
+            self._recent_acks = {crc: ts for crc, ts in self._recent_acks.items() if now - ts < 5}
 
             # Clean old packet hashes for deduplication
             self.packet_filter.cleanup_old_hashes()

--- a/src/openhop_core/protocol/constants.py
+++ b/src/openhop_core/protocol/constants.py
@@ -56,6 +56,7 @@ PATH_HASH_SIZE_SHIFT = 6  # bits 6-7 of encoded path_len
 CIPHER_MAC_SIZE = 32  # SHA‑256 HMAC
 CIPHER_BLOCK_SIZE = 16
 MAX_PACKET_PAYLOAD = 256  # firmware's default
+MAX_TEXT_LEN = 10 * CIPHER_BLOCK_SIZE  # firmware BaseChatMesh.h message text cap (160)
 
 MAX_PATH_SIZE = 64
 MAX_PACKET_PAYLOAD = 256
@@ -115,9 +116,7 @@ CONTACT_TYPE_HYBRID = 4
 # Protocol Request Types
 REQ_TYPE_GET_STATUS = 0x01  # Get repeater stats (RepeaterStats struct)
 REQ_TYPE_GET_TELEMETRY_DATA = 0x03  # Get telemetry data (CayenneLPP)
-REQ_TYPE_GET_OWNER_INFO = (
-    0x07  # Variable-length: tag(4) + "version\nname\nowner" (simple_repeater)
-)
+REQ_TYPE_GET_OWNER_INFO = 0x07  # Variable-length: tag(4) + "version\nname\nowner" (simple_repeater)
 TELEM_PERM_BASE = 0x01
 TELEM_PERM_LOCATION = 0x02
 TELEM_PERM_ENVIRONMENT = 0x04

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -115,6 +115,7 @@ class Packet:
         "drop_reason",
         "_tx_metadata",
         "_path_hash_mode_applied",
+        "_flood_scope_applied",
         "_injected_for_tx",
     )
 
@@ -139,6 +140,9 @@ class Packet:
         self._do_not_retransmit = False
         self.drop_reason = None  # Optional: reason for dropping packet
         self._path_hash_mode_applied = False
+        # Set once the companion layer has decided this flood packet's scoping
+        # (scoped or deliberately plain); the dispatcher must not re-scope it.
+        self._flood_scope_applied = False
         self._injected_for_tx = False  # Set by repeater inject path; skip engine on route
 
     def get_route_type(self) -> int:

--- a/src/openhop_core/protocol/packet_builder.py
+++ b/src/openhop_core/protocol/packet_builder.py
@@ -18,6 +18,7 @@ from .constants import (
     MAX_ADVERT_DATA_SIZE,
     MAX_PACKET_PAYLOAD,
     MAX_PATH_SIZE,
+    MAX_TEXT_LEN,
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_ANON_REQ,
@@ -87,9 +88,7 @@ class PacketBuilder:
         return PacketDataUtils.hash_bytes(pubkey, local_identity.get_public_key())
 
     @staticmethod
-    def _encrypt_payload(
-        aes_key: bytes, shared_secret: bytes, plaintext: bytes
-    ) -> bytes:
+    def _encrypt_payload(aes_key: bytes, shared_secret: bytes, plaintext: bytes) -> bytes:
         """Encrypt plaintext payload using AES key and shared secret."""
         return CryptoUtils.encrypt_then_mac(aes_key, shared_secret, plaintext)
 
@@ -125,9 +124,7 @@ class PacketBuilder:
         """Calculate shared secret and AES key from contact - reduces duplication."""
         pubkey = bytes.fromhex(contact.public_key)
         peer_identity = Identity(pubkey)
-        shared_secret = peer_identity.calc_shared_secret(
-            local_identity.get_private_key()
-        )
+        shared_secret = peer_identity.calc_shared_secret(local_identity.get_private_key())
         aes_key = shared_secret[:16]
         return shared_secret, aes_key
 
@@ -147,13 +144,10 @@ class PacketBuilder:
         contact: Any, local_identity: LocalIdentity, plaintext: bytes
     ) -> tuple[bytes, bytes, bytes]:
         """Create encrypted payload for contact-based packets with authentication."""
-        shared_secret, aes_key = PacketBuilder._calc_shared_secret_and_key(
-            contact, local_identity
-        )
+        shared_secret, aes_key = PacketBuilder._calc_shared_secret_and_key(contact, local_identity)
         encrypted = PacketBuilder._encrypt_payload(aes_key, shared_secret, plaintext)
         payload = (
-            PacketBuilder._hash_bytes(bytes.fromhex(contact.public_key), local_identity)
-            + encrypted
+            PacketBuilder._hash_bytes(bytes.fromhex(contact.public_key), local_identity) + encrypted
         )
         return payload, shared_secret, aes_key
 
@@ -254,9 +248,7 @@ class PacketBuilder:
             if isinstance(text, str)
             else bytes(text).strip(b"\x00")
         )
-        ack_hash = PacketBuilder.calc_text_ack_hash(
-            pubkey, timestamp, attempt, text_bytes
-        )
+        ack_hash = PacketBuilder.calc_text_ack_hash(pubkey, timestamp, attempt, text_bytes)
         return PacketBuilder.create_ack_from_bytes(ack_hash)
 
     @staticmethod
@@ -292,9 +284,7 @@ class PacketBuilder:
             bytes: 6-byte ACK hash.
         """
         text_bytes = text.encode("utf-8") if isinstance(text, str) else bytes(text)
-        temp = PacketBuilder._pack_timestamp_data(
-            timestamp, flags_byte & 0xFF, text_bytes
-        )
+        temp = PacketBuilder._pack_timestamp_data(timestamp, flags_byte & 0xFF, text_bytes)
         digest = CryptoUtils.sha256(temp + pubkey)
         last_byte = os.urandom(1) if randomize else b"\x00"
         return digest[:4] + bytes([ext_attempt & 0xFF]) + last_byte
@@ -358,9 +348,7 @@ class PacketBuilder:
         header = PacketBuilder._create_header(
             PAYLOAD_TYPE_MULTIPART, route_type="direct", has_routing_path=has_path
         )
-        payload = bytes([((remaining & 0x0F) << 4) | PAYLOAD_TYPE_ACK]) + bytes(
-            ack_bytes
-        )
+        payload = bytes([((remaining & 0x0F) << 4) | PAYLOAD_TYPE_ACK]) + bytes(ack_bytes)
         pkt = PacketBuilder._create_packet(header, payload)
         if has_path:
             pkt.set_path(bytes(path), path_len_encoded)
@@ -448,9 +436,7 @@ class PacketBuilder:
         timestamp = PacketBuilder._get_timestamp()
         pubkey = local_identity.get_public_key()
         ts_bytes = struct.pack("<I", timestamp)
-        appdata = PacketBuilder._encode_advert_data(
-            name, lat, lon, feature1, feature2, flags
-        )
+        appdata = PacketBuilder._encode_advert_data(name, lat, lon, feature1, feature2, flags)
         if len(appdata) > MAX_ADVERT_DATA_SIZE:
             raise ValueError(
                 f"advert appdata too large: {len(appdata)} bytes (max {MAX_ADVERT_DATA_SIZE})"
@@ -537,9 +523,7 @@ class PacketBuilder:
 
         aes_key = secret[:16]
         cipher = PacketBuilder._encrypt_payload(aes_key, secret, plaintext)
-        payload = (
-            PacketBuilder._hash_bytes(dest.get_public_key(), local_identity) + cipher
-        )
+        payload = PacketBuilder._hash_bytes(dest.get_public_key(), local_identity) + cipher
 
         header = PacketBuilder._create_header(ptype, route_type)
         pkt = PacketBuilder._create_packet(header, payload)
@@ -616,9 +600,7 @@ class PacketBuilder:
         plaintext = PacketBuilder._pack_timestamp_data(timestamp, req_data)
 
         contact_pubkey = bytes.fromhex(contact.public_key)
-        shared_secret, aes_key = PacketBuilder._calc_shared_secret_and_key(
-            contact, local_identity
-        )
+        shared_secret, aes_key = PacketBuilder._calc_shared_secret_and_key(contact, local_identity)
         cipher = PacketBuilder._encrypt_payload(aes_key, shared_secret, plaintext)
         dest_hash = PacketBuilder._hash_byte(contact_pubkey)
         payload = bytearray([dest_hash]) + local_identity.get_public_key() + cipher
@@ -637,9 +619,9 @@ class PacketBuilder:
         if route_type == "direct" and len(out_path) > 0:
             path_bytes = out_path[:MAX_PATH_SIZE]
             encoded_len = None
-            if PathUtils.is_valid_path_len(
+            if PathUtils.is_valid_path_len(out_path_len) and PathUtils.get_path_byte_len(
                 out_path_len
-            ) and PathUtils.get_path_byte_len(out_path_len) <= len(path_bytes):
+            ) <= len(path_bytes):
                 encoded_len = out_path_len
             elif len(path_bytes) == 64:
                 path_bytes = path_bytes[:63]
@@ -648,9 +630,7 @@ class PacketBuilder:
         return packet, timestamp
 
     @staticmethod
-    def create_login_packet(
-        contact: Any, local_identity: LocalIdentity, password: str
-    ) -> Packet:
+    def create_login_packet(contact: Any, local_identity: LocalIdentity, password: str) -> Packet:
         """
         Create a login packet for repeater authentication.
 
@@ -672,9 +652,7 @@ class PacketBuilder:
         is_room = getattr(contact, "type", 0) == CONTACT_TYPE_ROOM_SERVER
 
         if is_room:
-            sync_since = getattr(
-                contact, "sync_since", 0
-            )  # Use contact's sync_since or 0
+            sync_since = getattr(contact, "sync_since", 0)  # Use contact's sync_since or 0
             plaintext = PacketBuilder._pack_timestamp_data(
                 timestamp, struct.pack("<I", sync_since), password_bytes
             )
@@ -683,9 +661,7 @@ class PacketBuilder:
 
         contact_pubkey = bytes.fromhex(contact.public_key)
         contact_identity = Identity(contact_pubkey)
-        shared_secret = contact_identity.calc_shared_secret(
-            local_identity.get_private_key()
-        )
+        shared_secret = contact_identity.calc_shared_secret(local_identity.get_private_key())
 
         out_path_len = getattr(contact, "out_path_len", -1)
         if out_path_len < 0:
@@ -702,9 +678,9 @@ class PacketBuilder:
             if out_path:
                 path_bytes = out_path[:MAX_PATH_SIZE]
                 encoded_len = None
-                if PathUtils.is_valid_path_len(
+                if PathUtils.is_valid_path_len(out_path_len) and PathUtils.get_path_byte_len(
                     out_path_len
-                ) and PathUtils.get_path_byte_len(out_path_len) <= len(path_bytes):
+                ) <= len(path_bytes):
                     encoded_len = out_path_len
                 elif len(path_bytes) == 64:
                     path_bytes = path_bytes[:63]
@@ -756,9 +732,7 @@ class PacketBuilder:
                 "channels_config parameter is required - protocol layer cannot access database"
             )
 
-        channel = next(
-            (ch for ch in channels_config if ch.get("name") == group_name), None
-        )
+        channel = next((ch for ch in channels_config if ch.get("name") == group_name), None)
         if not channel:
             raise ValueError(f"Channel '{group_name}' not in provided channels_config")
 
@@ -780,8 +754,18 @@ class PacketBuilder:
         channel_hash = hashlib.sha256(hash_input).digest()[0]
         secret_bytes = (secret_bytes + b"\x00" * 32)[:32]
 
-        timestamp, flags = (timestamp if timestamp is not None else PacketBuilder._get_timestamp()), 0x00
-        content = f"{sender_name}: {message}".encode("utf-8")
+        if timestamp is None:
+            timestamp = PacketBuilder._get_timestamp()
+        flags = 0x00
+        # Firmware sendGroupMessage caps "<sender>: <text>" at MAX_TEXT_LEN bytes,
+        # truncating the text (never the prefix). Re-encode after the byte cut so a
+        # multi-byte UTF-8 sequence split at the boundary is dropped, not corrupted.
+        prefix = f"{sender_name}: ".encode("utf-8")
+        text_bytes = message.encode("utf-8")
+        max_text = max(MAX_TEXT_LEN - len(prefix), 0)
+        if len(text_bytes) > max_text:
+            text_bytes = text_bytes[:max_text].decode("utf-8", errors="ignore").encode("utf-8")
+        content = prefix + text_bytes
         plaintext = PacketBuilder._pack_timestamp_data(timestamp, flags, content)
 
         ciphertext = CryptoUtils._aes_encrypt(secret_bytes[:16], plaintext)
@@ -863,9 +847,7 @@ class PacketBuilder:
 
         # Create packet with proper structure
         pkt = Packet()
-        pkt.header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_TRACE, route_type="direct"
-        )
+        pkt.header = PacketBuilder._create_header(PAYLOAD_TYPE_TRACE, route_type="direct")
         pkt.path_len = 0  # No routing path in packet path field
         pkt.path = bytearray()  # Empty routing path
         pkt.payload = bytearray(payload)
@@ -884,9 +866,7 @@ class PacketBuilder:
             raise ValueError(
                 f"Raw data length {len(data)} exceeds MAX_PACKET_PAYLOAD ({MAX_PACKET_PAYLOAD})"
             )
-        header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_RAW_CUSTOM, route_type="direct"
-        )
+        header = PacketBuilder._create_header(PAYLOAD_TYPE_RAW_CUSTOM, route_type="direct")
         return PacketBuilder._create_packet(header, data)
 
     @staticmethod
@@ -931,9 +911,7 @@ class PacketBuilder:
         if len(path) + len(extra) + 5 > (MAX_PACKET_PAYLOAD - 2 - CIPHER_BLOCK_SIZE):
             raise ValueError("Combined path/extra too long")
 
-        if path_len_encoded is not None and PathUtils.is_valid_path_len(
-            path_len_encoded
-        ):
+        if path_len_encoded is not None and PathUtils.is_valid_path_len(path_len_encoded):
             expected_len = PathUtils.get_path_byte_len(path_len_encoded)
             if len(path) != expected_len:
                 raise ValueError(
@@ -1004,14 +982,10 @@ class PacketBuilder:
         attempt &= 0x03
         txt_type &= 0x3F
         flags_byte = (txt_type << 2) | attempt
-        timestamp = (
-            timestamp if timestamp is not None else PacketBuilder._get_timestamp()
-        )
+        timestamp = timestamp if timestamp is not None else PacketBuilder._get_timestamp()
 
         signed_sender_prefix = (
-            local_identity.get_public_key()[:4]
-            if txt_type == TXT_TYPE_SIGNED_PLAIN
-            else b""
+            local_identity.get_public_key()[:4] if txt_type == TXT_TYPE_SIGNED_PLAIN else b""
         )
 
         # Use  timestamp+data packing
@@ -1035,18 +1009,14 @@ class PacketBuilder:
 
         # Use  path validation
         routing_path = (
-            out_path
-            if out_path is not None
-            else (contact.out_path if contact.out_path else [])
+            out_path if out_path is not None else (contact.out_path if contact.out_path else [])
         )
         routing_path = PacketBuilder._validate_routing_path(routing_path)
 
         # Create packet with validated path
         pkt = Packet()
         has_path = bool(routing_path and len(routing_path) > 0)
-        pkt.header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_TXT_MSG, message_type, has_path
-        )
+        pkt.header = PacketBuilder._create_header(PAYLOAD_TYPE_TXT_MSG, message_type, has_path)
 
         if routing_path and len(routing_path) > 0:
             if len(routing_path) > MAX_PATH_SIZE:
@@ -1092,9 +1062,7 @@ class PacketBuilder:
             f"{route_type_names.get(header_route_type, 'UNKNOWN')})"
         )
         logger.debug(f"  Path: {list(pkt.path)} (len={pkt.path_len})")
-        logger.debug(
-            f"  Payload: {len(pkt.payload)} bytes, first 10: {list(pkt.payload[:10])}"
-        )
+        logger.debug(f"  Payload: {len(pkt.payload)} bytes, first 10: {list(pkt.payload[:10])}")
         logger.debug(
             f"  Message: '{message}', attempt={attempt}, txt_type={txt_type}, "
             f"flags=0x{flags_byte:02X}, timestamp={timestamp}"
@@ -1163,9 +1131,9 @@ class PacketBuilder:
         if route_type == "direct" and len(out_path) > 0:
             path_bytes = out_path[:MAX_PATH_SIZE]
             encoded_len = None
-            if PathUtils.is_valid_path_len(
+            if PathUtils.is_valid_path_len(out_path_len) and PathUtils.get_path_byte_len(
                 out_path_len
-            ) and PathUtils.get_path_byte_len(out_path_len) <= len(path_bytes):
+            ) <= len(path_bytes):
                 encoded_len = out_path_len
             elif len(path_bytes) == 64:
                 path_bytes = path_bytes[:63]
@@ -1174,9 +1142,7 @@ class PacketBuilder:
         return packet, timestamp
 
     @staticmethod
-    def create_logout_packet(
-        contact: Any, local_identity: LocalIdentity
-    ) -> tuple[Packet, int]:
+    def create_logout_packet(contact: Any, local_identity: LocalIdentity) -> tuple[Packet, int]:
         """
         Create a logout packet for repeater authentication.
 
@@ -1255,9 +1221,7 @@ class PacketBuilder:
             # Returns: 4
             ```
         """
-        inv = PacketBuilder._compute_inverse_perm_mask(
-            want_base, want_location, want_environment
-        )
+        inv = PacketBuilder._compute_inverse_perm_mask(want_base, want_location, want_environment)
 
         return PacketBuilder.create_protocol_request(
             contact=contact,
@@ -1318,9 +1282,7 @@ class PacketBuilder:
 
         # Create packet with direct routing (will be sent as zero-hop)
         pkt = Packet()
-        pkt.header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_CONTROL, route_type="direct"
-        )
+        pkt.header = PacketBuilder._create_header(PAYLOAD_TYPE_CONTROL, route_type="direct")
         pkt.path_len = 0
         pkt.path = bytearray()
         pkt.payload = payload
@@ -1382,9 +1344,7 @@ class PacketBuilder:
 
         # Create packet with direct routing (will be sent as zero-hop)
         pkt = Packet()
-        pkt.header = PacketBuilder._create_header(
-            PAYLOAD_TYPE_CONTROL, route_type="direct"
-        )
+        pkt.header = PacketBuilder._create_header(PAYLOAD_TYPE_CONTROL, route_type="direct")
         pkt.path_len = 0
         pkt.path = bytearray()
         pkt.payload = payload

--- a/tests/test_companion_base.py
+++ b/tests/test_companion_base.py
@@ -326,6 +326,59 @@ def test_apply_flood_scope_uses_default_scope_when_transient_unset():
     assert pkt.transport_codes[0] != 0
 
 
+def test_set_flood_scope_zero_key_resets_to_default_scope():
+    """An all-zero key is firmware's null override, so default scope still applies."""
+    bridge = _make_bridge(path_hash_mode=0)
+    default_key = b"\x22" * 16
+    assert bridge.set_default_flood_scope("region1", default_key) is True
+    key = b"\x11" * 16
+    bridge.set_flood_scope(key)
+    assert bridge._resolve_flood_transport_key() == key
+
+    bridge.set_flood_scope(b"\x00" * 16)
+
+    assert bridge._flood_transport_key is None
+    assert bridge._resolve_flood_transport_key() == default_key
+
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+
+def test_set_flood_scope_none_after_zero_key_uses_default_scope():
+    """Mode 0 without a key resets the null override and lets default scope apply."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", b"\x22" * 16) is True
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
+
+    bridge.set_flood_scope(b"\x00" * 16)
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
+    bridge.set_flood_scope(None)
+    assert bridge._resolve_flood_transport_key() == b"\x22" * 16
+
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+    pkt2 = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt2)
+    assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+
+def test_set_flood_scope_none_clears_sticky_unscoped_state():
+    """Mode 0 set/reset cancels sticky unscoped, so the default scope applies again."""
+    bridge = _make_bridge(path_hash_mode=0)
+    assert bridge.set_default_flood_scope("region1", b"\x33" * 16) is True
+    bridge.set_flood_unscoped()
+
+    bridge.set_flood_scope(None)
+
+    assert bridge._resolve_flood_transport_key() == b"\x33" * 16
+    pkt = _make_flood_pkt()
+    bridge._apply_flood_scope(pkt)
+    assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+
+
 def _make_flood_pkt() -> Packet:
     pkt = Packet()
     pkt.header = (PAYLOAD_TYPE_TRACE << 2) | 0x01  # route type FLOOD
@@ -336,7 +389,7 @@ def _make_flood_pkt() -> Packet:
     return pkt
 
 
-def test_set_flood_unscoped_overrides_default_scope_one_shot():
+def test_set_flood_unscoped_overrides_default_scope_sticky():
     """FW #2492: explicit unscoped forces a plain flood, bypassing the default scope."""
     bridge = _make_bridge(path_hash_mode=0)
     assert bridge.set_default_flood_scope("region1", bytes(range(16))) is True
@@ -348,11 +401,11 @@ def test_set_flood_unscoped_overrides_default_scope_one_shot():
     assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
     assert pkt.transport_codes[0] == 0
 
-    # One-shot: the next flood falls back to the default scope.
+    # Sticky: following floods stay plain until mode 0 sets/resets scope.
     pkt2 = _make_flood_pkt()
     bridge._apply_flood_scope(pkt2)
-    assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
-    assert pkt2.transport_codes[0] != 0
+    assert pkt2.get_route_type() == ROUTE_TYPE_FLOOD
+    assert pkt2.transport_codes[0] == 0
 
 
 def test_set_flood_scope_cancels_pending_unscoped():

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -196,6 +196,69 @@ class TestRadioDispatcherSync:
         companion.set_flood_scope(None)
         assert companion.node.dispatcher.flood_transport_key is None
 
+    def test_set_flood_unscoped_clears_dispatcher_mirror(self):
+        companion = _make_companion()
+        companion.set_flood_scope(b"\x01" * 16)
+        companion.set_flood_unscoped()
+        assert companion.node.dispatcher.flood_transport_key is None
+
+
+# ---------------------------------------------------------------------------
+# Explicit-unscoped mode (firmware CMD_SET_FLOOD_SCOPE_KEY mode 1, FW #2492)
+# ---------------------------------------------------------------------------
+
+
+class TestFloodUnscoped:
+    def test_unscoped_leaves_plain_flood_and_marks_packet(self):
+        companion = _make_companion()
+        companion.set_flood_scope(b"\x01" * 16)
+        companion.set_flood_unscoped()
+        pkt = _make_flood_packet()
+
+        companion._apply_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+        assert pkt._flood_scope_applied
+
+    def test_dispatcher_skips_companion_marked_packet(self):
+        """A stale dispatcher-level key must not re-scope a packet the
+        companion layer deliberately left as plain flood."""
+        companion = _make_companion()
+        dispatcher = companion.node.dispatcher
+        dispatcher.flood_transport_key = b"\x01" * 16
+        pkt = _make_flood_packet()
+        pkt._flood_scope_applied = True
+
+        dispatcher._apply_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
+    @pytest.mark.asyncio
+    async def test_unscoped_send_stays_plain_flood_end_to_end(self):
+        """set_flood_scope(K) then unscoped mode: the transmitted packet must
+        be a plain flood (firmware checks send_unscoped before send_scope)."""
+        radio = MockRadio()
+        identity = LocalIdentity()
+        companion = CompanionRadio(radio=radio, identity=identity, node_name="unscoped")
+        companion.channels.set(0, Channel(name="test-ch", secret=b"\xAB" * 16))
+        companion.set_flood_region("usa")
+        companion.set_flood_unscoped()
+
+        await companion.start()
+        try:
+            await companion.send_channel_message(0, "hello")
+        finally:
+            await companion.stop()
+
+        assert len(radio.sent) > 0
+        raw = radio.sent[-1]
+        pkt = Packet()
+        pkt.read_from(raw)
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
 
 # ---------------------------------------------------------------------------
 # Default flood scope semantics

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -291,6 +291,30 @@ class TestDefaultFloodScope:
         assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert pkt.transport_codes[0] == expected_code
 
+    def test_apply_default_flood_scope_ignores_override(self):
+        companion = _make_companion()
+        default_key = get_auto_key_for("#usa")
+        companion.set_default_flood_scope("usa", default_key)
+        companion.set_flood_region("europe")  # transient override
+        pkt = _make_flood_packet()
+
+        expected_code = calc_transport_code(default_key, pkt)
+        companion._apply_default_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == expected_code
+
+    def test_apply_default_flood_scope_null_default_stays_plain(self):
+        companion = _make_companion()
+        companion.set_flood_region("europe")  # transient override, no default
+        pkt = _make_flood_packet()
+
+        companion._apply_default_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+        assert pkt._flood_scope_applied
+
 
 # ---------------------------------------------------------------------------
 # Integration: advertise with flood scope
@@ -299,11 +323,13 @@ class TestDefaultFloodScope:
 
 class TestAdvertiseWithFloodScope:
     @pytest.mark.asyncio
-    async def test_advertise_flood_with_scope_sends_transport_flood(self):
+    async def test_advertise_flood_uses_default_scope(self):
+        """Flood adverts are scoped with the persisted default scope (firmware
+        CMD_SEND_SELF_ADVERT builds the scope from prefs.default_scope_key)."""
         radio = MockRadio()
         identity = LocalIdentity()
         companion = CompanionRadio(radio=radio, identity=identity, node_name="scoped")
-        companion.set_flood_region("usa")
+        companion.set_default_flood_scope("usa", get_auto_key_for("#usa"))
 
         await companion.start()
         try:
@@ -311,7 +337,6 @@ class TestAdvertiseWithFloodScope:
         finally:
             await companion.stop()
 
-        # Verify the sent packet has transport codes
         assert len(radio.sent) > 0
         raw = radio.sent[-1]
         pkt = Packet()
@@ -319,6 +344,28 @@ class TestAdvertiseWithFloodScope:
         assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
         assert pkt.transport_codes[0] != 0
         assert pkt.transport_codes[1] == 0
+
+    @pytest.mark.asyncio
+    async def test_advertise_flood_ignores_transient_override(self):
+        """Firmware flood adverts bypass the transient send_scope override:
+        with an override set but no default scope, the advert stays plain."""
+        radio = MockRadio()
+        identity = LocalIdentity()
+        companion = CompanionRadio(radio=radio, identity=identity, node_name="scoped")
+        companion.set_flood_region("usa")  # transient override only
+
+        await companion.start()
+        try:
+            await companion.advertise(flood=True)
+        finally:
+            await companion.stop()
+
+        assert len(radio.sent) > 0
+        raw = radio.sent[-1]
+        pkt = Packet()
+        pkt.read_from(raw)
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
 
     @pytest.mark.asyncio
     async def test_advertise_flood_without_scope_sends_normal_flood(self):

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -198,6 +198,38 @@ class TestRadioDispatcherSync:
 
 
 # ---------------------------------------------------------------------------
+# Default flood scope semantics
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultFloodScope:
+    def test_zero_key_default_is_reported_but_null_at_send(self):
+        """Firmware persists and echoes a named default with an all-zero key
+        (GET checks only the name); the null-key check happens at send time."""
+        companion = _make_companion()
+        companion.set_default_flood_scope("usa", b"\x00" * 16)
+
+        assert companion.get_default_flood_scope() == ("usa", b"\x00" * 16)
+        assert companion._resolve_flood_transport_key() is None
+
+        pkt = _make_flood_packet()
+        companion._apply_flood_scope(pkt)
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+
+    def test_default_scope_used_when_no_override(self):
+        companion = _make_companion()
+        key = get_auto_key_for("#usa")
+        companion.set_default_flood_scope("usa", key)
+        pkt = _make_flood_packet()
+
+        expected_code = calc_transport_code(key, pkt)
+        companion._apply_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == expected_code
+
+
+# ---------------------------------------------------------------------------
 # Integration: advertise with flood scope
 # ---------------------------------------------------------------------------
 

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1481,10 +1481,11 @@ async def test_cmd_send_channel_txt_msg_paths():
     bridge.send_channel_message = AsyncMock(return_value=True)
     server, frames = _make_capture_server(bridge)
 
-    data = bytes([0, 1]) + struct.pack("<I", 0) + b"hello"
+    # App-supplied timestamp is passed through to the bridge (PR #93)
+    data = bytes([0, 1]) + struct.pack("<I", 1234) + b"hello"
     await server._cmd_send_channel_txt_msg(data)
     assert frames == [bytes([RESP_CODE_OK])]
-    bridge.send_channel_message.assert_awaited_once_with(1, "hello")
+    bridge.send_channel_message.assert_awaited_once_with(1, "hello", timestamp=1234)
 
     # Non-plain txt_type is rejected before channel lookup
     frames.clear()

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1497,6 +1497,13 @@ async def test_cmd_send_channel_txt_msg_paths():
     await server._cmd_send_channel_txt_msg(bytes([0, 9]) + struct.pack("<I", 0) + b"x")
     assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_NOT_FOUND])]
 
+    # Send failure: firmware reports NOT_FOUND (not BAD_STATE) for channel sends
+    bridge.get_channel = Mock(return_value=Channel(name="general", secret=bytes(16)))
+    bridge.send_channel_message = AsyncMock(return_value=False)
+    frames.clear()
+    await server._cmd_send_channel_txt_msg(bytes([0, 1]) + struct.pack("<I", 0) + b"x")
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_NOT_FOUND])]
+
 
 # ---------------------------------------------------------------------------
 # CMD_SEND_BINARY_REQ

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -6,6 +6,7 @@ import struct
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from openhop_core.companion.constants import (
     CMD_GET_DEVICE_TIME,
     ERR_CODE_BAD_STATE,
@@ -716,15 +717,10 @@ async def test_device_info_includes_path_hash_mode():
 @pytest.mark.asyncio
 async def test_cmd_send_status_req_failure_no_empty_push():
     """Failed status request must NOT send PUSH_CODE_STATUS_RESPONSE (matches firmware)."""
-    from openhop_core.companion.constants import (
-        PUSH_CODE_STATUS_RESPONSE,
-        RESP_CODE_SENT,
-    )
+    from openhop_core.companion.constants import PUSH_CODE_STATUS_RESPONSE, RESP_CODE_SENT
 
     bridge = Mock()
-    bridge.send_status_request = AsyncMock(
-        return_value={"success": False, "reason": "timeout"}
-    )
+    bridge.send_status_request = AsyncMock(return_value={"success": False, "reason": "timeout"})
     server = CompanionFrameServer(bridge, "hash", port=0)
     frames: list[bytes] = []
     server._write_frame = lambda f: frames.append(f)
@@ -740,10 +736,7 @@ async def test_cmd_send_status_req_failure_no_empty_push():
 @pytest.mark.asyncio
 async def test_cmd_send_status_req_empty_raw_bytes_no_push():
     """Status response with empty raw_bytes must NOT send PUSH_CODE_STATUS_RESPONSE."""
-    from openhop_core.companion.constants import (
-        PUSH_CODE_STATUS_RESPONSE,
-        RESP_CODE_SENT,
-    )
+    from openhop_core.companion.constants import PUSH_CODE_STATUS_RESPONSE, RESP_CODE_SENT
 
     bridge = Mock()
     bridge.send_status_request = AsyncMock(
@@ -787,10 +780,7 @@ async def test_cmd_send_status_req_success_sends_push_with_data():
 @pytest.mark.asyncio
 async def test_cmd_send_telemetry_req_failure_no_empty_push():
     """Failed telemetry request must NOT send PUSH_CODE_TELEMETRY_RESPONSE."""
-    from openhop_core.companion.constants import (
-        PUSH_CODE_TELEMETRY_RESPONSE,
-        RESP_CODE_SENT,
-    )
+    from openhop_core.companion.constants import PUSH_CODE_TELEMETRY_RESPONSE, RESP_CODE_SENT
 
     bridge = Mock()
     bridge.send_telemetry_request = AsyncMock(return_value={"success": False})
@@ -938,9 +928,7 @@ async def test_handle_client_connection_reset_disconnects_cleanly(caplog):
     bridge.get_time = Mock(return_value=0)
     server = CompanionFrameServer(bridge, "hash", port=0, client_idle_timeout_sec=None)
 
-    await server._handle_client(
-        _RaisingReader(ConnectionResetError("boom")), _DummyWriter()
-    )
+    await server._handle_client(_RaisingReader(ConnectionResetError("boom")), _DummyWriter())
 
     assert server._client_writer is None
     assert server._client_reader is None
@@ -996,10 +984,7 @@ async def test_cmd_send_raw_packet_too_short():
 def test_parse_binary_response_regions():
     """Anon REGIONS response decodes clock + comma-separated region names."""
     from openhop_core.companion import binary_parsing
-    from openhop_core.companion.constants import (
-        ANON_REQ_TYPE_REGIONS,
-        PROTOCOL_CODE_ANON_REQ,
-    )
+    from openhop_core.companion.constants import ANON_REQ_TYPE_REGIONS, PROTOCOL_CODE_ANON_REQ
 
     # response_data (tag already stripped) = clock(4) + null-terminated name list
     data = struct.pack("<I", 0x11223344) + b"home,usa,*\x00"
@@ -1015,10 +1000,7 @@ def test_parse_binary_response_anon_not_mistaken_for_owner_info():
     """A REGIONS anon response must NOT be parsed as REQ owner-info, even though
     both carry numeric type 0x07."""
     from openhop_core.companion import binary_parsing
-    from openhop_core.companion.constants import (
-        ANON_REQ_TYPE_REGIONS,
-        PROTOCOL_CODE_ANON_REQ,
-    )
+    from openhop_core.companion.constants import ANON_REQ_TYPE_REGIONS, PROTOCOL_CODE_ANON_REQ
 
     data = struct.pack("<I", 0) + b"alpha\x00"
     parsed = binary_parsing.parse_binary_response(
@@ -1066,9 +1048,7 @@ async def test_cmd_send_anon_req_success_writes_sent():
     from openhop_core.companion.constants import RESP_CODE_SENT
 
     bridge = _MockBridgeAnonReq(
-        SentResult(
-            success=True, is_flood=False, expected_ack=0x11223344, timeout_ms=4000
-        )
+        SentResult(success=True, is_flood=False, expected_ack=0x11223344, timeout_ms=4000)
     )
     server = CompanionFrameServer(bridge, "hash", port=0)
     frames = []
@@ -1159,6 +1139,7 @@ async def test_cmd_set_flood_scope_dispatches_mode_byte():
     bridge = Mock()
     server = CompanionFrameServer(bridge, "hash", port=0)
     server._write_ok = Mock()
+    server._write_err = Mock()
 
     # mode 1 (v12+): force unscoped
     await server._cmd_set_flood_scope(bytes([0x01]))
@@ -1176,6 +1157,15 @@ async def test_cmd_set_flood_scope_dispatches_mode_byte():
     bridge.reset_mock()
     await server._cmd_set_flood_scope(bytes([0x00]))
     bridge.set_flood_scope.assert_called_once_with(None)
+
+    # unknown mode: firmware falls through to unsupported command
+    bridge.reset_mock()
+    server._write_ok.reset_mock()
+    await server._cmd_set_flood_scope(bytes([0x02]) + bytes(range(16)))
+    bridge.set_flood_scope.assert_not_called()
+    bridge.set_flood_unscoped.assert_not_called()
+    server._write_ok.assert_not_called()
+    server._write_err.assert_called_once_with(ERR_CODE_UNSUPPORTED_CMD)
 
 
 def test_max_frame_size_is_176():
@@ -1217,9 +1207,7 @@ async def test_cmd_send_txt_msg_threads_host_timestamp():
 
     host_ts = 1700000000
     # data: txt_type(1) + attempt(1) + msg_timestamp(4, LE) + pubkey_prefix(6) + text
-    data = (
-        bytes([TXT_TYPE_PLAIN, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"hello"
-    )
+    data = bytes([TXT_TYPE_PLAIN, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"hello"
     await server._cmd_send_txt_msg(data)
 
     bridge.send_text_message.assert_awaited_once()
@@ -1227,9 +1215,7 @@ async def test_cmd_send_txt_msg_threads_host_timestamp():
 
     # CLI_DATA mints a fresh timestamp (timestamp=None), matching firmware's RTC override.
     bridge.send_text_message.reset_mock()
-    data_cli = (
-        bytes([TXT_TYPE_CLI_DATA, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"cmd"
-    )
+    data_cli = bytes([TXT_TYPE_CLI_DATA, 0]) + struct.pack("<I", host_ts) + pubkey[:6] + b"cmd"
     await server._cmd_send_txt_msg(data_cli)
     assert bridge.send_text_message.call_args.kwargs["timestamp"] is None
 
@@ -1249,9 +1235,7 @@ async def test_cmd_send_txt_msg_zero_host_timestamp_mints_fresh():
     pubkey = peer.get_public_key()
     bridge.contacts.add(Contact(public_key=pubkey, name="Peer"))
     bridge.send_text_message = AsyncMock(
-        return_value=SentResult(
-            success=True, is_flood=False, expected_ack=0, timeout_ms=5000
-        )
+        return_value=SentResult(success=True, is_flood=False, expected_ack=0, timeout_ms=5000)
     )
 
     server = CompanionFrameServer(bridge, "hash", port=0)

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -9,7 +9,6 @@ import pytest
 
 from openhop_core.companion.constants import (
     CMD_GET_DEVICE_TIME,
-    ERR_CODE_BAD_STATE,
     ERR_CODE_ILLEGAL_ARG,
     ERR_CODE_NOT_FOUND,
     ERR_CODE_TABLE_FULL,
@@ -1462,7 +1461,8 @@ async def test_cmd_send_txt_msg_unknown_contact_and_failure():
     server, frames = _make_capture_server(_txt_bridge(contact, SentResult(False)))
     data = bytes([0, 0]) + struct.pack("<I", 1) + contact.public_key[:6] + b"hi"
     await server._cmd_send_txt_msg(data)
-    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_BAD_STATE])]
+    # Firmware maps MSG_SEND_FAILED to TABLE_FULL (not BAD_STATE)
+    assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_TABLE_FULL])]
 
     server, frames = _make_capture_server(_txt_bridge(contact, SentResult(True)))
     await server._cmd_send_txt_msg(b"\x00\x00")  # too short

--- a/tests/test_packet_builder.py
+++ b/tests/test_packet_builder.py
@@ -2,6 +2,7 @@ from openhop_core import LocalIdentity
 from openhop_core.protocol import CryptoUtils
 from openhop_core.protocol.constants import (
     MAX_PACKET_PAYLOAD,
+    MAX_TEXT_LEN,
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_ANON_REQ,
@@ -498,3 +499,52 @@ def test_create_text_message_uses_explicit_timestamp():
         contact, sender, text, attempt=attempt, message_type="direct"
     )
     assert crc3 != crc
+
+
+def _decrypt_group_content(pkt: Packet, secret: bytes) -> bytes:
+    """Return the '<sender>: <text>' content of a group datagram payload."""
+    # Payload layout: channel_hash (1) + MAC (2) + ciphertext
+    ciphertext = bytes(pkt.payload[3:])
+    plaintext = CryptoUtils._aes_decrypt(secret[:16], ciphertext)
+    # Skip timestamp (4) + flags (1); strip AES zero-padding like receivers do.
+    return plaintext[5:].rstrip(b"\x00")
+
+
+def test_create_group_datagram_truncates_content_to_max_text_len():
+    """Firmware sendGroupMessage caps '<sender>: <text>' at MAX_TEXT_LEN bytes."""
+    secret = b"\x11" * 16
+    channels = [{"name": "general", "secret": secret}]
+    sender = "Alice"
+
+    pkt = PacketBuilder.create_group_datagram(
+        "general", LocalIdentity(), "x" * 500, sender, channels
+    )
+
+    content = _decrypt_group_content(pkt, secret)
+    assert len(content) == MAX_TEXT_LEN
+    prefix = f"{sender}: "
+    assert content.decode("utf-8") == prefix + "x" * (MAX_TEXT_LEN - len(prefix))
+
+
+def test_create_group_datagram_short_message_not_truncated():
+    secret = b"\x11" * 16
+    channels = [{"name": "general", "secret": secret}]
+
+    pkt = PacketBuilder.create_group_datagram(
+        "general", LocalIdentity(), "hello", "Alice", channels
+    )
+
+    assert _decrypt_group_content(pkt, secret) == b"Alice: hello"
+
+
+def test_create_group_datagram_truncation_keeps_utf8_valid():
+    """A multi-byte char split at the byte cap is dropped, not corrupted."""
+    secret = b"\x11" * 16
+    channels = [{"name": "general", "secret": secret}]
+
+    # Prefix "A: " is 3 bytes; 157 remaining is odd, so a 2-byte char straddles the cut.
+    pkt = PacketBuilder.create_group_datagram("general", LocalIdentity(), "é" * 200, "A", channels)
+
+    content = _decrypt_group_content(pkt, secret)
+    assert len(content) <= MAX_TEXT_LEN
+    assert content.decode("utf-8") == "A: " + "é" * ((MAX_TEXT_LEN - 3) // 2)


### PR DESCRIPTION
## Summary

Ports #91 (thanks @Bjorkan) onto the post-refactor module layout and stacks three more firmware-parity fixes. All semantics were verified against the MeshCore companion firmware source (`MyMesh.cpp`, `BaseChatMesh.cpp`). Supersedes #91.

## Changes

**Flood scope (port of #91)**
- `SET_FLOOD_SCOPE` mode 0 with an all-zero key is treated as a null override and falls back to the configured default scope, instead of scoping with a literal zero key (firmware: `send_scope.isNull() → default_scope`).
- Mode 1 explicit-unscoped is now sticky until a mode 0 set/reset, matching Companion v12, rather than one-shot.
- Unknown modes return `ERR_CODE_UNSUPPORTED_CMD`.
- `set_flood_region()` also clears the sticky unscoped flag, mirroring mode 0.

**Error-code parity**
- Channel text send failures return `ERR_CODE_NOT_FOUND` (was `BAD_STATE`), matching the firmware's `CMD_SEND_CHANNEL_TXT_MSG` handler.
- DM send failures return `ERR_CODE_TABLE_FULL` (was `BAD_STATE`), matching the firmware's `MSG_SEND_FAILED` mapping.

**Group message length**
- `create_group_datagram` caps `<sender>: <text>` at `MAX_TEXT_LEN` (160 bytes) like firmware `sendGroupMessage`, truncating the text and never the prefix. One deliberate divergence: a multi-byte UTF-8 character split at the cap is dropped rather than sent as invalid UTF-8.

**Tests/docs**
- New tests: zero-key default-scope fallback, sticky unscoped, unknown mode, error-code paths, truncation (including the UTF-8 boundary case).
- Fixes `test_cmd_send_channel_txt_msg_paths`, which #93 left asserting the old `send_channel_message` signature — this test currently fails on `dev`.
- Updated the flood-scope resolution order in `docs/docs/companion.md`.

## Testing

Full suite: 947 passed. The only failure is the pre-existing `test_floor_calculated_after_n_samples` (SX1262 noise floor), which fails identically on clean `dev`.