### PR TITLE
fix(modem): support CAD symbol counts over TCP and USB

### DIFF
--- a/src/openhop_core/hardware/protocol_constants.py
+++ b/src/openhop_core/hardware/protocol_constants.py
@@ -86,6 +86,18 @@ RADIO_CONFIG_SIZE = struct.calcsize(RADIO_CONFIG_FMT)
 STATUS_RESP_FMT = "<IIIIhhhbB"
 STATUS_RESP_SIZE = struct.calcsize(STATUS_RESP_FMT)
 
+# RadioLib CAD symbol-count encoding used by CMD_SET_CAD_PARAMS.
+CAD_SYMBOL_CODES = {1: 0x00, 2: 0x01, 4: 0x02, 8: 0x03, 16: 0x04}
+
+
+def build_cad_params_payload(cad_symbol_num: int, peak: int, min_val: int) -> bytes:
+    """Build the firmware CAD-parameter payload for a supported symbol count."""
+    try:
+        symbol_code = CAD_SYMBOL_CODES[int(cad_symbol_num)]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("cad_symbol_num must be one of: 1, 2, 4, 8, 16") from exc
+    return bytes([symbol_code, int(peak) & 0xFF, int(min_val) & 0xFF, 0x00])
+
 
 # ─── Framing helpers ─────────────────────────────────────────────────
 
@@ -176,7 +188,9 @@ __all__ = [
     "RADIO_CONFIG_SIZE",
     "STATUS_RESP_FMT",
     "STATUS_RESP_SIZE",
+    "CAD_SYMBOL_CODES",
     # Framing
     "crc16_ccitt",
     "build_frame",
+    "build_cad_params_payload",
 ]

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -67,6 +67,7 @@ from .protocol_constants import (
     RADIO_CONFIG_FMT,
     STATUS_RESP_FMT,
     STATUS_RESP_SIZE,
+    build_cad_params_payload,
     build_frame,
     crc16_ccitt,
 )
@@ -149,6 +150,7 @@ class TCPLoRaRadio(_RadioBase):
         # from construction time even when never customised.
         self._custom_cad_peak: Optional[int] = None
         self._custom_cad_min: Optional[int] = None
+        self._custom_cad_symbol_num: Optional[int] = None
 
         # Signal metrics
         self.last_rssi: int = -99
@@ -460,30 +462,29 @@ class TCPLoRaRadio(_RadioBase):
         det_min: Optional[int] = None,
         timeout: float = 1.0,
         calibration: bool = False,
+        cad_symbol_num: Optional[int] = None,
     ) -> bool:
         """Public CAD interface compatible with sx1262_wrapper.perform_cad().
 
         When det_peak/det_min are supplied (e.g. by the repeater's CAD
-        calibration tool), program the chip with those thresholds via
-        CMD_SET_CAD_PARAMS before running the scan. Without this each
-        calibration sample would silently fall back to whatever thresholds
-        were last installed, defeating the sweep.
+        calibration tool), program the chip with those thresholds and the
+        requested symbol count via CMD_SET_CAD_PARAMS before running the scan.
         """
+        if cad_symbol_num is None:
+            cad_symbol_num = self._custom_cad_symbol_num or 2
+        cad_symbol_num = int(cad_symbol_num)
+
         if det_peak is not None and det_min is not None:
             new_peak = int(det_peak)
             new_min = int(det_min)
-            # Skip the firmware roundtrip when thresholds haven't changed
-            # since the previous call. Saves ~50-80 ms per CAD during the
-            # repeated-sample phase of the calibration sweep.
-            if new_peak != self._custom_cad_peak or new_min != self._custom_cad_min:
-                payload = bytes(
-                    [
-                        0x01,  # symNum: CAD_ON_2_SYMB
-                        new_peak & 0xFF,
-                        new_min & 0xFF,
-                        0x00,  # exitMode: STDBY
-                    ]
-                )
+            # Skip the firmware roundtrip when all CAD parameters match the
+            # previous call. Changing only symbol count must still be pushed.
+            if (
+                new_peak != self._custom_cad_peak
+                or new_min != self._custom_cad_min
+                or cad_symbol_num != self._custom_cad_symbol_num
+            ):
+                payload = build_cad_params_payload(cad_symbol_num, new_peak, new_min)
                 await self._send_command(
                     CMD_SET_CAD_PARAMS,
                     payload,
@@ -492,6 +493,7 @@ class TCPLoRaRadio(_RadioBase):
                 )
                 self._custom_cad_peak = new_peak
                 self._custom_cad_min = new_min
+                self._custom_cad_symbol_num = cad_symbol_num
 
         # Calibration engine passes 0.3s, which is tight for TCP transport
         # with the firmware's CAD-prime delay; floor it so the sweep gets
@@ -1070,7 +1072,7 @@ class TCPLoRaRadio(_RadioBase):
             return True
         if self._event_loop is None or not self._event_loop.is_running():
             return True
-        payload = bytes([0x01, peak & 0xFF, min_val & 0xFF, 0x00])
+        payload = build_cad_params_payload(self._custom_cad_symbol_num or 2, peak, min_val)
         ok = self._run_async_safe(
             self._send_command(
                 CMD_SET_CAD_PARAMS, payload, expect_cmd=CMD_CAD_PARAMS_RESP, timeout=3.0
@@ -1079,6 +1081,12 @@ class TCPLoRaRadio(_RadioBase):
         )
         logger.info(f"CAD thresholds pushed peak={peak} min={min_val}: {'OK' if ok else 'TIMEOUT'}")
         return ok
+
+    def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> bool:
+        """Store a validated CAD symbol count for calls that omit an override."""
+        build_cad_params_payload(cad_symbol_num, 0, 0)
+        self._custom_cad_symbol_num = int(cad_symbol_num)
+        return True
 
     def clear_custom_cad_thresholds(self) -> None:
         self._custom_cad_peak = None

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -73,6 +73,7 @@ from .protocol_constants import (
     WIFI_MODE_OFFLINE,
     WIFI_MODE_STA_CONNECTED,
     WIFI_MODE_STA_CONNECTING,
+    build_cad_params_payload,
     build_frame,
     crc16_ccitt,
 )
@@ -165,6 +166,7 @@ class USBLoRaRadio(_RadioBase):
         # AttributeError before the first call.
         self._custom_cad_peak: Optional[int] = None
         self._custom_cad_min: Optional[int] = None
+        self._custom_cad_symbol_num: Optional[int] = None
 
         # TX lock to serialize transmissions (matches SX1262Radio)
         self._tx_lock = asyncio.Lock()
@@ -499,27 +501,28 @@ class USBLoRaRadio(_RadioBase):
         det_min: Optional[int] = None,
         timeout: float = 1.0,
         calibration: bool = False,
+        cad_symbol_num: Optional[int] = None,
     ) -> bool:
         """Public CAD interface matching SX1262Radio.perform_cad().
 
         When det_peak/det_min are supplied (used by the repeater CAD
-        calibration tool to sweep different thresholds), program the chip
-        with those values via CMD_SET_CAD_PARAMS before running the scan.
+        calibration tool), program the thresholds and requested symbol count
+        via CMD_SET_CAD_PARAMS before running the scan.
         """
+        if cad_symbol_num is None:
+            cad_symbol_num = self._custom_cad_symbol_num or 2
+        cad_symbol_num = int(cad_symbol_num)
+
         if det_peak is not None and det_min is not None:
             new_peak = int(det_peak)
             new_min = int(det_min)
-            # Same caching rationale as tcp_radio: avoid re-sending unchanged
-            # thresholds during the per-sample inner loop of calibration.
-            if new_peak != self._custom_cad_peak or new_min != self._custom_cad_min:
-                payload = bytes(
-                    [
-                        0x01,
-                        new_peak & 0xFF,
-                        new_min & 0xFF,
-                        0x00,
-                    ]
-                )
+            # Avoid re-sending only when thresholds and symbol count all match.
+            if (
+                new_peak != self._custom_cad_peak
+                or new_min != self._custom_cad_min
+                or cad_symbol_num != self._custom_cad_symbol_num
+            ):
+                payload = build_cad_params_payload(cad_symbol_num, new_peak, new_min)
                 await self._send_command(
                     CMD_SET_CAD_PARAMS,
                     payload,
@@ -528,11 +531,18 @@ class USBLoRaRadio(_RadioBase):
                 )
                 self._custom_cad_peak = new_peak
                 self._custom_cad_min = new_min
+                self._custom_cad_symbol_num = cad_symbol_num
 
         # Calibration tool sends timeout=0.3 which is tight for our stack;
         # raise the floor so we don't lose samples to "no response".
         effective = max(timeout, 0.6)
         return await self._perform_cad(effective)
+
+    def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> bool:
+        """Store a validated CAD symbol count for calls that omit an override."""
+        build_cad_params_payload(cad_symbol_num, 0, 0)
+        self._custom_cad_symbol_num = int(cad_symbol_num)
+        return True
 
     # ── Wi-Fi / OTA provisioning (v0.5) ───────────────────────
 

--- a/tests/test_modem_cad.py
+++ b/tests/test_modem_cad.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openhop_core.hardware.protocol_constants import (
+    CMD_CAD_PARAMS_RESP,
+    CMD_SET_CAD_PARAMS,
+)
+from openhop_core.hardware.tcp_radio import TCPLoRaRadio
+from openhop_core.hardware.usb_radio import USBLoRaRadio
+
+
+def _make_radio(radio_cls):
+    if radio_cls is TCPLoRaRadio:
+        return radio_cls("127.0.0.1")
+    return radio_cls("/dev/null")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+async def test_modem_cad_accepts_symbol_count_and_programs_firmware(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio._send_command = AsyncMock(return_value=b"\x01")
+    radio._perform_cad = AsyncMock(return_value=False)
+
+    result = await radio.perform_cad(
+        det_peak=23,
+        det_min=11,
+        timeout=0.5,
+        calibration=True,
+        cad_symbol_num=8,
+    )
+
+    assert result is False
+    radio._send_command.assert_awaited_once_with(
+        CMD_SET_CAD_PARAMS,
+        bytes([0x03, 23, 11, 0x00]),
+        expect_cmd=CMD_CAD_PARAMS_RESP,
+        timeout=2.0,
+    )
+    radio._perform_cad.assert_awaited_once_with(0.6)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+async def test_modem_cad_reprograms_firmware_when_only_symbol_count_changes(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio._send_command = AsyncMock(return_value=b"\x01")
+    radio._perform_cad = AsyncMock(return_value=False)
+
+    await radio.perform_cad(det_peak=23, det_min=11, cad_symbol_num=2)
+    await radio.perform_cad(det_peak=23, det_min=11, cad_symbol_num=8)
+
+    payloads = [call.args[1] for call in radio._send_command.await_args_list]
+    assert payloads == [bytes([0x01, 23, 11, 0x00]), bytes([0x03, 23, 11, 0x00])]
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+def test_modem_cad_symbol_setter_tracks_valid_symbol_count_before_start(radio_cls):
+    radio = _make_radio(radio_cls)
+
+    assert radio.set_custom_cad_symbol_num(16) is True
+    assert radio._custom_cad_symbol_num == 16
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+def test_modem_cad_symbol_setter_rejects_unsupported_count(radio_cls):
+    radio = _make_radio(radio_cls)
+
+    with pytest.raises(ValueError, match="cad_symbol_num must be one of"):
+        radio.set_custom_cad_symbol_num(3)


### PR DESCRIPTION
## Summary

Fix CAD calibration and manual CAD checks for OpenHop TCP and USB modem backends after the Repeater CAD interface gained configurable symbol-count support.

The native `SX1262Radio.perform_cad()` wrapper accepts `cad_symbol_num`, but `TCPLoRaRadio.perform_cad()` and `USBLoRaRadio.perform_cad()` did not. The Repeater passes this argument during CAD calibration and manual checks, causing every TCP or USB modem attempt to fail before a CAD request reaches the modem.

## Issue

This incompatibility became visible with OpenHop Repeater commit
`fac5b1bd`:

```text
feat: add CAD calibration session configuration and manual check endpoint
```

That commit introduced the `/api/cad_manual_check` endpoint and added configurable CAD symbol counts to both the manual-check and calibration-engine paths.

Those paths call:

```python
await radio.perform_cad(
    det_peak=det_peak,
    det_min=det_min,
    timeout=cad_timeout_seconds,
    calibration=True,
    cad_symbol_num=cad_symbol_num,
)
```

The parent of `fac5b1bd` did not contain the manual CAD endpoint or pass `cad_symbol_num` to `perform_cad()`.

The native `SX1262Radio` wrapper supports the expanded call, but the TCP and USB modem wrappers retained their older signatures. Each modem calibration sample therefore raised:

```text
TypeError: perform_cad() got an unexpected keyword argument 'cad_symbol_num'
```

The Repeater calibration engine catches each exception and counts it as an error. A calibration run could consequently report only errors, with no completed CAD operations, detections, non-detections, or timeouts.

This is a Core wrapper compatibility issue. The modem firmware already supports the CAD parameter command and was not the source of this specific failure.

## Fix

- Add the optional `cad_symbol_num` argument to:
  - `TCPLoRaRadio.perform_cad()`
  - `USBLoRaRadio.perform_cad()`
- Encode supported CAD symbol counts using the RadioLib/SX1262 values expected by the modem firmware:
  - 1 symbol: `0x00`
  - 2 symbols: `0x01`
  - 4 symbols: `0x02`
  - 8 symbols: `0x03`
  - 16 symbols: `0x04`
- Include the selected symbol count in `CMD_SET_CAD_PARAMS`.
- Track the selected symbol count alongside the CAD peak and minimum thresholds.
- Reprogram the firmware when only the symbol count changes, even when the peak and minimum thresholds remain unchanged.
- Add validated `set_custom_cad_symbol_num()` support to the TCP and USB wrappers.
- Centralize CAD parameter payload construction in `protocol_constants.py` so both modem transports use the same wire encoding.

No modem firmware changes are required.

## Modem regression tests

This PR adds a focused test file:

```text
tests/test_modem_cad.py
```

The test file exercises both `TCPLoRaRadio` and `USBLoRaRadio` without opening a real serial port or network connection.

It verifies that:

- Both modem wrappers accept the same `cad_symbol_num` argument used by the Repeater.
- The correct `CMD_SET_CAD_PARAMS` payload is generated for an eight-symbol CAD request.
- Changing only the symbol count causes the CAD parameters to be sent again.
- Valid symbol counts can be stored before radio startup.
- Unsupported symbol counts are rejected rather than being silently mapped to an incorrect firmware value.

These tests establish a focused compatibility contract between the Repeater CAD API and both OpenHop modem transports.

## TDD and local verification

The modem regression tests were written before the implementation and reproduced the failure:

- 8 tests failed
- TCP and USB rejected `cad_symbol_num`
- Both wrappers lacked `set_custom_cad_symbol_num()`

After implementing the fix:

- Focused modem CAD tests: **8 passed**
- Modem CAD and wire-protocol tests: **29 passed**
- Full OpenHop Core test suite: **1,409 passed**
- `pre-commit run --all-files`: **passed**
  - Black
  - isort
  - flake8
  - repository file-hygiene checks
- `git diff --check`: **passed**

## Live hardware verification

The change was installed into the newest OpenHop Repeater dev build,
**v1.1.2.dev149**, using OpenHop Core dev **v1.1.3.dev8**.

Hardware and transport:

- Heltec V4.2 OpenHop Modem
- Wi-Fi/TCP modem transport
- Authenticated TCP connection

The manual CAD endpoint was exercised with three samples at each of these symbol-count settings:

1. 2 symbols
2. 8 symbols
3. 2 symbols again

Switching from 2 to 8 and back to 2 verifies that a symbol-count change reprograms the modem instead of incorrectly reusing the previously cached CAD parameters.

Every run returned:

- 3 attempts
- 3 completed CAD operations
- 0 errors
- 0 timeouts
- API `success: true`

The channel was clear during testing, so the successful samples were returned as valid non-detections.

The running Repeater remained active and connected to the modem. There were no CAD command timeouts or missing CAD responses during the test.

## Test scope

Physical hardware verification was performed with the TCP backend and a Heltec V4.2 modem.

The USB backend uses the same centralized CAD payload builder and is covered by the new automated modem regression tests. A physical USB modem was not exercised during this test.
