### PR TITLE
fix(handlers): return HandlerResult so callers forward prefix collisions

### DIFF
--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Iterable, Optional
 from ..node.handlers import create_core_handlers
 from ..node.handlers.crypto_helpers import iter_decrypt_by_src_hash
 from ..node.handlers.login_server import LoginServerHandler
+from ..node.handlers.result import HandlerResult
 from ..protocol import LocalIdentity, Packet
 from ..protocol.constants import (
     PAYLOAD_TYPE_ACK,
@@ -290,8 +291,20 @@ class CompanionBridge(CompanionBase):
     # RX Entry Point
     # -------------------------------------------------------------------------
 
-    async def process_received_packet(self, packet: Packet) -> None:
-        """Process a packet destined for this companion."""
+    async def process_received_packet(self, packet: Packet) -> HandlerResult:
+        """Process a packet destined for this companion.
+
+        Returns an authenticated HandlerResult only when a handler authenticated
+        (MAC-verified/decrypted) the packet for this companion identity and
+        consumed it. Returns a not-for-us result when no handler claimed it —
+        e.g. a one-byte dest-hash collision where the packet actually belongs to
+        another node — so the caller may still forward it instead of swallowing it.
+
+        Note: handlers that report authenticated ownership (text, login/anon)
+        return a HandlerResult; broadcast-style handlers (advert, ack, group,
+        path, response) return None and are treated here as non-authoritative for
+        the caller's forwarding decision.
+        """
         ptype = packet.get_payload_type()
         route_type = packet.get_route_type()
         is_flood = route_type in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD)
@@ -300,9 +313,11 @@ class CompanionBridge(CompanionBase):
         handler = self._handlers.get(ptype)
         if handler:
             try:
-                await handler(packet)
+                result = await handler(packet)
+                return result if isinstance(result, HandlerResult) else HandlerResult.not_for_us()
             except Exception as e:
                 logger.error("Handler error for type %02X: %s", ptype, e)
+                return HandlerResult.not_for_us()
         elif ptype == PAYLOAD_TYPE_GRP_DATA:
             try:
                 await self._handle_group_data_packet(packet)
@@ -313,6 +328,7 @@ class CompanionBridge(CompanionBase):
         # via PathHandler.__call__ (path.py), which runs as the handler above.
         # No duplicate call here — it would cause double decryption and could
         # deliver the result to response waiters twice.
+        return HandlerResult.not_for_us()
 
     # -------------------------------------------------------------------------
     # Abstract method implementations

--- a/src/openhop_core/node/handlers/__init__.py
+++ b/src/openhop_core/node/handlers/__init__.py
@@ -14,6 +14,7 @@ from .path import PathHandler
 from .protocol_request import ProtocolRequestHandler
 from .protocol_response import ProtocolResponseHandler
 from .registry import CoreHandlers, create_core_handlers
+from .result import HandlerResult
 from .text import TextMessageHandler
 from .trace import TraceHandler
 
@@ -35,4 +36,5 @@ __all__ = [
     "ControlHandler",
     "CoreHandlers",
     "create_core_handlers",
+    "HandlerResult",
 ]

--- a/src/openhop_core/node/handlers/anon_request.py
+++ b/src/openhop_core/node/handlers/anon_request.py
@@ -40,6 +40,7 @@ from ...protocol.constants import (
 from ...protocol.packet_utils import PathUtils
 from .base import BaseHandler
 from .login_server import LoginServerHandler
+from .result import HandlerResult
 
 # Server response delay (ms) — matches firmware SERVER_RESPONSE_DELAY.
 SERVER_RESPONSE_DELAY_MS = 300
@@ -127,17 +128,28 @@ class AnonRequestHandler(BaseHandler):
         # Keep the wrapped login handler wired through the same sender.
         self.login_handler.set_send_packet_callback(callback)
 
-    async def __call__(self, packet: Packet) -> None:
-        """Handle an ANON_REQ packet: decrypt, then dispatch on the sub-type byte."""
+    async def __call__(self, packet: Packet) -> HandlerResult:
+        """Handle an ANON_REQ packet: decrypt, then dispatch on the sub-type byte.
+
+        Returns an authenticated HandlerResult when the request was decrypted for
+        this identity — i.e. it is genuinely addressed to us and the caller should
+        consume it (this holds even when we decline to answer, e.g. a rate-limited
+        or non-direct discovery query). Returns a not-for-us result when it was not
+        for us (wrong dest hash, or an HMAC failure from a dest-hash collision) so
+        the caller may forward/re-flood it.
+        """
+        # Flipped to True once decryption succeeds; used by the outer handler so a
+        # post-decrypt error still counts as "for us" while a pre-decrypt error forwards.
+        for_us = False
         try:
             # Parse ANON_REQ: dest_hash(1) + client_pubkey(32) + encrypted_data
             if len(packet.payload) < 34:
-                return
+                return HandlerResult.not_for_us()
 
             dest_hash = packet.payload[0]
             our_hash = self.local_identity.get_public_key()[0]
             if dest_hash != our_hash:
-                return  # Not for us
+                return HandlerResult.not_for_us()  # Not for us
 
             client_pubkey = bytes(packet.payload[1:33])
             encrypted_data = bytes(packet.payload[33:])
@@ -152,20 +164,25 @@ class AnonRequestHandler(BaseHandler):
                 plaintext = CryptoUtils.mac_then_decrypt(aes_key, shared_secret, encrypted_data)
             except Exception as e:
                 self.log(f"[AnonReq] Failed to decrypt request: {e}")
-                return
+                return HandlerResult.not_for_us()
+
+            # Decryption succeeded: this ANON_REQ is genuinely for us. Consume it
+            # from here on regardless of sub-type or whether we choose to reply.
+            for_us = True
+
             # Firmware parity (simple_room_server): room servers do not subtype
             # dispatch ANON_REQ by plaintext byte 4. Their login payload is:
             # timestamp(4) + sync_since(4) + password...
             # so byte 4 is sync_since[0], not an anon request code.
             if getattr(self.login_handler, "is_room_server", False):
                 await self.login_handler(packet)
-                return
+                return HandlerResult.consumed()
 
             if len(plaintext) < 5:
                 # Too short to carry a sub-type byte; treat as login (let it
                 # apply its own length checks).
                 await self.login_handler(packet)
-                return
+                return HandlerResult.consumed()
 
             subtype = plaintext[4]
 
@@ -173,7 +190,7 @@ class AnonRequestHandler(BaseHandler):
             # i.e. an actual password. Delegate verbatim to the login handler.
             if subtype == 0x00 or subtype >= 0x20:
                 await self.login_handler(packet)
-                return
+                return HandlerResult.consumed()
 
             # Regions/owner/basic discovery: route-direct only (firmware parity).
             if subtype in (ANON_REQ_TYPE_REGIONS, ANON_REQ_TYPE_OWNER, ANON_REQ_TYPE_BASIC):
@@ -188,21 +205,23 @@ class AnonRequestHandler(BaseHandler):
                         f"[AnonReq] {kind} request from {client_hex} ignored "
                         f"(not route-direct — firmware only answers direct)"
                     )
-                    return
+                    return HandlerResult.consumed()
                 if not self.anon_limiter.allow(time.time()):
                     self.log(f"[AnonReq] {kind} request from {client_hex} rate limited, dropping")
-                    return
+                    return HandlerResult.consumed()
                 self.log(f"[AnonReq] {kind} request from {client_hex} -> replying")
                 await self._handle_discovery(
                     packet, client_identity, shared_secret, subtype, plaintext
                 )
-                return
+                return HandlerResult.consumed()
 
             # Unknown/invalid sub-type: ignore.
             self.log(f"[AnonReq] Unknown anon sub-type 0x{subtype:02X}, ignoring")
+            return HandlerResult.consumed()
 
         except Exception as e:
             self.log(f"[AnonReq] Error handling anon request: {e}")
+            return HandlerResult(authenticated=for_us)
 
     async def _handle_discovery(
         self,

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -18,6 +18,7 @@ from typing import Callable, Optional
 from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder
 from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE
 from .base import BaseHandler
+from .result import HandlerResult
 
 # Response codes
 RESP_SERVER_LOGIN_OK = 0x00  # Login successful
@@ -85,8 +86,19 @@ class LoginServerHandler(BaseHandler):
         """Set callback for sending response packets."""
         self._send_packet_callback = callback
 
-    async def __call__(self, packet: Packet) -> None:
-        """Handle ANON_REQ login packet from client."""
+    async def __call__(self, packet: Packet) -> HandlerResult:
+        """Handle ANON_REQ login packet from client.
+
+        Returns an authenticated HandlerResult when the request was decrypted for
+        this identity — i.e. it is genuinely addressed to us and the caller should
+        consume it (a failed password is still ours to reject, not a collision).
+        Returns a not-for-us result when it was not for us (wrong dest hash, or an
+        HMAC failure from a dest-hash collision), so the caller may forward/re-flood
+        it instead of dropping it.
+        """
+        # Flipped to True once decryption succeeds; used by the outer handler so a
+        # post-decrypt error still counts as "for us" while a pre-decrypt error forwards.
+        for_us = False
         try:
             # Debug: Log packet routing info
             path_data = packet.get_path_hashes_hex() if packet.path_len > 0 else []
@@ -98,7 +110,7 @@ class LoginServerHandler(BaseHandler):
             # Parse ANON_REQ structure: dest_hash(1) + client_pubkey(32) + encrypted_data
             if len(packet.payload) < 34:
                 self.log("[LoginServer] ANON_REQ packet too short")
-                return
+                return HandlerResult.not_for_us()
 
             dest_hash = packet.payload[0]
             client_pubkey = bytes(packet.payload[1:33])
@@ -107,7 +119,7 @@ class LoginServerHandler(BaseHandler):
             # Verify this is for us
             our_hash = self.local_identity.get_public_key()[0]
             if dest_hash != our_hash:
-                return  # Not for us
+                return HandlerResult.not_for_us()  # Not for us
 
             # Create client identity and calculate shared secret
             client_identity = Identity(client_pubkey)
@@ -118,16 +130,18 @@ class LoginServerHandler(BaseHandler):
 
             # Decrypt the login request
             try:
-                plaintext = CryptoUtils.mac_then_decrypt(
-                    aes_key, shared_secret, encrypted_data
-                )
+                plaintext = CryptoUtils.mac_then_decrypt(aes_key, shared_secret, encrypted_data)
             except Exception as e:
                 self.log(f"[LoginServer] Failed to decrypt login request: {e}")
-                return
+                return HandlerResult.not_for_us()
+
+            # Decryption succeeded: this ANON_REQ is genuinely for us. Consume it
+            # from here on regardless of parse/auth outcome.
+            for_us = True
 
             if len(plaintext) < 4:
                 self.log("[LoginServer] Decrypted data too short")
-                return
+                return HandlerResult.consumed()
 
             # Parse plaintext - two formats:
             # Repeater format: timestamp(4) + password(variable) + null
@@ -143,10 +157,8 @@ class LoginServerHandler(BaseHandler):
             if self.is_room_server:
                 # Room server format: sync_since(4) + password
                 if len(plaintext) < 8:
-                    self.log(
-                        "[LoginServer] Room server packet too short for sync_since field"
-                    )
-                    return
+                    self.log("[LoginServer] Room server packet too short for sync_since field")
+                    return HandlerResult.consumed()
                 sync_since = struct.unpack("<I", plaintext[4:8])[0]
 
                 # Find null terminator AFTER sync_since field (starting from byte 8)
@@ -171,9 +183,7 @@ class LoginServerHandler(BaseHandler):
                     null_idx = len(plaintext)
 
                 password_bytes = plaintext[4:null_idx]
-                self.log(
-                    f"[LoginServer] Repeater format: password from byte 4 to {null_idx}"
-                )
+                self.log(f"[LoginServer] Repeater format: password from byte 4 to {null_idx}")
 
             # Null-terminate password
             null_idx = password_bytes.find(b"\x00")
@@ -221,8 +231,11 @@ class LoginServerHandler(BaseHandler):
                 # Optionally send failure response (or just ignore)
                 # Most implementations just ignore failed attempts
 
+            return HandlerResult.consumed()
+
         except Exception as e:
             self.log(f"[LoginServer] Error handling login packet: {e}")
+            return HandlerResult(authenticated=for_us)
 
     async def _send_login_response(
         self,
@@ -251,9 +264,7 @@ class LoginServerHandler(BaseHandler):
             # is_admin: check if permission bits include admin bit (0x02)
             reply_data[6] = 1 if (permissions & 0x02) else 0
             reply_data[7] = permissions  # full permissions byte
-            struct.pack_into(
-                "<I", reply_data, 8, random.randint(0, 0xFFFFFFFF)
-            )  # random blob
+            struct.pack_into("<I", reply_data, 8, random.randint(0, 0xFFFFFFFF))  # random blob
             reply_data[12] = FIRMWARE_VER_LEVEL  # firmware version
 
             # Create response packet
@@ -303,9 +314,7 @@ class LoginServerHandler(BaseHandler):
                     route_type="flood",
                 )
                 packet_type_name = "RESPONSE(flood)"
-                self.log(
-                    "[LoginServer] Creating RESPONSE datagram (direct login, flood reply)"
-                )
+                self.log("[LoginServer] Creating RESPONSE datagram (direct login, flood reply)")
 
             # Debug: Log packet details
             self.log(

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -8,13 +8,11 @@ import struct
 from typing import Callable, Optional
 
 from openhop_core.protocol import PacketBuilder
-from openhop_core.protocol.constants import (
-    MAX_PATH_SIZE,
-    PAYLOAD_TYPE_REQ,
-    PAYLOAD_TYPE_RESPONSE,
-)
+from openhop_core.protocol.constants import MAX_PATH_SIZE, PAYLOAD_TYPE_REQ, PAYLOAD_TYPE_RESPONSE
 from openhop_core.protocol.crypto import CryptoUtils
 from openhop_core.protocol.packet_utils import PathUtils
+
+from .result import HandlerResult
 
 # Request type codes (matching C++ implementation)
 REQ_TYPE_GET_STATUS = 0x01
@@ -68,7 +66,7 @@ class ProtocolRequestHandler:
         self.request_handlers = request_handlers or {}
         self.log = log_fn if log_fn else lambda msg: None
 
-    async def __call__(self, packet):
+    async def __call__(self, packet) -> HandlerResult:
         """
         Process a protocol request packet.
 
@@ -76,11 +74,20 @@ class ProtocolRequestHandler:
             packet: Packet instance with REQ payload
 
         Returns:
-            Packet: RESPONSE packet to send, or None
+            HandlerResult: ``authenticated`` is True once the REQ has been
+            MAC-verified and decrypted for a concrete local client (the caller
+            must consume it even when no response is produced); False when the
+            one-byte dest prefix collided with ours but no local client
+            authenticated it, so the caller must leave the packet for the
+            forwarding engine. ``response`` carries the RESPONSE packet to send,
+            or None.
         """
+        # Flipped to True once decryption succeeds; used so a post-decrypt error
+        # still counts as "for us" while a pre-decrypt error is forwarded.
+        for_us = False
         try:
             if len(packet.payload) < 2:
-                return None
+                return HandlerResult.not_for_us()
 
             dest_hash = packet.payload[0]
             src_hash = packet.payload[1]
@@ -88,7 +95,7 @@ class ProtocolRequestHandler:
             # Verify this packet is for us
             our_hash = self.local_identity.get_public_key()[0]
             if dest_hash != our_hash:
-                return None
+                return HandlerResult.not_for_us()
 
             self.log(f"Processing REQ from 0x{src_hash:02X}")
 
@@ -96,7 +103,7 @@ class ProtocolRequestHandler:
             clients = self._get_clients(src_hash)
             if not clients:
                 self.log(f"REQ from unknown client 0x{src_hash:02X}")
-                return None
+                return HandlerResult.not_for_us()
 
             # Decrypt request
             encrypted_data = packet.payload[2:]
@@ -128,12 +135,17 @@ class ProtocolRequestHandler:
                         f"Failed to decrypt REQ for all {decrypt_attempted} candidate(s) "
                         f"with src hash 0x{src_hash:02X}"
                     )
-                return None
+                return HandlerResult.not_for_us()
+
+            # MAC verified for a concrete client: this REQ is genuinely for us.
+            # Consume it from here on even if parsing fails or no response is built —
+            # forwarding a packet that is cryptographically ours would be wrong.
+            for_us = True
 
             # Parse request
             if len(plaintext) < 5:
                 self.log("REQ packet too short")
-                return None
+                return HandlerResult.consumed()
 
             timestamp = struct.unpack("<I", plaintext[0:4])[0]
             req_type = plaintext[4]
@@ -142,20 +154,18 @@ class ProtocolRequestHandler:
             self.log(f"REQ type=0x{req_type:02X}, timestamp={timestamp}")
 
             # Handle request
-            response_data = await self._handle_request(
-                client, timestamp, req_type, req_data
-            )
+            response_data = await self._handle_request(client, timestamp, req_type, req_data)
 
             if response_data:
-                return self._build_response(
-                    packet, client, response_data, shared_secret
+                return HandlerResult.consumed(
+                    self._build_response(packet, client, response_data, shared_secret)
                 )
 
-            return None
+            return HandlerResult.consumed()
 
         except Exception as e:
             self.log(f"Error processing REQ: {e}")
-            return None
+            return HandlerResult(authenticated=for_us)
 
     def _get_clients(self, src_hash: int):
         """Get all client candidates by source hash."""
@@ -204,9 +214,7 @@ class ProtocolRequestHandler:
 
         return None
 
-    async def _handle_request(
-        self, client, timestamp: int, req_type: int, req_data: bytes
-    ):
+    async def _handle_request(self, client, timestamp: int, req_type: int, req_data: bytes):
         """
         Handle request and generate response.
 
@@ -237,9 +245,7 @@ class ProtocolRequestHandler:
         self.log(f"No handler for request type 0x{req_type:02X}")
         return None
 
-    def _build_response(
-        self, original_packet, client, response_data: bytes, shared_secret: bytes
-    ):
+    def _build_response(self, original_packet, client, response_data: bytes, shared_secret: bytes):
         """
         Build RESPONSE packet to send back to client.
 
@@ -274,9 +280,7 @@ class ProtocolRequestHandler:
                 raw_path = getattr(original_packet, "path", None) or b""
                 path_list = list(raw_path[:path_byte_len]) if path_byte_len else []
                 path_len_encoded_arg = (
-                    path_len_byte
-                    if PathUtils.is_valid_path_len(path_len_byte)
-                    else None
+                    path_len_byte if PathUtils.is_valid_path_len(path_len_byte) else None
                 )
                 reply_packet = PacketBuilder.create_path_return(
                     dest_hash=client_hash,

--- a/src/openhop_core/node/handlers/result.py
+++ b/src/openhop_core/node/handlers/result.py
@@ -1,0 +1,37 @@
+"""Shared result type returned by receive handlers."""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class HandlerResult:
+    """Uniform outcome returned by every receive handler.
+
+    A single result type lets callers — the local node, the companion bridge,
+    and the repeater router — make one consistent forwarding decision instead of
+    interpreting handler-specific return values. New fields can be added here
+    without touching call sites that only care about ``authenticated``.
+
+    Attributes:
+        authenticated: True once the packet was MAC-verified/decrypted for a
+            concrete local identity, so the caller must consume it (stop
+            forwarding) even when there is no reply. False means no local
+            identity proved ownership — e.g. a one-byte prefix collision — and
+            the caller must leave the packet available to the forwarding engine.
+        response: An optional packet to transmit in reply (e.g. a request
+            response or path return); None when no reply is warranted.
+    """
+
+    authenticated: bool
+    response: Optional[Any] = None
+
+    @classmethod
+    def not_for_us(cls) -> "HandlerResult":
+        """No local identity authenticated the packet; leave it for forwarding."""
+        return cls(authenticated=False)
+
+    @classmethod
+    def consumed(cls, response: Optional[Any] = None) -> "HandlerResult":
+        """Authenticated for a local identity; optionally reply with ``response``."""
+        return cls(authenticated=True, response=response)

--- a/src/openhop_core/node/handlers/text.py
+++ b/src/openhop_core/node/handlers/text.py
@@ -1,13 +1,6 @@
 import asyncio
 
-from ...protocol import (
-    CryptoUtils,
-    Identity,
-    Packet,
-    PacketBuilder,
-    PacketTimingUtils,
-    PathUtils,
-)
+from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder, PacketTimingUtils, PathUtils
 from ...protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_TXT_MSG,
@@ -15,6 +8,7 @@ from ...protocol.constants import (
     TXT_TYPE_SIGNED_PLAIN,
 )
 from .base import BaseHandler
+from .result import HandlerResult
 
 # Stagger between a multi-ack and the normal ACK on a known direct route, mirroring the
 # firmware's `d += 300` in BaseChatMesh::sendAckTo.
@@ -41,9 +35,7 @@ class TextMessageHandler(BaseHandler):
         self.send_packet = send_packet_fn
         self.event_service = event_service  # Event service for broadcasting
         self.command_response_callback = None  # Callback for command responses
-        self.radio_config = (
-            radio_config or {}
-        )  # Radio configuration for airtime calculations
+        self.radio_config = radio_config or {}  # Radio configuration for airtime calculations
         self.multi_acks = 0  # multi_acks pref (0=off); set via set_multi_acks()
 
     def set_command_response_callback(self, callback):
@@ -113,9 +105,7 @@ class TextMessageHandler(BaseHandler):
         """
 
         def airtime(pkt) -> float:
-            return PacketTimingUtils.estimate_airtime_ms(
-                len(pkt.write_to()), self.radio_config
-            )
+            return PacketTimingUtils.estimate_airtime_ms(len(pkt.write_to()), self.radio_config)
 
         if is_flood:
             incoming_path = list(packet.path if hasattr(packet, "path") else [])
@@ -151,9 +141,7 @@ class TextMessageHandler(BaseHandler):
             # known reverse path (mirrors firmware sendAckTo OUT_PATH_UNKNOWN -> sendFloodScoped;
             # a path-less direct ACK would not be relayed past direct neighbours). The
             # dispatcher applies flood scope at send time.
-            ack_packet = PacketBuilder.create_ack_from_bytes(
-                ack_hash, route_type="flood"
-            )
+            ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash, route_type="flood")
             delay_ms = PacketTimingUtils.calc_flood_timeout_ms(airtime(ack_packet))
             self.log(f"FLOOD ACK timing (no out_path) - delay:{delay_ms:.1f}ms")
             return [(ack_packet, delay_ms / 1000.0)]
@@ -163,23 +151,17 @@ class TextMessageHandler(BaseHandler):
         ack_packet = PacketBuilder.create_ack_from_bytes(
             ack_hash, path=out_path, path_len_encoded=out_path_len
         )
-        base_delay_ms = PacketTimingUtils.calc_direct_timeout_ms(
-            airtime(ack_packet), path_hops
-        )
+        base_delay_ms = PacketTimingUtils.calc_direct_timeout_ms(airtime(ack_packet), path_hops)
 
         if self.multi_acks <= 0:
-            self.log(
-                f"DIRECT ACK timing (routed) - delay:{base_delay_ms:.1f}ms, hops:{path_hops}"
-            )
+            self.log(f"DIRECT ACK timing (routed) - delay:{base_delay_ms:.1f}ms, hops:{path_hops}")
             return [(ack_packet, base_delay_ms / 1000.0)]
 
         # multi-ack fires at the base delay; the normal ACK is staggered later
         multi_packet = PacketBuilder.create_multi_ack(
             ack_hash, remaining=1, path=out_path, path_len_encoded=out_path_len
         )
-        self.log(
-            f"DIRECT multi-ack timing - base_delay:{base_delay_ms:.1f}ms, hops:{path_hops}"
-        )
+        self.log(f"DIRECT multi-ack timing - base_delay:{base_delay_ms:.1f}ms, hops:{path_hops}")
         return [
             (multi_packet, base_delay_ms / 1000.0),
             (ack_packet, (base_delay_ms + MULTI_ACK_STAGGER_MS) / 1000.0),
@@ -197,10 +179,19 @@ class TextMessageHandler(BaseHandler):
         except Exception as ack_send_error:
             self.log(f"Failed to send ACK packet: {ack_send_error}")
 
-    async def __call__(self, packet: Packet) -> None:
+    async def __call__(self, packet: Packet) -> HandlerResult:
+        """Process an inbound TXT_MSG.
+
+        Returns an authenticated HandlerResult when the message was decrypted for
+        one of our contacts — i.e. it is genuinely addressed to this identity and
+        the caller should consume it. Returns a not-for-us result when it could
+        not be decrypted (payload too short, unknown sender, or HMAC failure from
+        a dest-hash collision), so the caller may forward/re-flood it instead of
+        dropping it.
+        """
         if len(packet.payload) < 4:
             self.log("TXT_MSG payload too short to decrypt")
-            return
+            return HandlerResult.not_for_us()
 
         src_hash = packet.payload[1]
         # Collect all contacts whose public key first byte matches src_hash (hash collision
@@ -216,7 +207,7 @@ class TextMessageHandler(BaseHandler):
 
         if not candidates:
             self.log(f"No contact found for src hash: {src_hash:02X}")
-            return
+            return HandlerResult.not_for_us()
 
         payload = packet.payload[2:]  # Skip dest_hash and src_hash
         matched_contact = None
@@ -242,11 +233,15 @@ class TextMessageHandler(BaseHandler):
                 f"Decryption failed: Invalid HMAC for all {len(candidates)} contact(s) "
                 f"with src hash {src_hash:02X}"
             )
-            return
+            return HandlerResult.not_for_us()
 
+        # Decryption succeeded: this message is genuinely for us. From here on we
+        # return a consumed result so the caller keeps it even if the plaintext
+        # turns out to be malformed — forwarding a packet that is cryptographically
+        # ours is wrong.
         if len(decrypted) < 5:  # timestamp(4) + flags(1) minimum
             self.log("Decrypted message too short for CRC calculation")
-            return
+            return HandlerResult.consumed()
 
         # Extract fields from decrypted data
         timestamp = decrypted[:4]  # First 4 bytes are the timestamp
@@ -260,7 +255,7 @@ class TextMessageHandler(BaseHandler):
             # onSignedMessageRecv(&data[5], &data[9])).
             if len(decrypted) < 9:
                 self.log("Signed message too short for author prefix")
-                return
+                return HandlerResult.consumed()
             sender_prefix = bytes(decrypted[5:9])
             message_body = decrypted[9:]
 
@@ -328,11 +323,9 @@ class TextMessageHandler(BaseHandler):
         if self.command_response_callback:
             try:
                 self.command_response_callback(decoded_msg, matched_contact)
-                self.log(
-                    f"Command response captured from {matched_contact.name}: {decoded_msg}"
-                )
+                self.log(f"Command response captured from {matched_contact.name}: {decoded_msg}")
                 # Don't save command responses to regular message database
-                return
+                return HandlerResult.consumed()
             except Exception as e:
                 self.log(f"Error in command response callback: {e}")
                 # Continue with normal message processing if callback fails
@@ -343,8 +336,7 @@ class TextMessageHandler(BaseHandler):
         # Create message event data for the app to handle storage and deduplication
         normalized_timestamp = (message_timestamp // 1000) * 1000
         content_hash = (
-            hash(f"{matched_contact.name}_{decoded_msg}_{normalized_timestamp}")
-            & 0xFFFFFFFF
+            hash(f"{matched_contact.name}_{decoded_msg}_{normalized_timestamp}") & 0xFFFFFFFF
         )
         message_id = f"rx_{normalized_timestamp}_{content_hash:08x}"
 
@@ -382,3 +374,4 @@ class TextMessageHandler(BaseHandler):
 
         # Set packet.decrypted for ACK processing
         packet.decrypted = {"text": decoded_msg}
+        return HandlerResult.consumed()

--- a/tests/test_anon_request_handler.py
+++ b/tests/test_anon_request_handler.py
@@ -164,6 +164,56 @@ class TestAnonRequestHandler:
 
         assert len(sent) == 1
 
+    # -- consume-vs-forward return contract (#353) --------------------------
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_decrypted_for_us(self):
+        """A request that decrypts for our identity is consumed (return True)."""
+        assert (await self.handler(self._build_login(route_type="flood"))).authenticated is True
+        assert (
+            await self.handler(self._build_discovery(ANON_REQ_TYPE_REGIONS))
+        ).authenticated is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_for_us_but_reply_declined(self):
+        """Rate-limited / non-direct discovery is still ours — consume, don't forward."""
+        # Non-direct discovery: firmware only answers direct, but it decrypted for us.
+        assert (
+            await self.handler(self._build_discovery(ANON_REQ_TYPE_OWNER, route_type="flood"))
+        ).authenticated is True
+        assert self.sent == []
+        # Exhaust the limiter, then a direct discovery is declined but still consumed.
+        for _ in range(4):
+            self.limiter.allow(1000.0)
+        assert (
+            await self.handler(self._build_discovery(ANON_REQ_TYPE_OWNER))
+        ).authenticated is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_dest_hash_mismatch(self):
+        """A packet addressed to a different identity is not ours (forward)."""
+        pkt = self._build_login(route_type="flood")
+        pkt.payload[0] = (pkt.payload[0] + 1) & 0xFF  # break the dest-hash match
+        assert (await self.handler(pkt)).authenticated is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_decrypt_failure_collision(self):
+        """dest hash matches ours but HMAC fails (hash collision): not ours, forward (#353)."""
+        pkt = self._build_login(route_type="flood")
+        pkt.payload[-1] ^= 0xFF  # corrupt ciphertext/MAC so decryption fails
+        assert (await self.handler(pkt)).authenticated is False
+        assert self.sent == []
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_short_payload(self):
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_ANON_REQ << 2) | ROUTE_TYPE_FLOOD
+        pkt.payload = bytearray([0x01, 0x02])
+        pkt.payload_len = 2
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        assert (await self.handler(pkt)).authenticated is False
+
     # -- regions / owner / basic responders --------------------------------
 
     @pytest.mark.asyncio

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -19,13 +19,7 @@ from openhop_core.node.handlers import (
     TraceHandler,
 )
 from openhop_core.node.handlers.login_server import FIRMWARE_VER_LEVEL
-from openhop_core.protocol import (
-    CryptoUtils,
-    Identity,
-    LocalIdentity,
-    Packet,
-    PacketBuilder,
-)
+from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, PacketBuilder
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
@@ -287,6 +281,53 @@ class TestTextMessageHandler:
         assert len(ack_packet.payload) == 6
         assert int.from_bytes(ack_packet.payload[:4], "little") == ack_crc
 
+    # -- consume-vs-forward return contract (#353) --------------------------
+
+    def _build_dm_to_self(self, sender, text="hi", route="flood"):
+        """Build a DM addressed to this handler's identity, sent by ``sender``."""
+        from openhop_core.protocol.packet_builder import PacketBuilder
+
+        class _SendContact:
+            def __init__(self, pubkey_hex):
+                self.public_key = pubkey_hex
+                self.out_path = []
+                self.out_path_len = -1
+
+        receiver_contact = _SendContact(self.local_identity.get_public_key().hex())
+        packet, _ = PacketBuilder.create_text_message(
+            receiver_contact, sender, text, attempt=0, message_type=route
+        )
+        return packet
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_decrypted_for_known_contact(self):
+        """A DM that decrypts for a known contact is genuinely ours -> consume (True)."""
+        sender = LocalIdentity()
+        packet = self._build_dm_to_self(sender)
+        self.contacts.contacts = [
+            MockContact(public_key=sender.get_public_key().hex(), name="sender")
+        ]
+        assert (await self.handler(packet)).authenticated is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_sender_unknown(self):
+        """No contact matches the src hash: can't decrypt -> forward (False)."""
+        sender = LocalIdentity()
+        packet = self._build_dm_to_self(sender)
+        self.contacts.contacts = []
+        assert (await self.handler(packet)).authenticated is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_decrypt_failure_collision(self):
+        """src hash matches a contact but HMAC fails (collision): forward (False) (#353)."""
+        sender = LocalIdentity()
+        packet = self._build_dm_to_self(sender)
+        self.contacts.contacts = [
+            MockContact(public_key=sender.get_public_key().hex(), name="sender")
+        ]
+        packet.payload[-1] ^= 0xFF  # corrupt ciphertext/MAC so decryption fails
+        assert (await self.handler(packet)).authenticated is False
+
     def _make_direct_dm_with_path(self, text="multi ack route"):
         """Build a direct DM addressed to the handler, with the sender registered as a
         contact that has a known multi-hop out_path. Returns (packet, ack_crc, out_path,
@@ -524,9 +565,7 @@ class TestPathHandler:
         self.log_fn = MagicMock()
         self.ack_handler = AckHandler(self.log_fn)
         self.protocol_response_handler = MagicMock()
-        self.handler = PathHandler(
-            self.log_fn, self.ack_handler, self.protocol_response_handler
-        )
+        self.handler = PathHandler(self.log_fn, self.ack_handler, self.protocol_response_handler)
 
     def test_payload_type(self):
         """Test path handler payload type."""
@@ -613,9 +652,7 @@ class TestLoginResponseHandler:
         self.log_fn = MagicMock()
         self.send_packet_fn = AsyncMock()
         self.local_identity = LocalIdentity()
-        self.handler = LoginResponseHandler(
-            self.local_identity, self.contacts, self.log_fn
-        )
+        self.handler = LoginResponseHandler(self.local_identity, self.contacts, self.log_fn)
 
     def test_payload_type(self):
         """Test login response handler payload type."""
@@ -636,9 +673,7 @@ class TestProtocolResponseHandler:
         self.log_fn = MagicMock()
         self.send_packet_fn = AsyncMock()
         self.local_identity = LocalIdentity()
-        self.handler = ProtocolResponseHandler(
-            self.log_fn, self.local_identity, self.contacts
-        )
+        self.handler = ProtocolResponseHandler(self.log_fn, self.local_identity, self.contacts)
 
     def test_payload_type(self):
         """Test protocol response handler payload type."""
@@ -725,9 +760,7 @@ class TestProtocolResponseHandler:
 
         callback_calls = []
 
-        async def on_path_updated(
-            pub: bytes, path_len: int, path_bytes_arg: bytes
-        ) -> None:
+        async def on_path_updated(pub: bytes, path_len: int, path_bytes_arg: bytes) -> None:
             callback_calls.append((pub, path_len, path_bytes_arg))
 
         handler.set_contact_path_updated_callback(on_path_updated)
@@ -780,9 +813,7 @@ class TestProtocolResponseHandler:
 
         callback_calls = []
 
-        async def on_path_updated(
-            pub: bytes, path_len: int, path_bytes_arg: bytes
-        ) -> None:
+        async def on_path_updated(pub: bytes, path_len: int, path_bytes_arg: bytes) -> None:
             callback_calls.append((pub, path_len, path_bytes_arg))
 
         handler.set_contact_path_updated_callback(on_path_updated)
@@ -830,9 +861,7 @@ class TestProtocolResponseHandler:
         reply[4] = 0x00  # RESP_SERVER_LOGIN_OK
         client_hash = local_identity.get_public_key()[0]
         server_hash = server_pubkey[0]
-        secret = Identity(server_pubkey).calc_shared_secret(
-            local_identity.get_private_key()
-        )
+        secret = Identity(server_pubkey).calc_shared_secret(local_identity.get_private_key())
         pkt = PacketBuilder.create_path_return(
             dest_hash=client_hash,
             src_hash=server_hash,
@@ -878,6 +907,45 @@ class TestProtocolRequestHandler:
         c.out_path_len = -1
         return c
 
+    @pytest.mark.asyncio
+    async def test_call_not_for_us_returns_for_us_false(self):
+        """A REQ whose dest hash does not match ours is not for us."""
+        packet = Packet()
+        packet.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        our_hash = self.local_identity.get_public_key()[0]
+        wrong_dest = our_hash ^ 0xFF
+        packet.payload = bytes([wrong_dest, 0x01, 0x02, 0x03])
+
+        result = await self.handler(packet)
+
+        assert result.authenticated is False
+        assert result.response is None
+
+    @pytest.mark.asyncio
+    async def test_call_prefix_match_but_undecryptable_returns_for_us_false(self):
+        """Dest prefix collides with ours but no client authenticates."""
+        packet = Packet()
+        packet.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        our_hash = self.local_identity.get_public_key()[0]
+        # dest matches us, but MockContactBook has no matching client / secret,
+        # so decryption cannot succeed -> must report not-for-us for forwarding.
+        packet.payload = bytes([our_hash, 0x01]) + b"\x00" * 16
+
+        result = await self.handler(packet)
+
+        assert result.authenticated is False
+        assert result.response is None
+
+    @pytest.mark.asyncio
+    async def test_call_short_payload_returns_for_us_false(self):
+        packet = Packet()
+        packet.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
+        packet.payload = b"\x01"
+
+        result = await self.handler(packet)
+
+        assert result.authenticated is False
+
     def test_flood_req_returns_path_packet(self):
         """REQ via flood → path-return PATH packet (firmware createPathReturn + sendFlood)."""
         peer_identity = LocalIdentity()
@@ -893,13 +961,9 @@ class TestProtocolRequestHandler:
         assert original.is_route_flood()
 
         response_data = b"\x39\x30\x00\x00\x00"  # timestamp LE + req_type 0
-        shared_secret = peer_identity.calc_shared_secret(
-            self.local_identity.get_private_key()
-        )
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
 
-        result = self.handler._build_response(
-            original, client, response_data, shared_secret
-        )
+        result = self.handler._build_response(original, client, response_data, shared_secret)
 
         assert result is not None
         assert result.get_payload_type() == PAYLOAD_TYPE_PATH
@@ -913,9 +977,7 @@ class TestProtocolRequestHandler:
 
         peer_identity = LocalIdentity()
         client = self._client_with_key(peer_identity.get_public_key())
-        shared_secret = peer_identity.calc_shared_secret(
-            self.local_identity.get_private_key()
-        )
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
 
         original = Packet()
         original.header = (ROUTE_TYPE_FLOOD & 0x03) | (PAYLOAD_TYPE_REQ << 2)
@@ -924,9 +986,7 @@ class TestProtocolRequestHandler:
         original.path = bytearray([0x01, 0x02, 0x03, 0x04])
         response_data = b"\x00\x00\x00\x00\x00"
 
-        result = self.handler._build_response(
-            original, client, response_data, shared_secret
-        )
+        result = self.handler._build_response(original, client, response_data, shared_secret)
 
         assert result is not None
         assert result.get_payload_type() == PAYLOAD_TYPE_PATH
@@ -939,9 +999,7 @@ class TestProtocolRequestHandler:
         client = self._client_with_key(peer_identity.get_public_key())
         client.out_path = b""
         client.out_path_len = -1
-        shared_secret = peer_identity.calc_shared_secret(
-            self.local_identity.get_private_key()
-        )
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
 
         original = Packet()
         original.header = (ROUTE_TYPE_DIRECT & 0x03) | (PAYLOAD_TYPE_REQ << 2)
@@ -950,9 +1008,7 @@ class TestProtocolRequestHandler:
         assert not original.is_route_flood()
 
         response_data = b"\x01\x00\x00\x00\x00"
-        result = self.handler._build_response(
-            original, client, response_data, shared_secret
-        )
+        result = self.handler._build_response(original, client, response_data, shared_secret)
 
         assert result is not None
         assert result.get_payload_type() == PAYLOAD_TYPE_RESPONSE
@@ -965,9 +1021,7 @@ class TestProtocolRequestHandler:
         client = self._client_with_key(peer_identity.get_public_key())
         client.out_path = bytes([0x01, 0x02])
         client.out_path_len = 2
-        shared_secret = peer_identity.calc_shared_secret(
-            self.local_identity.get_private_key()
-        )
+        shared_secret = peer_identity.calc_shared_secret(self.local_identity.get_private_key())
 
         original = Packet()
         original.header = (ROUTE_TYPE_DIRECT & 0x03) | (PAYLOAD_TYPE_REQ << 2)
@@ -975,9 +1029,7 @@ class TestProtocolRequestHandler:
         original.path = bytearray()
 
         response_data = b"\x02\x00\x00\x00\x00"
-        result = self.handler._build_response(
-            original, client, response_data, shared_secret
-        )
+        result = self.handler._build_response(original, client, response_data, shared_secret)
 
         assert result is not None
         assert result.get_payload_type() == PAYLOAD_TYPE_RESPONSE
@@ -1002,9 +1054,7 @@ class TestTraceHandler:
 
     def test_parse_trace_payload_one_byte_hashes(self):
         """flags=0: 1 byte per hop; path 0x01 0x02 = two hops."""
-        payload = struct.pack("<IIB", 0x11111111, 0x22222222, 0x00) + bytes(
-            [0x01, 0x02]
-        )
+        payload = struct.pack("<IIB", 0x11111111, 0x22222222, 0x00) + bytes([0x01, 0x02])
         r = self.handler._parse_trace_payload(payload)
         assert r["valid"]
         assert r["path_hash_width"] == 1
@@ -1081,9 +1131,7 @@ async def test_handlers_can_be_called():
 
     handlers = [
         AckHandler(log_fn),
-        TextMessageHandler(
-            local_identity, contacts, log_fn, send_packet_fn, event_service
-        ),
+        TextMessageHandler(local_identity, contacts, log_fn, send_packet_fn, event_service),
         AdvertHandler(log_fn),
         PathHandler(log_fn),
         GroupTextHandler(local_identity, contacts, log_fn, send_packet_fn),
@@ -1103,9 +1151,7 @@ async def test_handlers_can_be_called():
         except Exception as e:
             # Some handlers may raise exceptions due to incomplete setup,
             # but they should be callable
-            assert isinstance(
-                e, (ValueError, AttributeError, TypeError)
-            )  # Expected exceptions
+            assert isinstance(e, (ValueError, AttributeError, TypeError))  # Expected exceptions
 
 
 # AnonReqResponseHandler Tests (separate from LoginResponseHandler)
@@ -1161,9 +1207,7 @@ class TestLoginServerHandler:
 
         # Calculate shared secret (client side)
         server_id = Identity(server_pubkey)
-        shared_secret = server_id.calc_shared_secret(
-            self.client_identity_local.get_private_key()
-        )
+        shared_secret = server_id.calc_shared_secret(self.client_identity_local.get_private_key())
         aes_key = shared_secret[:16]
 
         # Repeater format plaintext: timestamp(4) + password + null
@@ -1200,6 +1244,33 @@ class TestLoginServerHandler:
         from openhop_core.node.handlers.login_server import LoginServerHandler
 
         assert LoginServerHandler.payload_type() == PAYLOAD_TYPE_ANON_REQ
+
+    # -- consume-vs-forward return contract (#353) --------------------------
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_decrypted_for_us(self):
+        """A login that decrypts for us is consumed (True), even on auth failure."""
+        assert (
+            await self.handler(self._build_login_packet(password="admin123"))
+        ).authenticated is True
+        # Wrong password still decrypted for us — it's ours to reject, not a collision.
+        self.auth_callback.return_value = (False, 0x00)
+        assert (await self.handler(self._build_login_packet(password="nope"))).authenticated is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_dest_hash_mismatch(self):
+        """A login addressed to a different identity is not ours (forward)."""
+        pkt = self._build_login_packet()
+        pkt.payload[0] = (pkt.payload[0] + 1) & 0xFF
+        assert (await self.handler(pkt)).authenticated is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_decrypt_failure_collision(self):
+        """dest hash matches ours but HMAC fails (collision): forward (False) (#353)."""
+        pkt = self._build_login_packet()
+        pkt.payload[-1] ^= 0xFF  # corrupt ciphertext/MAC
+        assert (await self.handler(pkt)).authenticated is False
+        assert self.sent_packets == []
 
     @pytest.mark.asyncio
     async def test_flood_login_sends_path_packet(self):
@@ -1255,9 +1326,7 @@ class TestLoginServerHandler:
 
         # Decrypt the PATH payload to verify inner structure
         client_id = Identity(self.client_identity_local.get_public_key())
-        shared_secret = client_id.calc_shared_secret(
-            self.server_identity.get_private_key()
-        )
+        shared_secret = client_id.calc_shared_secret(self.server_identity.get_private_key())
         aes_key = shared_secret[:16]
 
         # PATH payload: dest_hash(1) + src_hash(1) + mac_and_ciphertext
@@ -1341,9 +1410,7 @@ class TestLoginServerHandler:
 
         # Decrypt and verify is_admin field
         client_id = Identity(self.client_identity_local.get_public_key())
-        shared_secret = client_id.calc_shared_secret(
-            self.server_identity.get_private_key()
-        )
+        shared_secret = client_id.calc_shared_secret(self.server_identity.get_private_key())
         aes_key = shared_secret[:16]
         encrypted_part = bytes(response_pkt.payload[2:])
         plaintext = CryptoUtils.mac_then_decrypt(aes_key, shared_secret, encrypted_part)
@@ -1371,9 +1438,7 @@ class TestLoginServerHandler:
     async def test_flood_login_with_path_includes_path_in_response(self):
         """Flood login with path hashes → PATH response includes those hashes."""
         path_hashes = [0xAA, 0xBB]
-        pkt = self._build_login_packet(
-            password="admin123", route_type="flood", path=path_hashes
-        )
+        pkt = self._build_login_packet(password="admin123", route_type="flood", path=path_hashes)
         # path_len encodes hash size and count: (hash_size-1)<<6 | count
         # For 1-byte hashes with 2 hops: (0<<6) | 2 = 2
         pkt.path_len = 2
@@ -1386,9 +1451,7 @@ class TestLoginServerHandler:
 
         # Decrypt and verify path is included
         client_id = Identity(self.client_identity_local.get_public_key())
-        shared_secret = client_id.calc_shared_secret(
-            self.server_identity.get_private_key()
-        )
+        shared_secret = client_id.calc_shared_secret(self.server_identity.get_private_key())
         aes_key = shared_secret[:16]
         encrypted_part = bytes(response_pkt.payload[2:])
         plaintext = CryptoUtils.mac_then_decrypt(aes_key, shared_secret, encrypted_part)


### PR DESCRIPTION
Introduce a single HandlerResult type returned by every receive handler (text, login, anon-request, protocol-request) and the companion bridge. It carries authenticated ownership plus an optional response packet, so callers consume a packet only when a local identity MAC-verifies it. A one-byte destination-prefix collision with a remote node — or a forged packet — is then left for the forwarding engine instead of being swallowed.

- protocol-request: replace the ambiguous Optional[Packet] return with a result that separates "not for us" from "for us, no reply"
- companion bridge: report authenticated handling instead of returning None
- unify the previously boolean text/login/anon handlers onto HandlerResult