### PR TITLE
Return-path teaching, region-scoped floods, and TX/lock concurrency fixes

### DIFF
--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -8,6 +8,7 @@ import logging
 import random
 import struct
 import time
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
 from ..protocol import Packet, PacketBuilder
@@ -50,6 +51,26 @@ from .timing import (
 )
 
 logger = logging.getLogger("CompanionBase")
+
+# Frame-server clients own login retry timing from the timeout in RESP_CODE_SENT.
+# Keep one authenticated-response waiter alive across those retries so a slow
+# flood reply can still complete login. This is deliberately longer than one
+# adaptive send timeout; observed multi-hop replies can take over a minute.
+FRAME_LOGIN_PENDING_TTL_S = 120.0
+
+
+@dataclass
+class _PendingFrameLogin:
+    """One logical frame-server login session, reused across client retries."""
+
+    target_key: bytes
+    dest_hash: int
+    contact_name: str
+    event: asyncio.Event
+    result: dict
+    callback: Callable[[bool, dict], None]
+    expires_at: float
+    task: Optional[asyncio.Task] = None
 
 
 class _SendOpsMixin:
@@ -884,28 +905,183 @@ class _SendOpsMixin:
                     "timeout": True,
                     "reason": "Login response timeout",
                 }
-            data = login_result["data"]
-            if login_result["success"]:
-                # Mirror firmware onContactResponse (MyMesh.cpp:686-690):
-                # open a connection on a successful login response. This is the
-                # single point every login response (frame server or direct API)
-                # flows through, matching the firmware's onContactResponse.
-                self.note_login_connection(pub_key, data.get("keep_alive_interval", 0))
-            return {
-                "success": login_result["success"],
-                "repeater": contact.name,
-                "is_admin": data.get("is_admin", False),
-                "keep_alive_interval": data.get("keep_alive_interval", 0),
-                "tag": data.get("timestamp", 0),
-                "acl_permissions": data.get("reserved", data.get("permissions", 0)),
-                "firmware_ver_level": data.get("firmware_ver_level"),
-                "reason": ("Login successful" if login_result["success"] else "Login failed"),
-            }
+            return self._build_login_result(
+                pub_key,
+                contact.name,
+                login_result["success"],
+                login_result["data"],
+            )
 
         started["task"] = self._spawn_background_task(
             _format_login_result(), "login result formatting"
         )
         return started
+
+    def _build_login_result(
+        self,
+        pub_key: bytes,
+        contact_name: str,
+        success: bool,
+        data: dict,
+    ) -> dict:
+        """Build the common login result returned by API and frame-server paths."""
+        if success:
+            self.note_login_connection(pub_key, data.get("keep_alive_interval", 0))
+        return {
+            "success": success,
+            "repeater": contact_name,
+            "is_admin": data.get("is_admin", False),
+            "keep_alive_interval": data.get("keep_alive_interval", 0),
+            "tag": data.get("timestamp", 0),
+            "acl_permissions": data.get("reserved", data.get("permissions", 0)),
+            "firmware_ver_level": data.get("firmware_ver_level"),
+            "reason": "Login successful" if success else "Login failed",
+        }
+
+    async def _start_frame_login_request(self, pub_key: bytes, password: str) -> dict:
+        """Send one frame-server login attempt and reuse its pending response session.
+
+        MeshCore companion clients own retries: each command gets one transmission
+        and one per-send timeout hint. Repeated commands for the same full public
+        key refresh this logical session instead of replacing its callback, so a
+        late authenticated reply completes whichever retry is currently pending.
+
+        The public :meth:`send_login` API intentionally keeps its existing
+        three-attempt behaviour; this method is the frame-server compatibility
+        boundary.
+        """
+        contact = self.contacts.get_by_key(pub_key)
+        if not contact:
+            return {"success": False, "error": "not_found", "reason": "Contact not found"}
+        proxy = self.contacts.get_proxy_by_key(pub_key)
+        if not proxy:
+            return {"success": False, "error": "not_found", "reason": "Contact not found"}
+        login_handler = self._get_login_response_handler()
+        if not login_handler:
+            return {
+                "success": False,
+                "error": "bad_state",
+                "reason": "Login handler not available",
+            }
+
+        target_key = proxy.public_key_bytes
+        sessions = self._pending_frame_logins
+        session = sessions.get(target_key)
+        if session is not None and (
+            session.event.is_set() or (session.task is not None and session.task.done())
+        ):
+            sessions.pop(target_key, None)
+            login_handler.remove_login_callback(target_key, session.callback)
+            session = None
+
+        session_owner = session is None
+        if session is None:
+            event = asyncio.Event()
+            result: dict = {"success": False, "data": {}}
+            session_ref: Optional[_PendingFrameLogin] = None
+
+            def _login_cb(success: bool, data: dict) -> None:
+                current = session_ref
+                if current is None or current.event.is_set():
+                    return
+                current.result["success"] = success
+                current.result["data"] = data
+                current.event.set()
+
+            session = _PendingFrameLogin(
+                target_key=target_key,
+                dest_hash=proxy.dest_hash,
+                contact_name=contact.name,
+                event=event,
+                result=result,
+                callback=_login_cb,
+                expires_at=time.monotonic() + FRAME_LOGIN_PENDING_TTL_S,
+            )
+            session_ref = session
+            sessions[target_key] = session
+            login_handler.register_login_callback(target_key, session.callback)
+
+        login_handler.store_login_password(proxy.dest_hash, password)
+        pkt = PacketBuilder.create_login_packet(
+            contact=proxy, local_identity=self._identity, password=password
+        )
+        self._apply_path_hash_mode(pkt)
+        timeout_s = self._response_timeout_s(pkt, proxy)
+        logger.debug(
+            "[PATHDIAG] frame login -> 0x%02X (%s): route=%s attempt=1/1 "
+            "timeout=%.1fs out_path_len=%s",
+            proxy.dest_hash,
+            contact.name,
+            "FLOOD" if pkt.is_route_flood() else "DIRECT",
+            timeout_s,
+            _fmt_path_len(getattr(proxy, "out_path_len", -1)),
+        )
+        if not await self._send_packet(pkt, wait_for_ack=False):
+            if session_owner and sessions.get(target_key) is session:
+                sessions.pop(target_key, None)
+                login_handler.remove_login_callback(target_key, session.callback)
+                login_handler.clear_login_password(proxy.dest_hash)
+            return {"success": False, "error": "send_failed", "reason": "Send failed"}
+
+        session.expires_at = time.monotonic() + FRAME_LOGIN_PENDING_TTL_S
+
+        if session.task is None:
+
+            async def _wait_for_frame_login() -> dict:
+                try:
+                    while not session.event.is_set():
+                        remaining = session.expires_at - time.monotonic()
+                        if remaining <= 0:
+                            return {
+                                "success": False,
+                                "timeout": True,
+                                "reason": "Login response timeout",
+                            }
+                        try:
+                            await asyncio.wait_for(session.event.wait(), timeout=remaining)
+                        except asyncio.TimeoutError:
+                            # A repeated command may have refreshed expires_at while
+                            # this wait used the previous deadline.
+                            continue
+                    return self._build_login_result(
+                        target_key,
+                        session.contact_name,
+                        session.result["success"],
+                        session.result["data"],
+                    )
+                finally:
+                    if sessions.get(target_key) is session:
+                        sessions.pop(target_key, None)
+                        login_handler.remove_login_callback(target_key, session.callback)
+                        login_handler.clear_login_password(session.dest_hash)
+
+            session.task = self._spawn_background_task(
+                _wait_for_frame_login(), "frame login response"
+            )
+
+        return {
+            "success": True,
+            "sent": SentResult(
+                success=True,
+                is_flood=pkt.is_route_flood(),
+                expected_ack=int.from_bytes(target_key[:4], "little"),
+                timeout_ms=int(timeout_s * 1000),
+            ),
+            "task": session.task,
+            "session_owner": session_owner,
+        }
+
+    def _clear_pending_frame_logins(self) -> None:
+        """Cancel frame-login sessions and detach their response callbacks."""
+        sessions = tuple(self._pending_frame_logins.values())
+        self._pending_frame_logins.clear()
+        login_handler = self._get_login_response_handler()
+        for session in sessions:
+            if login_handler is not None:
+                login_handler.remove_login_callback(session.target_key, session.callback)
+                login_handler.clear_login_password(session.dest_hash)
+            if session.task is not None and not session.task.done():
+                session.task.cancel()
 
     async def send_login(self, pub_key: bytes, password: str) -> dict:
         """Send a login request to a repeater and wait for the response."""

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -693,6 +693,7 @@ class _SendOpsMixin:
         log_label: str,
         cleanup: Optional[Callable[[], None]],
         response_tag_registered: Optional[Callable[[int], None]],
+        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Finish a request after its first packet has already been sent."""
         try:
@@ -701,6 +702,8 @@ class _SendOpsMixin:
                 return result
 
             for attempt in range(1, DEFAULT_MAX_ATTEMPTS):
+                if contact_pubkey is not None:
+                    await self._teach_return_path_before_retry(contact_pubkey, log_label)
                 pkt, packet_tag = build_packet()
                 if response_tag_registered is not None and packet_tag is not None:
                     response_tag_registered(packet_tag)
@@ -744,6 +747,7 @@ class _SendOpsMixin:
         sent_tag: Optional[int] = None,
         cleanup: Optional[Callable[[], None]] = None,
         response_tag_registered: Optional[Callable[[int], None]] = None,
+        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Send the first packet and return its metadata plus a waiter task."""
         deadline = time.monotonic() + total_timeout_s if total_timeout_s is not None else None
@@ -783,6 +787,7 @@ class _SendOpsMixin:
                     log_label=log_label,
                     cleanup=cleanup,
                     response_tag_registered=response_tag_registered,
+                    contact_pubkey=contact_pubkey,
                 ),
                 f"{log_label} response",
             )
@@ -1006,6 +1011,7 @@ class _SendOpsMixin:
         total_timeout_s: Optional[float] = None,
         log_label: str = "request",
         response_tag_registered: Optional[Callable[[int], None]] = None,
+        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Send a request up to DEFAULT_MAX_ATTEMPTS times until a response lands.
 
@@ -1016,10 +1022,15 @@ class _SendOpsMixin:
         ``total_timeout_s`` caps the cumulative wait across attempts: the final
         attempt's wait is clipped to the remaining budget and no new attempt
         starts once the budget is spent.
+
+        A timed-out attempt also re-teaches our return path when ``contact_pubkey``
+        is known; see :meth:`_teach_return_path_before_retry`.
         """
         result: dict = {"timeout": True}
         deadline = time.monotonic() + total_timeout_s if total_timeout_s else None
         for attempt in range(DEFAULT_MAX_ATTEMPTS):
+            if attempt > 0 and contact_pubkey is not None:
+                await self._teach_return_path_before_retry(contact_pubkey, log_label)
             pkt, packet_tag = build_packet()
             if response_tag_registered is not None and packet_tag is not None:
                 response_tag_registered(packet_tag)
@@ -1045,14 +1056,39 @@ class _SendOpsMixin:
                 break
         return result
 
+    async def _teach_return_path_before_retry(self, contact_pubkey: bytes, log_label: str) -> None:
+        """Re-teach our return path after a request attempt timed out.
+
+        openHop hardening with no firmware equivalent. When a server answers
+        DIRECT down a route that no longer reaches us, *nothing* arrives — there
+        is no flood reply to trigger the normal re-teach and no inbound path to
+        embed. A timeout against a contact we hold an ``out_path`` for is the
+        only evidence available, so the teacher falls back to reversing our own
+        ``out_path`` (see ``maybe_teach_reverse_of_out_path``). Best-effort: any
+        failure just leaves the retry to proceed as before.
+        """
+        try:
+            proto_handler = self._get_protocol_response_handler()
+            teacher = getattr(proto_handler, "return_path_teacher", None)
+            if teacher is None:
+                return
+            await teacher.maybe_teach_reverse_of_out_path(
+                contact_pubkey, reason=f"{log_label} retry after timeout"
+            )
+        except Exception as e:
+            logger.debug("[PATHDIAG] return-path teach before retry failed: %s", e)
+
     async def _wait_for_path_propagation(self, proxy: Any, request_type: str) -> None:
         """Log the pre-send path; no longer sleeps.
 
-        Firmware sends the request immediately and relies on the reciprocal PATH
-        (which openHop already sends at login time, see ProtocolResponseHandler).
-        The previous 0.5s/hop sleep added up to ~1.5s+ of latency per request for
-        multi-hop contacts with no reliability benefit and has been removed; the
-        adaptive timeout + internal resend now handle a lost first attempt.
+        Firmware sends the request immediately and relies on the peer already
+        holding a route back to us. openHop teaches that route from the flood
+        PATH a flood login returns, and — since a DIRECT (forced-path) login is
+        answered with a plain flood RESPONSE instead — also from that RESPONSE;
+        see :mod:`openhop_core.node.handlers.return_path`. The previous
+        0.5s/hop sleep added up to ~1.5s+ of latency per request for multi-hop
+        contacts with no reliability benefit and has been removed; the adaptive
+        timeout + internal resend now handle a lost first attempt.
         """
         out_path_len = getattr(proxy, "out_path_len", -1)
         out_path = getattr(proxy, "out_path", b"") or b""
@@ -1115,6 +1151,7 @@ class _SendOpsMixin:
                 log_label=log_label,
                 cleanup=_clear_response_tags,
                 response_tag_registered=_register_response_tag,
+                contact_pubkey=pub_key,
             )
             if not started.get("success"):
                 return started
@@ -1263,6 +1300,7 @@ class _SendOpsMixin:
                 proxy,
                 log_label=f"protocol REQ 0x{protocol_code:02X}",
                 response_tag_registered=_register_response_tag,
+                contact_pubkey=pub_key,
             )
             return {
                 "success": result.get("success", False),

--- a/src/openhop_core/companion/companion_base.py
+++ b/src/openhop_core/companion/companion_base.py
@@ -110,6 +110,10 @@ class CompanionBase(
         # note_login_connection / has_login_connection / clear_login_connection
         # methods in base_send.py for the lifecycle.
         self._login_connections: dict[bytes, float] = {}
+        # Frame-server login commands expose a per-send timeout and are retried
+        # by the companion app. Keep one logical response session per full
+        # contact key so those retries do not replace each other's callbacks.
+        self._pending_frame_logins: dict[bytes, Any] = {}
         self._sign_buffer: Optional[bytearray] = None
         self._flood_transport_key: Optional[bytes] = None
         # Sticky "force unscoped flood" flag (FW PR #2492 / FIRMWARE_VER_CODE 12+):

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -61,9 +61,12 @@ class _BridgeAckHandler:
         return PAYLOAD_TYPE_ACK
 
     async def __call__(self, packet: Packet) -> None:
-        if not packet.payload or len(packet.payload) != 4:
+        # Firmware emits 6-byte ACKs for plain DMs (4-byte hash + ext-attempt +
+        # random byte); accept >= 4 and correlate on the first 4 bytes only,
+        # matching the shared AckHandler.
+        if not packet.payload or len(packet.payload) < 4:
             return
-        crc = int.from_bytes(packet.payload, "little")
+        crc = int.from_bytes(packet.payload[:4], "little")
         await self._apply_ack(crc)
 
     async def _apply_ack(self, crc: int) -> None:

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -473,6 +473,11 @@ class CompanionBridge(CompanionBase):
 
     async def stop(self) -> None:
         self._running = False
+        self._clear_pending_frame_logins()
+        protocol_handler = self._get_protocol_response_handler()
+        if protocol_handler is not None:
+            protocol_handler.cancel_pending_reciprocals()
+            await protocol_handler.wait_for_pending_reciprocals()
         logger.info("CompanionBridge stopped")
 
     @property

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -180,13 +180,16 @@ class CompanionRadio(CompanionBase):
 
     async def stop(self) -> None:
         self._running = False
+        self._clear_pending_frame_logins()
         try:
             self.node.dispatcher.remove_raw_packet_subscriber(self._on_raw_packet_rx_log)
-            teacher = getattr(
-                self.node.dispatcher.protocol_response_handler, "return_path_teacher", None
-            )
+            protocol_handler = self.node.dispatcher.protocol_response_handler
+            teacher = getattr(protocol_handler, "return_path_teacher", None)
             if teacher is not None:
                 self.node.dispatcher.remove_raw_packet_subscriber(teacher.note_flood_copy)
+            if protocol_handler is not None:
+                protocol_handler.cancel_pending_reciprocals()
+                await protocol_handler.wait_for_pending_reciprocals()
         except Exception:
             logger.debug("Remove raw packet subscriber during stop failed", exc_info=True)
         await self.node.stop()

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -182,6 +182,11 @@ class CompanionRadio(CompanionBase):
         self._running = False
         try:
             self.node.dispatcher.remove_raw_packet_subscriber(self._on_raw_packet_rx_log)
+            teacher = getattr(
+                self.node.dispatcher.protocol_response_handler, "return_path_teacher", None
+            )
+            if teacher is not None:
+                self.node.dispatcher.remove_raw_packet_subscriber(teacher.note_flood_copy)
         except Exception:
             logger.debug("Remove raw packet subscriber during stop failed", exc_info=True)
         await self.node.stop()
@@ -374,6 +379,13 @@ class CompanionRadio(CompanionBase):
             # (firmware onContactPathRecv behaviour). Without this the remote
             # repeater never learns its route back to us and floods every reply.
             dispatcher.protocol_response_handler.set_packet_injector(self._send_packet)
+            # Feed the return-path teacher every flood reply copy pre-dedup so it
+            # teaches from the best-received route, not the first-arrived one (see
+            # ReturnPathTeacher.note_flood_copy). Dedup below would otherwise hide
+            # every copy but the first from the handlers.
+            teacher = getattr(dispatcher.protocol_response_handler, "return_path_teacher", None)
+            if teacher is not None:
+                dispatcher.add_raw_packet_subscriber(teacher.note_flood_copy)
         # When a direct trace reaches the end of its path, push completion data
         # to connected clients (firmware onTraceRecv -> PUSH_CODE_TRACE_DATA).
         if getattr(dispatcher, "trace_handler", None):

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -432,11 +432,15 @@ class _MessagingCommandsMixin:
             if len(data) > PUB_KEY_SIZE
             else ""
         )
-        started = await self.bridge._start_login_request(pubkey, password)
+        started = await self.bridge._start_frame_login_request(pubkey, password)
         if not started.get("success"):
             self._write_request_start_error(started)
             return
         self._write_sent_result(started["sent"], default_timeout_ms=LOGIN_TIMEOUT_HINT_MS)
+        if not started.get("session_owner", True):
+            # A previous command already owns the one completion writer for this
+            # logical login session. This retry only sends another radio packet.
+            return
 
         async def _write_login_result() -> None:
             result = await started["task"]

--- a/src/openhop_core/hardware/kiss_modem_wrapper.py
+++ b/src/openhop_core/hardware/kiss_modem_wrapper.py
@@ -725,11 +725,21 @@ class KissModemWrapper(LoRaRadio):
                 self._last_failure_log_ts = now
                 logger.warning("Marking KISS serial link degraded: %s", reason)
 
-        with self._connection_lock:
-            self._degraded = True
-            self._degraded_reason = reason
-            self.is_connected = False
-            self._close_serial_connection()
+        # Do not wait for the connection lock here. A failed SetHardware write can
+        # hold _command_lock (or _serial_write_lock), while the reconnect worker
+        # holds _connection_lock and needs that lock for its handshake. Waiting
+        # would form an ABBA deadlock and leave the wrapper permanently degraded.
+        # Defer closing the port while that lifecycle transition is in progress.
+        self._degraded = True
+        self._degraded_reason = reason
+        self.is_connected = False
+        if self._connection_lock.acquire(blocking=False):
+            try:
+                self._close_serial_connection()
+            finally:
+                self._connection_lock.release()
+        else:
+            logger.debug("Connection lock busy; deferring serial close to its owner")
 
         # Wake any in-flight DATA sender so it fails fast instead of waiting out the
         # full TX_DONE timeout on a link that is already gone (cleanup() does the same).
@@ -746,6 +756,15 @@ class KissModemWrapper(LoRaRadio):
         self.reconnect_thread.start()
 
     def _reconnect_worker(self) -> None:
+        """Run the reconnect loop and release its gate when the worker exits."""
+        try:
+            self._reconnect_loop()
+        except Exception:
+            logger.exception("KISS modem reconnect worker died unexpectedly")
+        finally:
+            self._reconnecting_event.clear()
+
+    def _reconnect_loop(self) -> None:
         """Reconnect with exponential backoff and re-run modem handshake."""
         attempts = 0
         while not self.stop_event.is_set():
@@ -781,10 +800,7 @@ class KissModemWrapper(LoRaRadio):
                 self._degraded = False
                 self._degraded_reason = None
                 logger.info("KISS modem serial reconnect successful on attempt %s", attempts)
-                self._reconnecting_event.clear()
                 return
-
-        self._reconnecting_event.clear()
 
     def _set_kiss_tx_delay(self, delay_ms: int) -> None:
         """

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -944,28 +944,76 @@ class Dispatcher:
         # disabled the send path is unchanged (a recorded deliberate deferral).
         if not self._client_repeat_enabled:
             async with self._tx_lock:  # Wait our turn
-                return await self._send_packet_immediate(packet, wait_for_ack, expected_crc)
-        # Throttle off-lock, then re-decide admission under the lock so a
-        # snapshot taken before queueing cannot transmit past a debit another
-        # task committed under _tx_lock. _debit_tx_budget runs only under the
-        # lock and the sole out-of-lock mutation (_refill_tx_budget) only
-        # increases the budget, so an under-lock pass holds until radio.send.
-        # Livelock is bounded: every debit sets _tx_next_time pacing that all
-        # later admissions honour (firmware's next_tx_time property). Never
-        # sleep under the lock -- fall out of the async with to wait again.
-        while True:
-            await self._await_tx_budget(packet)
-            async with self._tx_lock:  # Wait our turn
-                if not self._client_repeat_enabled or self._tx_budget_wait_s() <= 0.0:
-                    return await self._send_packet_immediate(packet, wait_for_ack, expected_crc)
+                tx_ok, ack_event, ack_crc = await self._transmit_locked(
+                    packet, wait_for_ack, expected_crc
+                )
+        else:
+            # Throttle off-lock, then re-decide admission under the lock so a
+            # snapshot taken before queueing cannot transmit past a debit another
+            # task committed under _tx_lock. _debit_tx_budget runs only under the
+            # lock and the sole out-of-lock mutation (_refill_tx_budget) only
+            # increases the budget, so an under-lock pass holds until radio.send.
+            # Livelock is bounded: every debit sets _tx_next_time pacing that all
+            # later admissions honour (firmware's next_tx_time property). Never
+            # sleep under the lock -- fall out of the async with to wait again.
+            while True:
+                await self._await_tx_budget(packet)
+                async with self._tx_lock:  # Wait our turn
+                    if not self._client_repeat_enabled or self._tx_budget_wait_s() <= 0.0:
+                        tx_ok, ack_event, ack_crc = await self._transmit_locked(
+                            packet, wait_for_ack, expected_crc
+                        )
+                        break
 
-    async def _send_packet_immediate(
+        # Wait for the ACK OUTSIDE _tx_lock so relay traffic and other sends can
+        # use the funnel during the up-to-ACK_TIMEOUT window. Firmware's
+        # Dispatcher::loop frees the radio when the physical send completes and
+        # services its outbound queue independently of ACK correlation; holding
+        # the funnel through the ACK wait was the divergence. The waiter was
+        # registered under the lock (and _register_ack_received also caches into
+        # _recent_acks), so an ACK arriving the instant the lock frees is caught.
+        if not tx_ok:
+            return False
+        if ack_event is None:
+            return True
+        try:
+            # Unchanged from the pre-shrink path except that it no longer runs
+            # under _tx_lock: the waiter is already registered, so an ACK landing
+            # during this pause is matched rather than raced.
+            await asyncio.sleep(self.tx_delay)
+            ack_received = await self._await_ack_event(ack_event, ack_crc, ACK_TIMEOUT)
+            if ack_received:
+                self._log(f"[>>acK] received for CRC {ack_crc:08X}")
+            else:
+                self._log(f"ACK timeout for CRC {ack_crc:08X}")
+            return ack_received
+        finally:
+            self.state = DispatcherState.IDLE
+            self._current_expected_crc = None
+            # Registration now happens under _tx_lock, one await earlier than the
+            # wait that owns its cleanup, so this scope -- not _await_ack_event --
+            # is the one that spans every exit path. Without this, a cancel during
+            # the tx_delay pause would strand the CRC in _waiting_acks forever
+            # (nothing prunes it, unlike _recent_acks), leaving relayed ACKs for
+            # that CRC permanently marked do-not-retransmit. Identity-guarded and
+            # idempotent: a no-op once the ACK path or _await_ack_event removed it.
+            if self._waiting_acks.get(ack_crc) is ack_event:
+                del self._waiting_acks[ack_crc]
+
+    async def _transmit_locked(
         self,
         packet: Packet,
         wait_for_ack: bool = True,
         expected_crc: Optional[int] = None,
-    ) -> bool:
-        """Send a packet immediately (assumes lock is held)."""
+    ) -> tuple[bool, Optional[asyncio.Event], Optional[int]]:
+        """Transmit the packet; assumes ``_tx_lock`` is held.
+
+        Returns ``(tx_ok, ack_event, ack_crc)``. When an ACK wait is needed the
+        waiter is registered here — before the caller releases ``_tx_lock`` — and
+        the event is returned so the caller can await it OUTSIDE the lock, freeing
+        the send funnel during the wait. ``ack_event`` is ``None`` when no wait is
+        needed (ADVERT/ACK, ``wait_for_ack`` False, or a transmit failure).
+        """
         payload_type = packet.get_payload_type()
 
         # Mark this packet seen before transmitting, matching firmware's
@@ -988,11 +1036,11 @@ class Dispatcher:
         except Exception as e:
             self._log(f"Radio transmit error: {e}")
             self.state = DispatcherState.IDLE
-            return False
+            return (False, None, None)
         if tx_metadata is None:
             self._log("Radio transmit returned no confirmation metadata")
             self.state = DispatcherState.IDLE
-            return False
+            return (False, None, None)
         # Spend the airtime budget on the completed transmit (client-repeat only).
         if self._client_repeat_enabled:
             self._debit_tx_budget(packet)
@@ -1011,40 +1059,31 @@ class Dispatcher:
         # Skip waiting for ACK if not needed
         if payload_type in {PAYLOAD_TYPE_ADVERT, PAYLOAD_TYPE_ACK} or not wait_for_ack:
             self.state = DispatcherState.IDLE
-            return True
+            return (True, None, None)
 
-        # ------------------------------------------------------------------ #
-        #  Wait for ACK using the callback system
-        # ------------------------------------------------------------------ #
-        await asyncio.sleep(self.tx_delay)
+        # ACK wait needed. Register the waiter now, while _tx_lock is still held,
+        # so an ACK arriving the instant the caller releases the lock is not
+        # missed; the caller awaits the event off-lock (see send_packet).
+        crc = expected_crc if expected_crc is not None else packet.get_crc()
+        self._current_expected_crc = crc
+        ack_event = self.expect_ack(crc)
         self.state = DispatcherState.WAIT
-
-        # Set the expected CRC for ACK matching
-        if expected_crc is not None:
-            self._current_expected_crc = expected_crc
-        else:
-            self._current_expected_crc = packet.get_crc()
-
-        self._log(
-            f"Waiting for ACK with CRC {self._current_expected_crc:08X} (timeout: {ACK_TIMEOUT}s)"
-        )
-
-        try:
-            # Wait for the ACK using the event-based system
-            ack_received = await self.wait_for_ack(self._current_expected_crc, ACK_TIMEOUT)
-            if ack_received:
-                self._log(f"[>>acK] received for CRC {self._current_expected_crc:08X}")
-                return True
-            else:
-                self._log(f"ACK timeout for CRC {self._current_expected_crc:08X}")
-                return False
-        finally:
-            self.state = DispatcherState.IDLE
-            self._current_expected_crc = None
+        self._log(f"Waiting for ACK with CRC {crc:08X} (timeout: {ACK_TIMEOUT}s)")
+        return (True, ack_event, crc)
 
     async def wait_for_ack(self, crc: int, timeout: float = ACK_TIMEOUT) -> bool:
         """Wait for a specific ACK CRC for up to `timeout` seconds."""
         event = self.expect_ack(crc)
+        return await self._await_ack_event(event, crc, timeout)
+
+    async def _await_ack_event(
+        self, event: asyncio.Event, crc: int, timeout: float = ACK_TIMEOUT
+    ) -> bool:
+        """Await an already-registered ACK event, cleaning up on every exit.
+
+        Split out of :meth:`wait_for_ack` so :meth:`send_packet` can register the
+        waiter under ``_tx_lock`` and await it after releasing the lock.
+        """
         try:
             await asyncio.wait_for(event.wait(), timeout)
             return True

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -546,10 +546,18 @@ class Dispatcher:
 
         # When disabled, packet_filter still tracks hashes for stats/visibility.
         packet_hash = pkt.calculate_packet_hash().hex()[:16]
-        if self.dedupe_enabled and self.packet_filter.is_duplicate(packet_hash):
-            self._log(f"Duplicate packet ignored (hash: {packet_hash})")
-            return
-        self.packet_filter.track_packet(packet_hash)
+        # MeshCore records a routed-direct packet in its seen table only when
+        # this node is the next hop (Mesh::onRecvPacket). A node that overhears
+        # an earlier route variant must not mark the path-independent hash seen,
+        # or it would later drop the self-stripped copy it is asked to relay.
+        # Flood, zero-hop direct and direct TRACE keep unconditional dedup: the
+        # first two match firmware's up-front markSeen, and the TRACE hash folds
+        # in path_len so its per-hop copies never collide.
+        if not self._is_transit_direct_not_next_hop(pkt):
+            if self.dedupe_enabled and self.packet_filter.is_duplicate(packet_hash):
+                self._log(f"Duplicate packet ignored (hash: {packet_hash})")
+                return
+            self.packet_filter.track_packet(packet_hash)
 
         # Client-repeat: build the retransmit from the just-received packet
         # BEFORE handlers run, so a copy is taken while path/payload are intact
@@ -762,6 +770,29 @@ class Dispatcher:
         fwd._flood_scope_applied = True
         fwd._path_hash_mode_applied = True
         return fwd
+
+    def _is_transit_direct_not_next_hop(self, pkt: Packet) -> bool:
+        """True for a routed-direct packet this node is not the next hop for.
+
+        Mirrors MeshCore ``Mesh::onRecvPacket``, which records a routed-direct
+        packet in the seen table only inside the
+        ``isHashMatch(path) && allowPacketForward`` branch. Such packets must be
+        left out of dedup so an overheard longer-path variant does not suppress
+        the self-stripped copy this node is later the next hop for. Direct TRACE
+        is excluded (its hash folds in ``path_len``, so per-hop copies never
+        collide) as are flood and zero-hop-direct packets.
+        """
+        if not pkt.is_route_direct() or pkt.get_path_hash_count() <= 0:
+            return False
+        if pkt.get_payload_type() == PAYLOAD_TYPE_TRACE:
+            return False
+        if self.local_identity is None:
+            return False
+        self_key = self.local_identity.get_public_key()
+        hash_size = pkt.get_path_hash_size()
+        if len(pkt.path) < hash_size:
+            return False
+        return bytes(pkt.path[:hash_size]) != self_key[:hash_size]
 
     def _build_client_repeat_forward(self, pkt: Packet) -> Optional[Packet]:
         """Build the retransmit packet for a received packet, or None to drop.

--- a/src/openhop_core/node/handlers/login_response.py
+++ b/src/openhop_core/node/handlers/login_response.py
@@ -7,6 +7,7 @@ from ...protocol.packet_utils import PathUtils
 from ...util.callbacks import invoke_maybe_awaitable
 from .base import BaseHandler
 from .result import HandlerResult
+from .return_path import ReturnPathTeacher
 
 # Response codes from C++ server
 RESP_SERVER_LOGIN_OK = 0x80
@@ -32,10 +33,15 @@ class LoginResponseHandler(BaseHandler):
     def payload_type() -> int:
         return PAYLOAD_TYPE_RESPONSE
 
-    def __init__(self, local_identity, contacts, log_fn):
+    def __init__(self, local_identity, contacts, log_fn, *, return_path_teacher=None):
         self.local_identity = local_identity
         self.contacts = contacts
         self.log = log_fn
+        # Shared with ProtocolResponseHandler by the factory; constructed here
+        # when absent so standalone use still works (see :mod:`.return_path`).
+        self.return_path_teacher = return_path_teacher or ReturnPathTeacher(
+            log_fn, local_identity, contacts
+        )
         # Pending login completions keyed by the target contact's full public key
         # (32 bytes). A response is dispatched only to the waiter whose target
         # matches the authenticated sender, mirroring the firmware sender gate
@@ -46,6 +52,16 @@ class LoginResponseHandler(BaseHandler):
         self._active_login_passwords = {}  # dest_hash -> password
         # Protocol response handler for forwarding telemetry responses
         self._protocol_response_handler = None
+
+    def set_packet_injector(self, injector) -> None:
+        """Wire the transmit path used for return-path teaching.
+
+        Companion layers normally reach the shared teacher through
+        ``ProtocolResponseHandler.set_packet_injector``; this exists so a
+        standalone ``LoginResponseHandler`` can teach too, instead of silently
+        no-opping.
+        """
+        self.return_path_teacher.set_injector(injector)
 
     def set_protocol_response_handler(self, protocol_response_handler):
         """Set protocol response handler for forwarding telemetry responses."""
@@ -177,6 +193,22 @@ class LoginResponseHandler(BaseHandler):
                 # pending_login pubkey mismatch falls through to the status/
                 # telemetry matchers instead of being treated as a login.
                 return await self._forward_to_protocol_handler(packet)
+            # Firmware parity (BaseChatMesh::onPeerDataRecv RESPONSE branch):
+            # a login sent DIRECT down a forced path is answered by the server
+            # with a *flood* RESPONSE (simple_repeater MyMesh::onAnonDataRecv,
+            # the reply_path_len < 0 branch). That is the tell that the server
+            # holds no usable out_path for us, and it is the only signal we get
+            # before the first CLI request goes out — so teach the route back
+            # now, or every subsequent REQ is answered down a dead route.
+            # PATH-shaped responses are excluded: the reciprocal for those is
+            # already sent by ProtocolResponseHandler.
+            if packet.get_payload_type() == PAYLOAD_TYPE_RESPONSE:
+                await self.return_path_teacher.maybe_teach_from_flood_reply(
+                    packet,
+                    self._pubkey_bytes(matched_contact),
+                    lookup_hash,
+                    reason="flood login RESPONSE",
+                )
             if response_data is None:
                 self.log("Authenticated login response had invalid or incomplete contents")
                 return HandlerResult.consumed()

--- a/src/openhop_core/node/handlers/protocol_response.py
+++ b/src/openhop_core/node/handlers/protocol_response.py
@@ -184,6 +184,9 @@ class ProtocolResponseHandler:
         self._login_response_handler: Optional[Any] = None
         # Packet injector for sending reciprocal PATH packets (mirrors C++ Mesh.cpp:168-169)
         self._packet_injector: Optional[Callable] = None
+        # Reciprocal sends are queued so login/ACK delivery cannot block behind
+        # radio TX, duty-cycle, or LBT waits. Keep strong references until done.
+        self._pending_reciprocals: set[asyncio.Task] = set()
         # Optional: notify when contact out_path is updated from decrypted PATH
         # (e.g. companion persist).
         self._contact_path_updated_callback: Optional[Callable[..., Any]] = None
@@ -217,6 +220,18 @@ class ProtocolResponseHandler:
         """
         self._packet_injector = injector
         self.return_path_teacher.set_injector(injector)
+
+    async def wait_for_pending_reciprocals(self) -> None:
+        """Await queued reciprocal PATH transmissions (shutdown/tests)."""
+        while self._pending_reciprocals:
+            pending = tuple(self._pending_reciprocals)
+            await asyncio.gather(*pending, return_exceptions=True)
+            self._pending_reciprocals.difference_update(pending)
+
+    def cancel_pending_reciprocals(self) -> None:
+        """Cancel reciprocal PATH transmissions that have not completed."""
+        for task in tuple(self._pending_reciprocals):
+            task.cancel()
 
     @staticmethod
     def payload_type() -> int:
@@ -416,6 +431,7 @@ class ProtocolResponseHandler:
     async def _send_reciprocal_path(
         self,
         src_hash: int,
+        contact_pubkey: bytes,
         shared_secret: bytes,
         pkt: Packet,
         decrypted: bytes,
@@ -436,10 +452,14 @@ class ProtocolResponseHandler:
         - The reciprocal is sent **DIRECT** using the inner ``out_path``
           extracted from the decrypted data (e.g. [hash_B, hash_X]), which
           routes through the mesh to reach the remote repeater.
+        - Transmission is queued rather than awaited inline. Firmware invokes
+          ``onContactResponse`` before queueing this reciprocal; doing the same
+          prevents a valid login reply from expiring behind the local TX path.
         """
         if self._packet_injector is None:
             return
         try:
+            injector = self._packet_injector
             our_hash = self._local_identity.get_public_key()[0]
             # The inbound flood path (pkt.path) tells the remote repeater
             # "to reach me, go through these intermediate hops".
@@ -464,24 +484,56 @@ class ProtocolResponseHandler:
             reciprocal.header = (reciprocal.header & ~0x03) | ROUTE_TYPE_DIRECT
             reciprocal.set_path(out_path_bytes, path_len_byte)
 
-            # Await injection so the reciprocal PATH is serialized through the
-            # radio TX pipeline before this method returns.  This ensures the
-            # login callback doesn't fire until the reciprocal PATH is in flight,
-            # preventing the app's first stats REQ from racing ahead of it.
-            await self._packet_injector(reciprocal)
+            evidence_resolved = False
 
-            self._log(
-                f"[ProtocolResponse] Sending reciprocal PATH to 0x{src_hash:02X} "
-                f"via DIRECT (out_path_len={path_len_byte}, in_path_len={len(in_path)})"
-            )
-            self._log(
-                f"[PATHDIAG] reciprocal -> 0x{src_hash:02X} route=DIRECT "
-                f"routing_path={out_path_bytes.hex() or '(empty)'} "
-                f"embedded_in_path={bytes(in_path).hex() or '(empty)'} "
-                f"path_len_byte=0x{path_len_byte:02X}"
-            )
+            async def _dispatch_reciprocal() -> None:
+                nonlocal evidence_resolved
+                try:
+                    sent = await injector(reciprocal)
+                    if sent is False:
+                        raise RuntimeError("packet injector rejected reciprocal PATH")
+                    self.return_path_teacher.note_evidence_teach(contact_pubkey)
+                    evidence_resolved = True
+                    self._log(
+                        f"[ProtocolResponse] Sending reciprocal PATH to 0x{src_hash:02X} "
+                        f"via DIRECT (out_path_len={path_len_byte}, "
+                        f"in_path_len={len(in_path)})"
+                    )
+                    self._log(
+                        f"[PATHDIAG] reciprocal -> 0x{src_hash:02X} route=DIRECT "
+                        f"routing_path={out_path_bytes.hex() or '(empty)'} "
+                        f"embedded_in_path={bytes(in_path).hex() or '(empty)'} "
+                        f"path_len_byte=0x{path_len_byte:02X}"
+                    )
+                except asyncio.CancelledError:
+                    if not evidence_resolved:
+                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
+                        evidence_resolved = True
+                    raise
+                except Exception as e:
+                    if not evidence_resolved:
+                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
+                        evidence_resolved = True
+                    self._log(f"[ProtocolResponse] Failed to send reciprocal PATH: {e}")
+
+            self.return_path_teacher.begin_evidence_teach(contact_pubkey)
+            try:
+                task = asyncio.create_task(_dispatch_reciprocal())
+                self._pending_reciprocals.add(task)
+
+                def _reciprocal_done(done: asyncio.Task) -> None:
+                    nonlocal evidence_resolved
+                    self._pending_reciprocals.discard(done)
+                    if done.cancelled() and not evidence_resolved:
+                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
+                        evidence_resolved = True
+
+                task.add_done_callback(_reciprocal_done)
+            except Exception:
+                self.return_path_teacher.fail_evidence_teach(contact_pubkey)
+                raise
         except Exception as e:
-            self._log(f"[ProtocolResponse] Failed to send reciprocal PATH: {e}")
+            self._log(f"[ProtocolResponse] Failed to queue reciprocal PATH: {e}")
 
     async def _decrypt_protocol_response(
         self, pkt: Packet, src_hash: int
@@ -570,16 +622,12 @@ class ProtocolResponseHandler:
                 if pkt.is_route_flood():
                     await self._send_reciprocal_path(
                         src_hash,
+                        contact_pubkey,
                         shared_secret,
                         pkt,
                         decrypted,
                         path_len_byte,
                     )
-                    # This reciprocal *is* an evidence-derived teach. Report it,
-                    # or the teacher would think the contact was never taught
-                    # and let its reverse-of-out_path guess overwrite a route
-                    # that is known good.
-                    self.return_path_teacher.note_evidence_teach(contact_pubkey)
             elif pkt_type == PAYLOAD_TYPE_RESPONSE:
                 # Plain RESPONSE (0x01). Firmware parity with
                 # BaseChatMesh::onPeerDataRecv's RESPONSE branch: a flood-routed

--- a/src/openhop_core/node/handlers/protocol_response.py
+++ b/src/openhop_core/node/handlers/protocol_response.py
@@ -15,6 +15,7 @@ from ...protocol.packet_builder import PacketBuilder
 from ...protocol.packet_utils import PathUtils
 from .crypto_helpers import iter_decrypt_by_src_hash
 from .result import HandlerResult
+from .return_path import ReturnPathTeacher
 
 # ---------------------------------------------------------------------------
 # Built-in CayenneLPP decoder (no external dependency)
@@ -151,10 +152,24 @@ class ProtocolResponseHandler:
     - etc.
     """
 
-    def __init__(self, log_fn: Callable[[str], None], local_identity, contact_book):
+    def __init__(
+        self,
+        log_fn: Callable[[str], None],
+        local_identity,
+        contact_book,
+        *,
+        return_path_teacher: Optional["ReturnPathTeacher"] = None,
+    ):
         self._log = log_fn
         self._local_identity = local_identity
         self._contact_book = contact_book
+        # Re-teaches a peer its route back to us when a reply arrives flooded
+        # despite us holding a direct out_path. Constructed here when the caller
+        # supplies none so standalone use of this handler still works; the
+        # factory passes a shared instance (see registry.create_core_handlers).
+        self.return_path_teacher = return_path_teacher or ReturnPathTeacher(
+            log_fn, local_identity, contact_book
+        )
 
         # A response is correlated only after the MAC identifies the complete
         # contact and the peer reflects the request tag. The one-byte source
@@ -195,8 +210,13 @@ class ProtocolResponseHandler:
         repeater has no out_path for us and must fall back to plain FLOOD for
         responses — which intermediate repeaters may drop due to transport-code
         region filtering.
+
+        The same transmit path is handed to the return-path teacher, which
+        covers the flood-RESPONSE case this handler's PATH-only reciprocal
+        misses (see :mod:`.return_path`).
         """
         self._packet_injector = injector
+        self.return_path_teacher.set_injector(injector)
 
     @staticmethod
     def payload_type() -> int:
@@ -555,6 +575,26 @@ class ProtocolResponseHandler:
                         decrypted,
                         path_len_byte,
                     )
+                    # This reciprocal *is* an evidence-derived teach. Report it,
+                    # or the teacher would think the contact was never taught
+                    # and let its reverse-of-out_path guess overwrite a route
+                    # that is known good.
+                    self.return_path_teacher.note_evidence_teach(contact_pubkey)
+            elif pkt_type == PAYLOAD_TYPE_RESPONSE:
+                # Plain RESPONSE (0x01). Firmware parity with
+                # BaseChatMesh::onPeerDataRecv's RESPONSE branch: a flood-routed
+                # reply from a peer we already hold a direct out_path for means
+                # the peer has no usable route back to us, so re-teach it. This
+                # is the path a DIRECT (user-forced) login takes — the server
+                # answers it with a flood RESPONSE, not the flood PATH that
+                # carries the reciprocal above, so nothing else teaches it.
+                await self.return_path_teacher.maybe_teach_from_flood_reply(
+                    pkt,
+                    contact_pubkey,
+                    src_hash,
+                    reason="flood RESPONSE",
+                    shared_secret=shared_secret,
+                )
 
             success, text, parsed = self._parse_protocol_response(response_data)
             return success, text, parsed, decrypted, contact_pubkey, response_payload

--- a/src/openhop_core/node/handlers/registry.py
+++ b/src/openhop_core/node/handlers/registry.py
@@ -15,6 +15,7 @@ from .group_text import GroupTextHandler
 from .login_response import LoginResponseHandler
 from .path import PathHandler
 from .protocol_response import ProtocolResponseHandler
+from .return_path import ReturnPathTeacher
 from .text import TextMessageHandler
 
 
@@ -28,6 +29,7 @@ class CoreHandlers:
     protocol_response_handler: ProtocolResponseHandler
     login_response_handler: LoginResponseHandler
     path_handler: PathHandler
+    return_path_teacher: ReturnPathTeacher
 
 
 def create_core_handlers(
@@ -64,9 +66,18 @@ def create_core_handlers(
         group_packet_seen_callback: Optional shared full-hash cache callback
             for companion group text/data loopback suppression.
     """
-    protocol_response_handler = ProtocolResponseHandler(log_fn, identity, contacts)
+    # Shared by both response handlers so the per-contact re-teach cooldown is
+    # accounted once, not once per handler. Its transmit path is wired later,
+    # via ProtocolResponseHandler.set_packet_injector.
+    return_path_teacher = ReturnPathTeacher(log_fn, identity, contacts)
 
-    login_response_handler = LoginResponseHandler(identity, contacts, log_fn)
+    protocol_response_handler = ProtocolResponseHandler(
+        log_fn, identity, contacts, return_path_teacher=return_path_teacher
+    )
+
+    login_response_handler = LoginResponseHandler(
+        identity, contacts, log_fn, return_path_teacher=return_path_teacher
+    )
     login_response_handler.set_protocol_response_handler(protocol_response_handler)
     protocol_response_handler.set_login_response_handler(login_response_handler)
 
@@ -105,4 +116,5 @@ def create_core_handlers(
         protocol_response_handler=protocol_response_handler,
         login_response_handler=login_response_handler,
         path_handler=path_handler,
+        return_path_teacher=return_path_teacher,
     )

--- a/src/openhop_core/node/handlers/return_path.py
+++ b/src/openhop_core/node/handlers/return_path.py
@@ -53,9 +53,11 @@ Deliberate deviations from firmware, each documented at its definition:
   embeds whichever copy it processed first, and only its (SNR-scored,
   ships-disabled) reception hold makes that the best one; neither firmware mode
   weighs hop count, so a strong nearby repeater can append itself as an extra
-  hop. openHop does not lean on the hold and discounts extra hops. See
-  ``RETURN_PATH_SETTLE_S`` and ``RETURN_PATH_HOP_PENALTY_DB``. There is
-  deliberately no cross-reply downgrade guard:
+  hop. openHop does not lean on the hold; it applies a fixed dependency penalty
+  before considering any routed copy, then discounts each hop. See
+  ``RETURN_PATH_SETTLE_S``, ``RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB``, and
+  ``RETURN_PATH_HOP_PENALTY_DB``. There is deliberately no cross-reply downgrade
+  guard:
   firmware has none, and a flood reply from a peer we hold an ``out_path`` for is
   by this module's own premise a broken return route, so refusing to re-teach it
   because a newer copy is weaker than a previous (non-working) one would prolong
@@ -123,9 +125,26 @@ RETURN_PATH_COOLDOWN_S = 5.0
 # firmware when the hold is off and no worse when it is on.
 RETURN_PATH_SETTLE_S = 3.0
 
-# Cost, in dB of last-hop RSSI, charged per hop when choosing between copies of a
-# flood reply. Copies are ranked by ``rssi - HOP_PENALTY_DB * hop_count`` so a
-# longer route only wins when it is *materially* stronger, not merely a couple dB.
+# Deliberate firmware divergence: fixed cost, in dB of last-hop RSSI, charged
+# once to every routed copy. Firmware embeds whichever flood copy it processes;
+# it does not give direct reception an explicit preference.
+#
+# This penalty represents the new forwarding dependency introduced by replacing
+# a proven zero-hop route with any routed route. It is intentionally finite:
+# HOWL Repeater's observed zero-hop -46 dBm copy should beat its one-hop B5B5
+# copy at -12 dBm, but a tenuous zero-hop copy around -120 dBm should still lose
+# to a materially stronger routed copy. Applying the same fixed cost to every
+# non-zero-hop candidate leaves comparisons among routed paths unchanged.
+RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB = 30.0
+
+# Additional cost, in dB of last-hop RSSI, charged per hop when choosing between
+# copies of a flood reply. Together with the fixed dependency penalty above,
+# copies are ranked by:
+#
+#   rssi - ROUTED_DEPENDENCY_PENALTY_DB - HOP_PENALTY_DB * hop_count
+#
+# (The fixed term is omitted for zero-hop copies.) A longer route therefore only
+# wins when it is materially stronger, not merely a couple dB.
 #
 # Neither firmware mode weighs hop count: the default embeds the first-arrived
 # copy (Mesh.cpp notes the path "may not be the best in terms of hops"), and the
@@ -172,8 +191,7 @@ class _FloodCopy:
     ``rssi`` is the last-hop RSSI of the copy (higher is stronger); ``path`` /
     ``len_byte`` are the flood accumulation path that copy arrived on — the route
     the peer should be taught to use back to us. ``score`` is the hop-penalized
-    rank (``rssi - HOP_PENALTY_DB * hop_count``) copies are compared on, so a
-    shorter route is preferred unless a longer one is materially stronger.
+    rank, including the fixed routed-dependency penalty documented above.
     ``ts`` is the monotonic time the entry was last improved, for TTL pruning.
     """
 
@@ -515,16 +533,18 @@ class ReturnPathTeacher:
     # ---- best-copy collection (hop-penalized RSSI selection) ---------------
 
     def _copy_score(self, rssi: int, len_byte: int) -> float:
-        """Rank a flood copy: last-hop RSSI minus a per-hop penalty.
+        """Rank a flood copy by last-hop RSSI and routing dependency.
 
-        Prefers a shorter return route unless a longer one is materially
-        stronger. See :data:`RETURN_PATH_HOP_PENALTY_DB`.
+        A routed copy pays one fixed dependency penalty plus the per-hop
+        penalty. A zero-hop copy pays neither. Both costs are finite, so a
+        materially stronger routed copy can still beat a tenuous direct link.
         """
         try:
             hops = PathUtils.get_path_hash_count(len_byte)
         except Exception:
             hops = 0
-        return rssi - self._hop_penalty_db * hops
+        dependency_penalty = RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB if hops else 0.0
+        return rssi - dependency_penalty - self._hop_penalty_db * hops
 
     def _addressed_to_us(self, dest_hash: int) -> bool:
         """True when ``dest_hash`` is our own hash (or our hash is unknown).
@@ -557,9 +577,10 @@ class ReturnPathTeacher:
     def _record_copy(self, packet_hash: bytes, path: bytes, len_byte: int, rssi: int) -> None:
         """Keep the highest-scoring copy of a flood reply, keyed by packet hash.
 
-        Copies are ranked by :meth:`_copy_score` (hop-penalized RSSI), so a
-        stronger-but-longer route only displaces a shorter one when it wins on
-        score, not on raw RSSI alone.
+        Copies are ranked by :meth:`_copy_score`, including the finite
+        routed-dependency and per-hop penalties. A routed copy can displace a
+        direct or shorter copy only when its last-hop RSSI advantage is large
+        enough to pay those costs.
         """
         now = self._time()
         self._prune_copies(now)

--- a/src/openhop_core/node/handlers/return_path.py
+++ b/src/openhop_core/node/handlers/return_path.py
@@ -42,12 +42,24 @@ Deliberate deviations from firmware, each documented at its definition:
 * ``RETURN_PATH_COOLDOWN_S`` throttles re-teaching per contact. Firmware has no
   such throttle; openHop adds one so a burst of flood replies cannot turn into a
   burst of transmits.
-* Firmware paces its retry with ``sendDirect(..., 3000)`` — a *queued* send with
-  a 3 s delay, which never blocks packet processing. openHop's injector takes no
-  delay argument, so a teach is dispatched as a background task instead. It must
-  not be awaited inline on the RX path: the injector may block on a TX lock and
-  an airtime budget, which would delay delivery of the very reply that triggered
-  it, potentially past its own response timeout.
+* Firmware paces its retry with ``sendDirect(..., 3000)`` — a *queued* send whose
+  3 s delay is a settle window (``queueOutbound(..., futureMillis(3000))``), not a
+  busy wait. openHop honours that window (``RETURN_PATH_SETTLE_S``) in a background
+  task rather than inline on the RX path: the injector may block on a TX lock and
+  an airtime budget, and awaiting it inline would delay delivery of the very reply
+  that triggered the teach, potentially past its own response timeout.
+* openHop picks the teach source by a hop-penalized last-hop RSSI across every
+  copy of the flood reply, collected pre-dedup via ``note_flood_copy``. Firmware
+  embeds whichever copy it processed first, and only its (SNR-scored,
+  ships-disabled) reception hold makes that the best one; neither firmware mode
+  weighs hop count, so a strong nearby repeater can append itself as an extra
+  hop. openHop does not lean on the hold and discounts extra hops. See
+  ``RETURN_PATH_SETTLE_S`` and ``RETURN_PATH_HOP_PENALTY_DB``. There is
+  deliberately no cross-reply downgrade guard:
+  firmware has none, and a flood reply from a peer we hold an ``out_path`` for is
+  by this module's own premise a broken return route, so refusing to re-teach it
+  because a newer copy is weaker than a previous (non-working) one would prolong
+  the failure.
 * ``maybe_teach_reverse_of_out_path`` has no firmware counterpart at all. See its
   docstring for the guard that keeps a guess from overwriting a known-good route.
 
@@ -62,10 +74,11 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import OrderedDict
 from typing import Any, Callable, Optional, Set
 
 from ...protocol import Identity, Packet
-from ...protocol.constants import PH_ROUTE_MASK, ROUTE_TYPE_DIRECT
+from ...protocol.constants import PAYLOAD_TYPE_RESPONSE, PH_ROUTE_MASK, ROUTE_TYPE_DIRECT
 from ...protocol.packet_builder import PacketBuilder
 from ...protocol.packet_utils import PathUtils
 
@@ -83,6 +96,53 @@ from ...protocol.packet_utils import PathUtils
 # no prior teach has no cooldown entry, and re-teaching the same guess every two
 # seconds buys nothing.
 RETURN_PATH_COOLDOWN_S = 5.0
+
+# How long to keep collecting copies of a flood reply before teaching from the
+# best-received one. Firmware sends its retry with ``sendDirect(..., 3000)``;
+# that 3 s is a queued-send "not before" schedule (``queueOutbound(...,
+# futureMillis(3000))``) — a settle window, not just pacing.
+#
+# A flood reply reaches us by several routes, and openHop's dedup, like
+# firmware's ``hasSeen``, is "first packet wins". The first copy to arrive is
+# NOT the best route -- observed on a live SF7/62.5k mesh, four copies of one
+# login reply landed over ~6 s at -102, -62, -41 and -24 dBm, weakest first.
+# Teaching from the first copy tells the peer to answer down its most marginal
+# link, and its replies then die there while flood replies still get through,
+# which looks exactly like the bug this module was written to fix.
+#
+# Firmware avoids this only when its reception-quality hold is enabled: the hold
+# reorders flood processing so the best-scored copy is seen (and marks-seen)
+# first, making firmware's embedded ``packet->path`` the best copy. But the hold
+# is scored on SNR alone and ships DISABLED (``rx_delay_base`` is memset-zeroed;
+# the enabling line is commented "enable once new algo fixed"), so on a stock
+# node firmware embeds the first-arrived copy -- and its 3 s delay only defers
+# the transmit, it does not re-pick the copy. openHop therefore selects the
+# teach source itself, by a hop-penalized last-hop RSSI (see
+# ``RETURN_PATH_HOP_PENALTY_DB`` and ``note_flood_copy``), during this window
+# instead of leaning on the hold. Unchanged on the wire, strictly better than
+# firmware when the hold is off and no worse when it is on.
+RETURN_PATH_SETTLE_S = 3.0
+
+# Cost, in dB of last-hop RSSI, charged per hop when choosing between copies of a
+# flood reply. Copies are ranked by ``rssi - HOP_PENALTY_DB * hop_count`` so a
+# longer route only wins when it is *materially* stronger, not merely a couple dB.
+#
+# Neither firmware mode weighs hop count: the default embeds the first-arrived
+# copy (Mesh.cpp notes the path "may not be the best in terms of hops"), and the
+# optional SNR hold would embed the strongest copy regardless of length. Without
+# this penalty, a strong nearby repeater -- e.g. one on the same desk as the
+# node -- re-floods almost every reply and appends itself as a final hop, so
+# pure best-RSSI would route returns through it even when a shorter route is
+# adequate. ~10 dB/hop keeps that extra hop only when it genuinely buys signal:
+# a 3-hop copy at -13 still beats a 2-hop copy at -40, but loses to one at -15.
+RETURN_PATH_HOP_PENALTY_DB = 10.0
+
+# Bounds for the best-copy table (``note_flood_copy``): entries older than the
+# TTL are dropped and the table never holds more than ``_MAX`` hashes (oldest
+# evicted). The TTL only has to outlive one settle window; it is clamped up to
+# cover a custom ``settle_s`` in __init__.
+RETURN_PATH_COPY_TTL_S = 8.0
+RETURN_PATH_COPY_CACHE_MAX = 128
 
 
 def reverse_path(path: bytes, path_len_byte: int) -> Optional[bytes]:
@@ -106,6 +166,27 @@ def reverse_path(path: bytes, path_len_byte: int) -> Optional[bytes]:
     return b"".join(reversed(hops))
 
 
+class _FloodCopy:
+    """The best-received copy of one flood reply, keyed by its packet hash.
+
+    ``rssi`` is the last-hop RSSI of the copy (higher is stronger); ``path`` /
+    ``len_byte`` are the flood accumulation path that copy arrived on — the route
+    the peer should be taught to use back to us. ``score`` is the hop-penalized
+    rank (``rssi - HOP_PENALTY_DB * hop_count``) copies are compared on, so a
+    shorter route is preferred unless a longer one is materially stronger.
+    ``ts`` is the monotonic time the entry was last improved, for TTL pruning.
+    """
+
+    __slots__ = ("path", "len_byte", "rssi", "score", "ts")
+
+    def __init__(self, path: bytes, len_byte: int, rssi: int, score: float, ts: float) -> None:
+        self.path = path
+        self.len_byte = len_byte
+        self.rssi = rssi
+        self.score = score
+        self.ts = ts
+
+
 class ReturnPathTeacher:
     """Sends ``PAYLOAD_TYPE_PATH`` teaches so a peer learns its route back to us.
 
@@ -121,12 +202,16 @@ class ReturnPathTeacher:
         contact_book: Any,
         *,
         cooldown_s: float = RETURN_PATH_COOLDOWN_S,
+        settle_s: float = RETURN_PATH_SETTLE_S,
+        hop_penalty_db: float = RETURN_PATH_HOP_PENALTY_DB,
         time_fn: Callable[[], float] = time.monotonic,
     ) -> None:
         self._log = log_fn
         self._local_identity = local_identity
         self._contact_book = contact_book
         self._cooldown_s = cooldown_s
+        self._settle_s = settle_s
+        self._hop_penalty_db = hop_penalty_db
         self._time = time_fn
         self._injector: Optional[Callable] = None
         # contact pubkey -> monotonic timestamp of the last teach dispatched.
@@ -138,6 +223,16 @@ class ReturnPathTeacher:
         self._taught_from_evidence: Set[bytes] = set()
         # In-flight teach tasks, so callers (and tests) can await completion.
         self._pending_teaches: Set[asyncio.Task] = set()
+        # packet hash -> best-received copy, populated pre-dedup by
+        # note_flood_copy across the settle window. Bounded and TTL-pruned; the
+        # TTL must outlive one settle window.
+        self._recent_copies: "OrderedDict[bytes, _FloodCopy]" = OrderedDict()
+        self._copy_ttl_s = max(RETURN_PATH_COPY_TTL_S, self._settle_s + 2.0)
+        self._copy_cache_max = RETURN_PATH_COPY_CACHE_MAX
+        # Cached destination hash (our own) used to filter recorded copies to
+        # replies addressed to us. Resolved lazily so a late-bound identity still
+        # works; None means "record regardless" rather than dropping everything.
+        self._local_hash: Optional[int] = None
 
     def set_injector(self, injector: Optional[Callable]) -> None:
         """Set the async callable used to transmit a teach packet."""
@@ -155,6 +250,42 @@ class ReturnPathTeacher:
         key = bytes(contact_pubkey)
         self._taught_from_evidence.add(key)
         self._last_taught[key] = self._time()
+
+    def note_flood_copy(self, pkt: Packet, data: Any = None, analysis: Any = None) -> None:
+        """Record a flood reply copy for best-route selection (raw RX subscriber).
+
+        Wired via ``dispatcher.add_raw_packet_subscriber``, which fires for every
+        received packet *before* dedup — the only place later copies of a flood
+        reply are visible, since dedup drops them before any handler runs. Keeps,
+        per packet hash, the highest-scoring copy (hop-penalized last-hop RSSI,
+        see :meth:`_copy_score`) so a teach triggered on the first-arrived copy
+        can still embed the best route (see :meth:`maybe_teach_from_flood_reply`).
+
+        Best-effort and cheap: only flood ``RESPONSE`` packets addressed to us are
+        recorded (exactly what triggers a teach), and any error is swallowed —
+        this runs on the hot RX path and must never disturb packet processing.
+        """
+        if self._injector is None:
+            return
+        try:
+            if not pkt.is_route_flood():
+                return
+            if pkt.get_payload_type() != PAYLOAD_TYPE_RESPONSE:
+                return
+            payload = getattr(pkt, "payload", None)
+            if payload is None or len(payload) < 2:
+                return
+            if not self._addressed_to_us(payload[0]):
+                return
+            len_byte = int(getattr(pkt, "path_len", 0) or 0)
+            path = self._validated_inbound_path(pkt, len_byte)
+            if path is None:
+                return
+            packet_hash = bytes(pkt.calculate_packet_hash())
+            rssi = int(getattr(pkt, "_rssi", 0) or 0)
+            self._record_copy(packet_hash, path, len_byte, rssi)
+        except Exception as e:  # never let a bad copy disturb RX
+            self._log(f"[ReturnPath] note_flood_copy ignored a packet: {e}")
 
     async def wait_for_pending(self) -> None:
         """Await every in-flight teach. Intended for shutdown and for tests."""
@@ -187,6 +318,12 @@ class ReturnPathTeacher:
         accumulation path the reply arrived on, which is precisely the route
         from the peer back to us.
 
+        The triggering ``pkt`` is only the *first-arrived* copy (dedup drops the
+        rest before this handler runs). This copy is used as a seed/fallback, but
+        the teach is delayed by :data:`RETURN_PATH_SETTLE_S` and then embeds the
+        best-RSSI copy collected pre-dedup by :meth:`note_flood_copy` — see the
+        constant's docstring for why first-arrived is often the worst route.
+
         Returns True when a teach was transmitted.
         """
         if self._injector is None:
@@ -201,31 +338,34 @@ class ReturnPathTeacher:
             return False
 
         in_len_byte = int(getattr(pkt, "path_len", 0) or 0)
-        if not PathUtils.is_valid_path_len(in_len_byte):
+        embedded_path = self._validated_inbound_path(pkt, in_len_byte)
+        if embedded_path is None:
             self._log(
-                f"[ReturnPath] Skip teach to 0x{src_hash:02X}: "
-                f"inbound path_len 0x{in_len_byte:02X} is malformed"
+                f"[ReturnPath] Skip teach to 0x{src_hash:02X}: inbound path "
+                f"(path_len 0x{in_len_byte:02X}) is malformed or truncated"
             )
             return False
-        in_byte_len = PathUtils.get_path_byte_len(in_len_byte)
-        raw_path = bytes(pkt.path or b"")
-        if len(raw_path) < in_byte_len:
-            self._log(
-                f"[ReturnPath] Skip teach to 0x{src_hash:02X}: inbound path is "
-                f"{len(raw_path)}B, path_len byte declares {in_byte_len}B"
-            )
-            return False
+
+        # Seed the best-copy table with this first-arrived copy so a teach still
+        # has a source even when no raw subscriber is wired (standalone/tests);
+        # note_flood_copy improves it with better copies during the settle window.
+        packet_hash = bytes(pkt.calculate_packet_hash())
+        self._record_copy(
+            packet_hash, embedded_path, in_len_byte, int(getattr(pkt, "_rssi", 0) or 0)
+        )
 
         return await self._teach(
             contact_pubkey=contact_pubkey,
             dest_hash=src_hash,
-            embedded_path=raw_path[:in_byte_len],
+            embedded_path=embedded_path,
             embedded_len_byte=in_len_byte,
             out_path=out_path,
             out_path_len=out_path_len,
             shared_secret=shared_secret,
             reason=reason,
             from_evidence=True,
+            hash_key=packet_hash,
+            settle_s=self._settle_s,
         )
 
     # ------------------------------------------------------------------
@@ -350,6 +490,83 @@ class ReturnPathTeacher:
         last = self._last_taught.get(key)
         return last is not None and (self._time() - last) < self._cooldown_s
 
+    # ---- best-copy collection (hop-penalized RSSI selection) ---------------
+
+    def _copy_score(self, rssi: int, len_byte: int) -> float:
+        """Rank a flood copy: last-hop RSSI minus a per-hop penalty.
+
+        Prefers a shorter return route unless a longer one is materially
+        stronger. See :data:`RETURN_PATH_HOP_PENALTY_DB`.
+        """
+        try:
+            hops = PathUtils.get_path_hash_count(len_byte)
+        except Exception:
+            hops = 0
+        return rssi - self._hop_penalty_db * hops
+
+    def _addressed_to_us(self, dest_hash: int) -> bool:
+        """True when ``dest_hash`` is our own hash (or our hash is unknown).
+
+        Filters the pre-dedup firehose down to replies actually meant for us.
+        If our hash cannot be resolved we record regardless rather than drop
+        everything — a slightly larger table is safer than a silent no-op.
+        """
+        if self._local_hash is None:
+            try:
+                self._local_hash = self._local_identity.get_public_key()[0]
+            except Exception:
+                return True
+        return dest_hash == self._local_hash
+
+    def _validated_inbound_path(self, pkt: Packet, len_byte: int) -> Optional[bytes]:
+        """The inbound flood path trimmed to its declared length, or None.
+
+        Shared by :meth:`note_flood_copy` (hot path) and
+        :meth:`maybe_teach_from_flood_reply`.
+        """
+        if not PathUtils.is_valid_path_len(len_byte):
+            return None
+        byte_len = PathUtils.get_path_byte_len(len_byte)
+        raw = bytes(getattr(pkt, "path", b"") or b"")
+        if len(raw) < byte_len:
+            return None
+        return raw[:byte_len]
+
+    def _record_copy(self, packet_hash: bytes, path: bytes, len_byte: int, rssi: int) -> None:
+        """Keep the highest-scoring copy of a flood reply, keyed by packet hash.
+
+        Copies are ranked by :meth:`_copy_score` (hop-penalized RSSI), so a
+        stronger-but-longer route only displaces a shorter one when it wins on
+        score, not on raw RSSI alone.
+        """
+        now = self._time()
+        self._prune_copies(now)
+        score = self._copy_score(rssi, len_byte)
+        existing = self._recent_copies.get(packet_hash)
+        if existing is not None and score <= existing.score:
+            existing.ts = now  # refresh so the winning copy outlives the window
+            self._recent_copies.move_to_end(packet_hash)
+            return
+        self._recent_copies[packet_hash] = _FloodCopy(path, len_byte, rssi, score, now)
+        self._recent_copies.move_to_end(packet_hash)
+        if len(self._recent_copies) > self._copy_cache_max:
+            self._recent_copies.popitem(last=False)  # evict least-recently-touched
+
+    def _prune_copies(self, now: float) -> None:
+        """Drop copies older than the TTL. Front entries are the oldest-touched."""
+        ttl = self._copy_ttl_s
+        while self._recent_copies:
+            oldest = next(iter(self._recent_copies))
+            if (now - self._recent_copies[oldest].ts) <= ttl:
+                break
+            self._recent_copies.popitem(last=False)
+
+    async def _settle(self, seconds: float) -> None:
+        """Wait out the teach settle window (overridable by tests/subclasses)."""
+        await asyncio.sleep(seconds)
+
+    # ---- teach dispatch ---------------------------------------------------
+
     async def _teach(
         self,
         *,
@@ -362,14 +579,22 @@ class ReturnPathTeacher:
         shared_secret: Optional[bytes],
         reason: str,
         from_evidence: bool,
+        hash_key: Optional[bytes] = None,
+        settle_s: float = 0.0,
     ) -> bool:
-        """Build one return-path teach and dispatch it. True when dispatched.
+        """Schedule one return-path teach. True when a teach was scheduled.
 
         The cooldown is claimed *synchronously*, before anything is awaited, so
         two concurrent triggers for the same contact cannot both pass the check
         and both transmit. It is released again if the packet never reaches the
         injector, so a failed teach is retried on the next trigger instead of
         being muted for the whole cooldown window.
+
+        The packet is *not* built here: with a ``settle_s`` window the best copy
+        is not known until the window closes, so build and transmit both happen
+        in :meth:`_dispatch_teach`. The shared secret is derived up front so a
+        contact that cannot be resolved fails synchronously (returns False)
+        rather than after the settle delay.
         """
         key = bytes(contact_pubkey)
         if self._cooldown_active(key):
@@ -382,6 +607,69 @@ class ReturnPathTeacher:
         secret = shared_secret if shared_secret is not None else self._shared_secret_for(key)
         if not secret:
             return False
+
+        # Claim the cooldown now: everything past this point is asynchronous.
+        previous = self._last_taught.get(key)
+        self._last_taught[key] = self._time()
+
+        # Firmware queues this send (sendDirect with a 3s delay) rather than
+        # blocking. Awaiting it here would stall the RX path — the injector can
+        # wait on a TX lock and an airtime budget — and delay delivery of the
+        # reply that triggered the teach.
+        task = asyncio.ensure_future(
+            self._dispatch_teach(
+                key=key,
+                previous_cooldown=previous,
+                dest_hash=dest_hash,
+                secret=secret,
+                embedded_path=embedded_path,
+                embedded_len_byte=embedded_len_byte,
+                out_path=out_path,
+                out_path_len=out_path_len,
+                reason=reason,
+                from_evidence=from_evidence,
+                hash_key=hash_key,
+                settle_s=settle_s,
+            )
+        )
+        self._pending_teaches.add(task)
+        task.add_done_callback(self._pending_teaches.discard)
+        return True
+
+    async def _dispatch_teach(
+        self,
+        *,
+        key: bytes,
+        previous_cooldown: Optional[float],
+        dest_hash: int,
+        secret: bytes,
+        embedded_path: bytes,
+        embedded_len_byte: int,
+        out_path: bytes,
+        out_path_len: int,
+        reason: str,
+        from_evidence: bool,
+        hash_key: Optional[bytes],
+        settle_s: float,
+    ) -> None:
+        """Wait out the settle window, then build and transmit the best teach.
+
+        Rolls the cooldown back on any failure so the next trigger can retry.
+        """
+        if settle_s > 0.0:
+            await self._settle(settle_s)
+
+        # Pick the best-received copy collected during the window. Falls back to
+        # the seed passed in (the first-arrived copy) when nothing better was
+        # recorded, when the entry was evicted, or for a reverse-of-out_path
+        # guess (which has no hash_key and no inbound copies to collect).
+        chosen_rssi: Optional[int] = None
+        if hash_key is not None:
+            best = self._recent_copies.pop(hash_key, None)
+            if best is not None:
+                embedded_path = best.path
+                embedded_len_byte = best.len_byte
+                chosen_rssi = best.rssi
 
         try:
             teach = PacketBuilder.create_path_return(
@@ -397,50 +685,6 @@ class ReturnPathTeacher:
             # sends it DIRECT along the out_path we already hold for the peer.
             teach.header = (teach.header & ~PH_ROUTE_MASK) | ROUTE_TYPE_DIRECT
             teach.set_path(out_path, out_path_len)
-        except Exception as e:
-            self._log(f"[ReturnPath] Failed to build teach for 0x{dest_hash:02X}: {e}")
-            return False
-
-        # Claim the cooldown now: everything past this point is asynchronous.
-        previous = self._last_taught.get(key)
-        self._last_taught[key] = self._time()
-
-        # Firmware queues this send (sendDirect with a 3s delay) rather than
-        # blocking. Awaiting the injector here would stall the RX path — it can
-        # wait on a TX lock and an airtime budget — and delay delivery of the
-        # reply that triggered the teach.
-        task = asyncio.ensure_future(
-            self._dispatch_teach(
-                teach=teach,
-                key=key,
-                previous_cooldown=previous,
-                dest_hash=dest_hash,
-                embedded_path=embedded_path,
-                embedded_len_byte=embedded_len_byte,
-                out_path=out_path,
-                reason=reason,
-                from_evidence=from_evidence,
-            )
-        )
-        self._pending_teaches.add(task)
-        task.add_done_callback(self._pending_teaches.discard)
-        return True
-
-    async def _dispatch_teach(
-        self,
-        *,
-        teach: Packet,
-        key: bytes,
-        previous_cooldown: Optional[float],
-        dest_hash: int,
-        embedded_path: bytes,
-        embedded_len_byte: int,
-        out_path: bytes,
-        reason: str,
-        from_evidence: bool,
-    ) -> None:
-        """Transmit a prepared teach, rolling back the cooldown on failure."""
-        try:
             await self._injector(teach)
         except Exception as e:
             if previous_cooldown is None:
@@ -456,9 +700,17 @@ class ReturnPathTeacher:
         if from_evidence:
             self._taught_from_evidence.add(key)
 
+        if chosen_rssi is not None:
+            try:
+                hops = PathUtils.get_path_hash_count(embedded_len_byte)
+            except Exception:
+                hops = "?"
+            rssi_note = f", best last-hop RSSI {chosen_rssi} over {hops} hop(s)"
+        else:
+            rssi_note = ""
         self._log(
             f"[ReturnPath] Taught 0x{dest_hash:02X} its route back ({reason}): "
             f"embedded={embedded_path.hex() or '(zero-hop)'} "
-            f"(path_len=0x{embedded_len_byte:02X}), "
+            f"(path_len=0x{embedded_len_byte:02X}){rssi_note}, "
             f"sent DIRECT via {out_path.hex() or '(zero-hop)'}"
         )

--- a/src/openhop_core/node/handlers/return_path.py
+++ b/src/openhop_core/node/handlers/return_path.py
@@ -221,6 +221,11 @@ class ReturnPathTeacher:
         # here, the reverse-of-out_path guess is permanently disabled for it —
         # see maybe_teach_reverse_of_out_path.
         self._taught_from_evidence: Set[bytes] = set()
+        # Reciprocal PATH sends are now queued so response delivery is never
+        # blocked by TX. Count queued evidence teaches per contact so a request
+        # timeout cannot launch a speculative reverse-path teach while a real
+        # observed-path teach is still in flight.
+        self._pending_evidence_teaches: dict[bytes, int] = {}
         # In-flight teach tasks, so callers (and tests) can await completion.
         self._pending_teaches: Set[asyncio.Task] = set()
         # packet hash -> best-received copy, populated pre-dedup by
@@ -248,8 +253,25 @@ class ReturnPathTeacher:
         let the reverse-of-out_path guess overwrite a route that is known good.
         """
         key = bytes(contact_pubkey)
+        self._finish_pending_evidence_teach(key)
         self._taught_from_evidence.add(key)
         self._last_taught[key] = self._time()
+
+    def begin_evidence_teach(self, contact_pubkey: bytes) -> None:
+        """Record one observed-path teach queued by another handler."""
+        key = bytes(contact_pubkey)
+        self._pending_evidence_teaches[key] = self._pending_evidence_teaches.get(key, 0) + 1
+
+    def fail_evidence_teach(self, contact_pubkey: bytes) -> None:
+        """Release one queued evidence teach that failed before transmission."""
+        self._finish_pending_evidence_teach(bytes(contact_pubkey))
+
+    def _finish_pending_evidence_teach(self, key: bytes) -> None:
+        count = self._pending_evidence_teaches.get(key, 0)
+        if count <= 1:
+            self._pending_evidence_teaches.pop(key, None)
+        else:
+            self._pending_evidence_teaches[key] = count - 1
 
     def note_flood_copy(self, pkt: Packet, data: Any = None, analysis: Any = None) -> None:
         """Record a flood reply copy for best-route selection (raw RX subscriber).
@@ -407,10 +429,10 @@ class ReturnPathTeacher:
             return False
 
         key = bytes(contact_pubkey)
-        if key in self._taught_from_evidence:
+        if key in self._taught_from_evidence or key in self._pending_evidence_teaches:
             self._log(
                 f"[ReturnPath] Skip reverse teach to 0x{key[0]:02X} ({reason}): "
-                "already taught from an observed inbound path"
+                "already taught, or being taught, from an observed inbound path"
             )
             return False
 

--- a/src/openhop_core/node/handlers/return_path.py
+++ b/src/openhop_core/node/handlers/return_path.py
@@ -1,0 +1,464 @@
+"""Reciprocal return-path teaching for flood-routed replies.
+
+MeshCore servers do **not** derive a reply route by reversing the path an
+inbound request arrived on. ``simple_repeater``'s ``MyMesh::onPeerDataRecv``
+answers a DIRECT ``PAYLOAD_TYPE_REQ`` out of the per-client ``out_path`` stored
+in its ACL::
+
+    if (client->out_path_len != OUT_PATH_UNKNOWN) {
+      sendDirect(reply, client->out_path, client->out_path_len, ...);
+    } else {
+      sendFloodReply(reply, ...);
+    }
+
+That ``out_path`` has exactly one writer — ``onPeerPathRecv``, i.e. receiving a
+``PAYLOAD_TYPE_PATH`` packet from the client. A client that never sends one
+leaves the server replying down whatever route it last stored, which after a
+direct login is either nothing (``OUT_PATH_UNKNOWN`` -> flood) or a stale route
+from an earlier session (``MyMesh.cpp``: ``if (is_flood) client->out_path_len =
+OUT_PATH_UNKNOWN;`` — a *direct* login deliberately does not reset it).
+
+MeshCore's chat client covers this with a self-healing retry
+(``BaseChatMesh::onPeerDataRecv`` RESPONSE branch and ``onAckRecv``)::
+
+    if (packet->isRouteFlood() && from.out_path_len != OUT_PATH_UNKNOWN) {
+      // we have direct path, but other node is still sending flood response,
+      // so maybe they didn't receive reciprocal path properly(?)
+      handleReturnPathRetry(from, packet->path, packet->path_len);
+    }
+
+A flood reply from a peer we *already* hold a direct ``out_path`` for is the
+tell: the peer has no usable route back to us. The fix is to re-teach it with a
+``createPathReturn`` sent DIRECT along our own ``out_path``.
+
+openHop previously sent a reciprocal PATH in only one place — on receiving a
+flood ``PAYLOAD_TYPE_PATH`` (:mod:`.protocol_response`). That covers a *flood*
+login, whose response comes back wrapped in a PATH. It does not cover a login
+sent DIRECT (the user-forced-path case), which the server answers with a plain
+flood ``RESPONSE``. This module supplies the missing parity.
+
+Deliberate deviations from firmware, each documented at its definition:
+
+* ``RETURN_PATH_COOLDOWN_S`` throttles re-teaching per contact. Firmware has no
+  such throttle; openHop adds one so a burst of flood replies cannot turn into a
+  burst of transmits.
+* Firmware paces its retry with ``sendDirect(..., 3000)`` — a *queued* send with
+  a 3 s delay, which never blocks packet processing. openHop's injector takes no
+  delay argument, so a teach is dispatched as a background task instead. It must
+  not be awaited inline on the RX path: the injector may block on a TX lock and
+  an airtime budget, which would delay delivery of the very reply that triggered
+  it, potentially past its own response timeout.
+* ``maybe_teach_reverse_of_out_path`` has no firmware counterpart at all. See its
+  docstring for the guard that keeps a guess from overwriting a known-good route.
+
+Not yet covered: firmware also re-teaches from ``onAckRecv``. A discrete ACK on
+the wire is a bare 4-byte CRC with no source hash, and openHop's dispatcher
+tracks pending ACK CRCs in a plain set with no contact attribution, so there is
+nothing to key the re-teach on. Wiring that up needs a CRC->contact map in the
+send path; it is not required for the request/response flows this module fixes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Callable, Optional, Set
+
+from ...protocol import Identity, Packet
+from ...protocol.constants import PH_ROUTE_MASK, ROUTE_TYPE_DIRECT
+from ...protocol.packet_builder import PacketBuilder
+from ...protocol.packet_utils import PathUtils
+
+# Minimum gap between two return-path teaches aimed at the same contact.
+# Firmware has no equivalent throttle: it re-teaches on every qualifying flood
+# reply. openHop adds one as a safety valve so a peer that keeps flooding (for
+# example because our teach itself is not getting through) cannot drive an
+# unbounded transmit rate.
+#
+# This is shorter than a typical request retry cadence but not uniformly so:
+# measured adaptive response timeouts (SF10/250k/4:5, 40 B) run ~2.4 s zero-hop,
+# ~4.2 s one-hop, ~4.8 s flood and ~6.1 s at two hops, so for near contacts the
+# second and third retry-driven teaches are suppressed. That is intended — the
+# first teach after a timeout still goes out immediately, because a contact with
+# no prior teach has no cooldown entry, and re-teaching the same guess every two
+# seconds buys nothing.
+RETURN_PATH_COOLDOWN_S = 5.0
+
+
+def reverse_path(path: bytes, path_len_byte: int) -> Optional[bytes]:
+    """Reverse a routing path hash-by-hash.
+
+    A path is ``hash_count`` entries of ``hash_size`` bytes each, ordered from
+    the sender outward. The route back is the same repeaters in the opposite
+    order, so the reversal has to work on whole hashes — reversing the raw bytes
+    would corrupt any path using 2- or 3-byte hashes.
+
+    Returns ``None`` when ``path_len_byte`` is malformed or does not describe
+    exactly ``path``.
+    """
+    if not PathUtils.is_valid_path_len(path_len_byte):
+        return None
+    hash_size = PathUtils.get_path_hash_size(path_len_byte)
+    hash_count = PathUtils.get_path_hash_count(path_len_byte)
+    if len(path) != hash_size * hash_count:
+        return None
+    hops = [path[i * hash_size : (i + 1) * hash_size] for i in range(hash_count)]
+    return b"".join(reversed(hops))
+
+
+class ReturnPathTeacher:
+    """Sends ``PAYLOAD_TYPE_PATH`` teaches so a peer learns its route back to us.
+
+    One instance is shared by the login and protocol-response handlers (see
+    :func:`..registry.create_core_handlers`) so the cooldown is accounted per
+    contact rather than per handler.
+    """
+
+    def __init__(
+        self,
+        log_fn: Callable[[str], None],
+        local_identity: Any,
+        contact_book: Any,
+        *,
+        cooldown_s: float = RETURN_PATH_COOLDOWN_S,
+        time_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._log = log_fn
+        self._local_identity = local_identity
+        self._contact_book = contact_book
+        self._cooldown_s = cooldown_s
+        self._time = time_fn
+        self._injector: Optional[Callable] = None
+        # contact pubkey -> monotonic timestamp of the last teach dispatched.
+        # Bounded by the contact book: keys only come from resolved contacts.
+        self._last_taught: dict[bytes, float] = {}
+        # Contacts we have taught from a real inbound path. Once a contact is in
+        # here, the reverse-of-out_path guess is permanently disabled for it —
+        # see maybe_teach_reverse_of_out_path.
+        self._taught_from_evidence: Set[bytes] = set()
+        # In-flight teach tasks, so callers (and tests) can await completion.
+        self._pending_teaches: Set[asyncio.Task] = set()
+
+    def set_injector(self, injector: Optional[Callable]) -> None:
+        """Set the async callable used to transmit a teach packet."""
+        self._injector = injector
+
+    def note_evidence_teach(self, contact_pubkey: bytes) -> None:
+        """Record that a return path was taught to ``contact_pubkey`` from a real
+        inbound path by some *other* code path.
+
+        :meth:`ProtocolResponseHandler._send_reciprocal_path` also teaches a
+        return path (its flood-PATH reciprocal). It must report that here, or
+        this teacher would believe the contact has never been taught and would
+        let the reverse-of-out_path guess overwrite a route that is known good.
+        """
+        key = bytes(contact_pubkey)
+        self._taught_from_evidence.add(key)
+        self._last_taught[key] = self._time()
+
+    async def wait_for_pending(self) -> None:
+        """Await every in-flight teach. Intended for shutdown and for tests."""
+        if self._pending_teaches:
+            await asyncio.gather(*tuple(self._pending_teaches), return_exceptions=True)
+
+    @property
+    def enabled(self) -> bool:
+        """True when a transmit path has been wired up."""
+        return self._injector is not None
+
+    # ------------------------------------------------------------------
+    # Firmware parity: re-teach after a flood reply
+    # ------------------------------------------------------------------
+
+    async def maybe_teach_from_flood_reply(
+        self,
+        pkt: Packet,
+        contact_pubkey: bytes,
+        src_hash: int,
+        *,
+        reason: str,
+        shared_secret: Optional[bytes] = None,
+    ) -> bool:
+        """Re-teach our return path when a flood reply arrives from a known route.
+
+        Mirrors ``BaseChatMesh::onPeerDataRecv``'s RESPONSE branch: only fires
+        when the reply is flood-routed *and* we already hold a direct
+        ``out_path`` for the sender. The path embedded in the teach is the flood
+        accumulation path the reply arrived on, which is precisely the route
+        from the peer back to us.
+
+        Returns True when a teach was transmitted.
+        """
+        if self._injector is None:
+            return False
+        if not pkt.is_route_flood():
+            return False
+
+        out_path, out_path_len = self._known_out_path(contact_pubkey)
+        if out_path is None:
+            # No stored route to the peer, so a flood reply is the expected
+            # behaviour, not a symptom. Firmware's OUT_PATH_UNKNOWN guard.
+            return False
+
+        in_len_byte = int(getattr(pkt, "path_len", 0) or 0)
+        if not PathUtils.is_valid_path_len(in_len_byte):
+            self._log(
+                f"[ReturnPath] Skip teach to 0x{src_hash:02X}: "
+                f"inbound path_len 0x{in_len_byte:02X} is malformed"
+            )
+            return False
+        in_byte_len = PathUtils.get_path_byte_len(in_len_byte)
+        raw_path = bytes(pkt.path or b"")
+        if len(raw_path) < in_byte_len:
+            self._log(
+                f"[ReturnPath] Skip teach to 0x{src_hash:02X}: inbound path is "
+                f"{len(raw_path)}B, path_len byte declares {in_byte_len}B"
+            )
+            return False
+
+        return await self._teach(
+            contact_pubkey=contact_pubkey,
+            dest_hash=src_hash,
+            embedded_path=raw_path[:in_byte_len],
+            embedded_len_byte=in_len_byte,
+            out_path=out_path,
+            out_path_len=out_path_len,
+            shared_secret=shared_secret,
+            reason=reason,
+            from_evidence=True,
+        )
+
+    # ------------------------------------------------------------------
+    # openHop hardening: re-teach when nothing comes back at all
+    # ------------------------------------------------------------------
+
+    async def maybe_teach_reverse_of_out_path(
+        self,
+        contact_pubkey: bytes,
+        *,
+        reason: str,
+    ) -> bool:
+        """Teach the reverse of our own ``out_path`` as the peer's route back.
+
+        This has no firmware equivalent and covers the case firmware cannot:
+        when the peer answers DIRECT down a stale route, *nothing* arrives, so
+        there is no flood reply to trigger :meth:`maybe_teach_from_flood_reply`
+        and no inbound path to embed. The best available guess is that the route
+        is symmetric — the same repeaters traversed in reverse — which is
+        exactly what a user-forced path asserts.
+
+        It is only ever a guess, and the peer applies whatever it last received
+        (``MyMesh::onPeerPathRecv`` overwrites ``client->out_path``
+        unconditionally). So it is strictly a **last resort**: once we have
+        taught this contact from a real inbound path, the guess is disabled for
+        good. Without that guard a merely slow first attempt would replace a
+        correct, evidence-derived route with a symmetry assumption — and if the
+        assumption is wrong the peer then replies into a void, no flood reply
+        ever arrives again, and nothing can re-teach it. That is strictly worse
+        than the pre-existing behaviour, where an untaught peer falls back to
+        flood replies that do reach us.
+
+        Only meaningful when we already hold an ``out_path``; a contact still on
+        flood needs no teach because flood replies reach us anyway.
+
+        Returns True when a teach was dispatched.
+        """
+        if self._injector is None:
+            return False
+
+        key = bytes(contact_pubkey)
+        if key in self._taught_from_evidence:
+            self._log(
+                f"[ReturnPath] Skip reverse teach to 0x{key[0]:02X} ({reason}): "
+                "already taught from an observed inbound path"
+            )
+            return False
+
+        out_path, out_path_len = self._known_out_path(contact_pubkey)
+        if out_path is None:
+            return False
+
+        embedded = reverse_path(out_path, out_path_len)
+        if embedded is None:
+            self._log(
+                "[ReturnPath] Skip reverse teach: stored out_path "
+                f"({len(out_path)}B) does not match path_len 0x{out_path_len:02X}"
+            )
+            return False
+
+        return await self._teach(
+            contact_pubkey=contact_pubkey,
+            dest_hash=contact_pubkey[0],
+            embedded_path=embedded,
+            embedded_len_byte=out_path_len,
+            out_path=out_path,
+            out_path_len=out_path_len,
+            shared_secret=None,
+            reason=reason,
+            from_evidence=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _known_out_path(self, contact_pubkey: bytes) -> tuple[Optional[bytes], int]:
+        """Return ``(out_path, encoded_len)`` for a contact, or ``(None, -1)``.
+
+        ``out_path_len`` is the encoded path_len byte, with -1 standing in for
+        firmware's ``OUT_PATH_UNKNOWN``. Zero is a *known* route (zero-hop
+        direct neighbour) and must not be confused with unknown, so the value is
+        range-checked rather than truth-tested.
+        """
+        try:
+            contact = self._contact_book.get_by_key(contact_pubkey)
+        except Exception as e:
+            self._log(f"[ReturnPath] Contact lookup failed: {e}")
+            return None, -1
+        if contact is None:
+            return None, -1
+
+        raw_len = getattr(contact, "out_path_len", -1)
+        try:
+            out_path_len = -1 if raw_len is None else int(raw_len)
+        except (TypeError, ValueError):
+            return None, -1
+        if out_path_len < 0 or not PathUtils.is_valid_path_len(out_path_len):
+            return None, -1
+
+        out_path = bytes(getattr(contact, "out_path", b"") or b"")
+        expected = PathUtils.get_path_byte_len(out_path_len)
+        if len(out_path) < expected:
+            self._log(
+                f"[ReturnPath] Stored out_path is {len(out_path)}B but path_len "
+                f"0x{out_path_len:02X} declares {expected}B — not teaching"
+            )
+            return None, -1
+        return out_path[:expected], out_path_len
+
+    def _shared_secret_for(self, contact_pubkey: bytes) -> Optional[bytes]:
+        """Derive the X25519 shared secret with ``contact_pubkey``."""
+        try:
+            return Identity(bytes(contact_pubkey)).calc_shared_secret(
+                self._local_identity.get_private_key()
+            )
+        except Exception as e:
+            self._log(f"[ReturnPath] Failed to derive shared secret: {e}")
+            return None
+
+    def _cooldown_active(self, key: bytes) -> bool:
+        last = self._last_taught.get(key)
+        return last is not None and (self._time() - last) < self._cooldown_s
+
+    async def _teach(
+        self,
+        *,
+        contact_pubkey: bytes,
+        dest_hash: int,
+        embedded_path: bytes,
+        embedded_len_byte: int,
+        out_path: bytes,
+        out_path_len: int,
+        shared_secret: Optional[bytes],
+        reason: str,
+        from_evidence: bool,
+    ) -> bool:
+        """Build one return-path teach and dispatch it. True when dispatched.
+
+        The cooldown is claimed *synchronously*, before anything is awaited, so
+        two concurrent triggers for the same contact cannot both pass the check
+        and both transmit. It is released again if the packet never reaches the
+        injector, so a failed teach is retried on the next trigger instead of
+        being muted for the whole cooldown window.
+        """
+        key = bytes(contact_pubkey)
+        if self._cooldown_active(key):
+            self._log(
+                f"[ReturnPath] Skip teach to 0x{dest_hash:02X} ({reason}): "
+                f"within {self._cooldown_s:.0f}s cooldown"
+            )
+            return False
+
+        secret = shared_secret if shared_secret is not None else self._shared_secret_for(key)
+        if not secret:
+            return False
+
+        try:
+            teach = PacketBuilder.create_path_return(
+                dest_hash=dest_hash,
+                src_hash=self._local_identity.get_public_key()[0],
+                secret=secret,
+                path=embedded_path,
+                extra_type=0xFF,  # no extra payload (firmware passes NULL/0)
+                extra=b"",
+                path_len_encoded=embedded_len_byte,
+            )
+            # createPathReturn yields a FLOOD PATH; firmware's handleReturnPathRetry
+            # sends it DIRECT along the out_path we already hold for the peer.
+            teach.header = (teach.header & ~PH_ROUTE_MASK) | ROUTE_TYPE_DIRECT
+            teach.set_path(out_path, out_path_len)
+        except Exception as e:
+            self._log(f"[ReturnPath] Failed to build teach for 0x{dest_hash:02X}: {e}")
+            return False
+
+        # Claim the cooldown now: everything past this point is asynchronous.
+        previous = self._last_taught.get(key)
+        self._last_taught[key] = self._time()
+
+        # Firmware queues this send (sendDirect with a 3s delay) rather than
+        # blocking. Awaiting the injector here would stall the RX path — it can
+        # wait on a TX lock and an airtime budget — and delay delivery of the
+        # reply that triggered the teach.
+        task = asyncio.ensure_future(
+            self._dispatch_teach(
+                teach=teach,
+                key=key,
+                previous_cooldown=previous,
+                dest_hash=dest_hash,
+                embedded_path=embedded_path,
+                embedded_len_byte=embedded_len_byte,
+                out_path=out_path,
+                reason=reason,
+                from_evidence=from_evidence,
+            )
+        )
+        self._pending_teaches.add(task)
+        task.add_done_callback(self._pending_teaches.discard)
+        return True
+
+    async def _dispatch_teach(
+        self,
+        *,
+        teach: Packet,
+        key: bytes,
+        previous_cooldown: Optional[float],
+        dest_hash: int,
+        embedded_path: bytes,
+        embedded_len_byte: int,
+        out_path: bytes,
+        reason: str,
+        from_evidence: bool,
+    ) -> None:
+        """Transmit a prepared teach, rolling back the cooldown on failure."""
+        try:
+            await self._injector(teach)
+        except Exception as e:
+            if previous_cooldown is None:
+                self._last_taught.pop(key, None)
+            else:
+                self._last_taught[key] = previous_cooldown
+            self._log(f"[ReturnPath] Failed to send teach to 0x{dest_hash:02X}: {e}")
+            return
+
+        # Only a confirmed send counts as evidence: marking it optimistically
+        # would permanently disable the reverse-path fallback on a teach that
+        # never left the node.
+        if from_evidence:
+            self._taught_from_evidence.add(key)
+
+        self._log(
+            f"[ReturnPath] Taught 0x{dest_hash:02X} its route back ({reason}): "
+            f"embedded={embedded_path.hex() or '(zero-hop)'} "
+            f"(path_len=0x{embedded_len_byte:02X}), "
+            f"sent DIRECT via {out_path.hex() or '(zero-hop)'}"
+        )

--- a/tests/test_client_repeat.py
+++ b/tests/test_client_repeat.py
@@ -76,6 +76,18 @@ def _flood_txt(dest_hash, path=b"", path_len=0):
     return p
 
 
+def _direct_txt(path, path_len, dest_hash=0x77):
+    p = Packet()
+    p.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_DIRECT
+    # payload: dest_hash, src_hash, MAC + ciphertext (opaque here). The hash is
+    # path-independent, so every route variant of this payload hashes alike.
+    p.payload = bytearray([dest_hash, 0x99]) + bytearray(b"\xAA" * 12)
+    p.payload_len = len(p.payload)
+    p.path = bytearray(path)
+    p.path_len = path_len
+    return p
+
+
 # --------------------------------------------------------------------------- #
 # Pure forward-builder behaviour
 # --------------------------------------------------------------------------- #
@@ -275,6 +287,56 @@ async def test_own_retransmit_echo_is_suppressed():
     # Hearing our own retransmit back over RF must not forward again: the send
     # funnel tracked the (path-excluded) hash before TX, so RX dedupe drops it.
     await d._process_received_packet(echoed, -70, 8.0)
+    await _drain_tasks()
+    assert radio.send_count == 1
+
+
+@pytest.mark.asyncio
+async def test_overheard_direct_variant_does_not_suppress_owned_relay():
+    """Overhearing a longer route variant must not poison the seen table so
+    that the self-stripped copy this node is the next hop for is dropped as a
+    duplicate (MeshCore marks a routed-direct packet seen only when it is the
+    next hop)."""
+    d, radio = _make_dispatcher(enabled=True)
+    d._client_repeat_delay_ms = lambda pkt: 0.0
+
+    # Overheard earlier variant: first hop is another node, so we are not the
+    # next hop. Same payload as the copy we will later own -> identical hash.
+    overheard = _direct_txt(
+        path=bytes([0xEE, SELF_HASH, 0xBB]),
+        path_len=PathUtils.encode_path_len(1, 3),
+    )
+    await d._process_received_packet(overheard.write_to(), -70, 8.0)
+    await _drain_tasks()
+    assert radio.send_count == 0  # not ours to relay, and not tracked as seen
+
+    # The upstream hop strips itself; now we are the next hop for the same
+    # payload. It must be forwarded, not dropped as a duplicate.
+    owned = _direct_txt(
+        path=bytes([SELF_HASH, 0xBB]),
+        path_len=PathUtils.encode_path_len(1, 2),
+    )
+    await d._process_received_packet(owned.write_to(), -70, 8.0)
+    await _drain_tasks()
+    assert radio.send_count == 1
+
+
+@pytest.mark.asyncio
+async def test_owned_direct_relay_still_deduplicates_second_copy():
+    """A genuine duplicate of the copy this node is the next hop for is still
+    suppressed: dedup is only bypassed for packets we do not own."""
+    d, radio = _make_dispatcher(enabled=True)
+    d._client_repeat_delay_ms = lambda pkt: 0.0
+    owned = _direct_txt(
+        path=bytes([SELF_HASH, 0xBB]),
+        path_len=PathUtils.encode_path_len(1, 2),
+    )
+
+    await d._process_received_packet(owned.write_to(), -70, 8.0)
+    await _drain_tasks()
+    assert radio.send_count == 1
+
+    await d._process_received_packet(owned.write_to(), -70, 8.0)
     await _drain_tasks()
     assert radio.send_count == 1
 

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -20,6 +20,7 @@ from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_RESPONSE,
     PAYLOAD_TYPE_TXT_MSG,
     REQ_TYPE_GET_TELEMETRY_DATA,
+    ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
     TELEM_PERM_BASE,
 )
@@ -1000,6 +1001,54 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         assert len(calls) == 1
         assert calls[0][0] == crc
         assert calls[0][1] >= 50
+
+    async def test_discrete_six_byte_ack_fires_send_confirmed(self):
+        """A direct-route plain-DM ACK is 6 bytes (4-byte hash + ext-attempt +
+        random byte). The bridge must accept it and correlate on the first 4
+        bytes; folding all 6 bytes or requiring exactly 4 would never match the
+        4-byte expected CRC and send_confirmed would silently never fire."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        confirmed = []
+        bridge.on_send_confirmed(lambda crc, *a: confirmed.append(crc))
+
+        ack_crc = 0x1A2B3C4D
+        bridge._track_pending_ack(ack_crc)
+
+        payload = ack_crc.to_bytes(4, "little") + bytes([0x07, 0xF3])
+        pkt = Packet()
+        pkt.header = ROUTE_TYPE_DIRECT | (PAYLOAD_TYPE_ACK << 2)
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(payload)
+        pkt.payload_len = len(payload)
+
+        await bridge.process_received_packet(pkt)
+
+        assert confirmed == [ack_crc]
+
+    async def test_discrete_ack_does_not_confirm_unpending_crc(self):
+        """The extended tail bytes are not part of correlation and must not be
+        able to produce a false confirm: a 6-byte ACK whose first 4 bytes are
+        not a pending CRC leaves send_confirmed unfired."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        confirmed = []
+        bridge.on_send_confirmed(lambda crc, *a: confirmed.append(crc))
+
+        bridge._track_pending_ack(0x1A2B3C4D)
+
+        payload = (0xDEADBEEF).to_bytes(4, "little") + bytes([0x01, 0x02])
+        pkt = Packet()
+        pkt.header = ROUTE_TYPE_DIRECT | (PAYLOAD_TYPE_ACK << 2)
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(payload)
+        pkt.payload_len = len(payload)
+
+        await bridge.process_received_packet(pkt)
+
+        assert confirmed == []
 
     async def test_node_discovered_fires_node_discovered_even_when_filtered(self):
         injector = MockPacketInjector()

--- a/tests/test_companion_radio.py
+++ b/tests/test_companion_radio.py
@@ -590,6 +590,70 @@ class TestCompanionLoginRetry:
         result = await started["task"]
         assert result["success"] is False
 
+    async def test_frame_login_retries_reuse_one_pending_session(self, monkeypatch):
+        """Each frame command sends once while late replies share one completion."""
+        radio = MockRadio()
+        comp = CompanionRadio(radio, LocalIdentity())
+        contact = _make_peer_contact("Rpt")
+        comp.contacts.add(contact)
+        monkeypatch.setattr(comp, "_response_timeout_s", lambda pkt, proxy: 0.01)
+
+        first = await comp._start_frame_login_request(contact.public_key, "pw")
+        second = await comp._start_frame_login_request(contact.public_key, "pw")
+
+        assert len(radio.sent) == 2
+        assert first["session_owner"] is True
+        assert second["session_owner"] is False
+        assert second["task"] is first["task"]
+        assert first["sent"].timeout_ms == 10
+
+        # The per-send timeout is only a client retry hint. The shared response
+        # session remains live and accepts a later authenticated response.
+        await asyncio.sleep(0.02)
+        callback = comp._get_login_response_handler()._pending_logins[contact.public_key]
+        callback(
+            True,
+            {
+                "timestamp": 123,
+                "is_admin": True,
+                "keep_alive_interval": 4,
+                "reserved": 3,
+                "firmware_ver_level": 2,
+            },
+        )
+        result = await first["task"]
+
+        assert result["success"] is True
+        assert result["tag"] == 123
+        assert result["is_admin"] is True
+        assert contact.public_key not in comp._pending_frame_logins
+        assert contact.public_key not in comp._get_login_response_handler()._pending_logins
+
+    async def test_frame_login_session_expires_and_cleans_up(self, monkeypatch):
+        """An abandoned frame login retains no callback after its bounded grace."""
+        monkeypatch.setattr(
+            "openhop_core.companion.base_send.FRAME_LOGIN_PENDING_TTL_S",
+            0.02,
+        )
+        radio = MockRadio()
+        comp = CompanionRadio(radio, LocalIdentity())
+        contact = _make_peer_contact("Rpt")
+        comp.contacts.add(contact)
+
+        started = await comp._start_frame_login_request(contact.public_key, "pw")
+        result = await started["task"]
+
+        assert result["timeout"] is True
+        assert len(radio.sent) == 1
+        assert contact.public_key not in comp._pending_frame_logins
+        assert contact.public_key not in comp._get_login_response_handler()._pending_logins
+
+        retried = await comp._start_frame_login_request(contact.public_key, "pw")
+        assert retried["session_owner"] is True
+        assert retried["task"] is not started["task"]
+        comp._clear_pending_frame_logins()
+        await asyncio.sleep(0)
+
 
 # ---------------------------------------------------------------------------
 # Repeater-command response correlation (drives the real text handler)
@@ -768,7 +832,7 @@ class TestRepeaterCommandCorrelation:
         """CLI_DATA from a contact with no pending command is a normal message
         (firmware queues it to the client rather than dropping it)."""
         radio, identity, comp, peers = self._setup(["Rpt"])
-        (rpt_identity, _) = peers[0]
+        rpt_identity, _ = peers[0]
         handler = comp._get_text_handler()
         recorder = _EventRecorder()
         monkeypatch.setattr(handler, "event_service", recorder)
@@ -785,7 +849,7 @@ class TestRepeaterCommandCorrelation:
     async def test_single_command_happy_path(self, monkeypatch):
         """A single command resolves with its target's CLI_DATA reply."""
         radio, identity, comp, peers = self._setup(["Rpt"])
-        (rpt_identity, rpt_contact) = peers[0]
+        rpt_identity, rpt_contact = peers[0]
         handler = comp._get_text_handler()
         _shorten_command_timeout(monkeypatch, [1.0])
 
@@ -945,7 +1009,7 @@ class TestLoginResponseCorrelation:
         """A single login resolves success from an OK response and failure from a
         rejection response (both via the real handler)."""
         radio, identity, comp, peers = self._setup(["Rpt"])
-        (rpt_identity, rpt_contact) = peers[0]
+        rpt_identity, rpt_contact = peers[0]
         monkeypatch.setattr(comp, "_response_timeout_s", lambda pkt, proxy: 0.5)
         handler = comp._get_login_response_handler()
 
@@ -1015,7 +1079,7 @@ class TestLoginResponseHashCollisions:
         radio = MockRadio()
         identity = LocalIdentity()
         comp = CompanionRadio(radio, identity)
-        (a_identity, a_contact) = _distinct_peers(["RptA"], avoid={identity.get_public_key()[0]})[0]
+        a_identity, a_contact = _distinct_peers(["RptA"], avoid={identity.get_public_key()[0]})[0]
         b_identity, b_contact = _colliding_peer(
             "RptB", a_contact.public_key[0], avoid_keys={a_contact.public_key}
         )

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -395,7 +395,7 @@ async def test_cmd_add_update_contact_writes_single_ok_response():
 @pytest.mark.parametrize(
     ("encoded_path_len", "path"),
     [
-        (PathUtils.encode_path_len(1, 2), b"\xA1\x00"),
+        (PathUtils.encode_path_len(1, 2), b"\xa1\x00"),
         (PathUtils.encode_path_len(2, 2), b"\x10\x00\x20\x00"),
         (PathUtils.encode_path_len(3, 2), b"\x30\x00\x32\x40\x41\x00"),
         (0, b""),
@@ -918,7 +918,7 @@ async def test_cmd_send_login_timeout_does_not_emit_failure_push():
 
     pubkey = bytes(range(32))
     bridge = Mock()
-    bridge._start_login_request = AsyncMock(
+    bridge._start_frame_login_request = AsyncMock(
         return_value={
             "success": True,
             "sent": SentResult(success=True, is_flood=True, expected_ack=0x1122, timeout_ms=9000),
@@ -938,6 +938,53 @@ async def test_cmd_send_login_timeout_does_not_emit_failure_push():
 
     assert frames == [bytes([RESP_CODE_SENT, 1]) + struct.pack("<II", 0x1122, 9000)]
     assert not any(frame[0] == PUSH_CODE_LOGIN_FAIL for frame in frames)
+
+
+@pytest.mark.asyncio
+async def test_cmd_send_login_retry_has_one_completion_writer():
+    """Repeated commands each get SENT, but one logical session emits one push."""
+    from openhop_core.companion.constants import PUSH_CODE_LOGIN_SUCCESS
+
+    pubkey = bytes(range(32))
+    result_task = asyncio.create_task(
+        _return_result(
+            {
+                "success": True,
+                "is_admin": True,
+                "tag": 123,
+                "acl_permissions": 3,
+                "firmware_ver_level": 2,
+            }
+        )
+    )
+    sent = SentResult(success=True, is_flood=True, expected_ack=0x1122, timeout_ms=9000)
+    bridge = Mock()
+    bridge._start_frame_login_request = AsyncMock(
+        side_effect=[
+            {
+                "success": True,
+                "sent": sent,
+                "task": result_task,
+                "session_owner": True,
+            },
+            {
+                "success": True,
+                "sent": sent,
+                "task": result_task,
+                "session_owner": False,
+            },
+        ]
+    )
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda frame: frames.append(frame)
+
+    await server._cmd_send_login(pubkey + b"pw")
+    await server._cmd_send_login(pubkey + b"pw")
+    await asyncio.sleep(0)
+
+    assert sum(frame[0] == RESP_CODE_SENT for frame in frames) == 2
+    assert sum(frame[0] == PUSH_CODE_LOGIN_SUCCESS for frame in frames) == 1
 
 
 @pytest.mark.asyncio
@@ -1801,7 +1848,7 @@ async def test_import_private_key_reports_disabled_without_changing_identity():
     server, frames = _make_capture_server(bridge)
     original_public_key = bridge.get_public_key()
 
-    await server._handle_cmd(bytes([CMD_IMPORT_PRIVATE_KEY]) + b"\xA5" * 64)
+    await server._handle_cmd(bytes([CMD_IMPORT_PRIVATE_KEY]) + b"\xa5" * 64)
 
     assert frames == [bytes([RESP_CODE_DISABLED])]
     assert bridge.get_public_key() == original_public_key
@@ -1811,7 +1858,7 @@ async def test_import_private_key_reports_disabled_without_changing_identity():
 async def test_short_private_key_import_is_unsupported():
     server, frames = _make_capture_server(Mock())
 
-    await server._handle_cmd(bytes([CMD_IMPORT_PRIVATE_KEY]) + b"\xA5" * 63)
+    await server._handle_cmd(bytes([CMD_IMPORT_PRIVATE_KEY]) + b"\xa5" * 63)
 
     assert frames == [bytes([RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD])]
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 import struct
 import time
 from unittest.mock import AsyncMock, MagicMock
@@ -496,16 +497,16 @@ class TestTextMessageHandler:
         ("route", "path", "path_len"),
         [
             pytest.param("direct", b"", 0xFF, id="direct-out-path-unknown-ff"),
-            pytest.param("flood", b"\xAA", 0x01, id="flood-one-byte-hash-01"),
+            pytest.param("flood", b"\xaa", 0x01, id="flood-one-byte-hash-01"),
             pytest.param(
                 "flood",
-                b"\xAA\xBB\xCC\xDD",
+                b"\xaa\xbb\xcc\xdd",
                 0x42,
                 id="flood-two-byte-hashes-42",
             ),
             pytest.param(
                 "transport_flood",
-                b"\xAA\xBB\xCC\xDD\xEE\xFF\x10\x20\x30",
+                b"\xaa\xbb\xcc\xdd\xee\xff\x10\x20\x30",
                 0x83,
                 id="transport-flood-three-byte-hashes-83",
             ),
@@ -1110,6 +1111,7 @@ class TestProtocolResponseHandler:
         handler.set_contact_path_updated_callback(on_path_updated)
 
         await handler(pkt)
+        await handler.wait_for_pending_reciprocals()
 
         assert len(callback_calls) == 1
         assert callback_calls[0][0] == peer_pubkey
@@ -1302,6 +1304,7 @@ class TestProtocolResponseHandler:
         assert pkt.is_route_flood()
 
         await handler(pkt)
+        await handler.wait_for_pending_reciprocals()
 
         # Path learned as zero-hop direct (out_path_len == 0).
         assert len(path_updates) == 1
@@ -1311,6 +1314,79 @@ class TestProtocolResponseHandler:
         assert learned.out_path_len == 0
         # Reciprocal PATH sent back so the repeater learns its route to us.
         injector.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_login_path_completes_before_blocked_reciprocal_tx(self):
+        """A valid PATH login response must not wait behind the radio TX path."""
+        from openhop_core.companion.contact_store import ContactStore
+        from openhop_core.companion.models import Contact
+
+        local_identity = LocalIdentity()
+        server_identity = LocalIdentity()
+        server_pubkey = server_identity.get_public_key()
+        contacts = ContactStore(5)
+        contacts.add(Contact(public_key=server_pubkey, name="Repeater"))
+        protocol_handler = ProtocolResponseHandler(MagicMock(), local_identity, contacts)
+        login_handler = LoginResponseHandler(local_identity, contacts, MagicMock())
+
+        injector_started = asyncio.Event()
+        release_injector = asyncio.Event()
+
+        async def blocked_injector(_packet):
+            injector_started.set()
+            await release_injector.wait()
+
+        protocol_handler.set_packet_injector(blocked_injector)
+        login_completed = asyncio.Event()
+        path_seen_by_callback = {}
+
+        def on_login(_success, _data):
+            contact = contacts.get_by_key(server_pubkey)
+            path_seen_by_callback["len"] = contact.out_path_len
+            path_seen_by_callback["path"] = contact.out_path
+            login_completed.set()
+
+        login_handler.register_login_callback(server_pubkey, on_login)
+
+        reply = bytearray(13)
+        struct.pack_into("<I", reply, 0, 1234)
+        reply[4] = 0x00
+        reply[12] = 2
+        secret = Identity(server_pubkey).calc_shared_secret(local_identity.get_private_key())
+        packet = PacketBuilder.create_path_return(
+            dest_hash=local_identity.get_public_key()[0],
+            src_hash=server_pubkey[0],
+            secret=secret,
+            path=[0xA1],
+            extra_type=PAYLOAD_TYPE_RESPONSE,
+            extra=bytes(reply),
+        )
+        packet.set_path(b"\xb2", PathUtils.encode_path_len(1, 1))
+
+        result = await asyncio.wait_for(
+            PathHandler(
+                MagicMock(),
+                protocol_response_handler=protocol_handler,
+                login_response_handler=login_handler,
+            )(packet),
+            timeout=0.1,
+        )
+
+        assert result.authenticated is True
+        assert login_completed.is_set()
+        assert path_seen_by_callback == {
+            "len": PathUtils.encode_path_len(1, 1),
+            "path": b"\xa1",
+        }
+        await asyncio.wait_for(injector_started.wait(), timeout=0.1)
+        assert (
+            await protocol_handler.return_path_teacher.maybe_teach_reverse_of_out_path(
+                server_pubkey, reason="login retry"
+            )
+            is False
+        )
+        release_injector.set()
+        await protocol_handler.wait_for_pending_reciprocals()
 
 
 class TestProtocolRequestHandler:

--- a/tests/test_kiss_modem_wrapper.py
+++ b/tests/test_kiss_modem_wrapper.py
@@ -1962,6 +1962,107 @@ class TestSerialRecovery:
         modem._start_reconnect_worker()
         assert modem.reconnect_thread is None
 
+    def test_mark_serial_failure_does_not_deadlock_with_reconnect_lock_order(self):
+        """A failed command must not wait for a reconnect handshake's lock.
+
+        An ordinary SetHardware caller holds _command_lock when its UART write
+        fails. A reconnect worker holds _connection_lock while it starts its
+        handshake and then needs _command_lock. Blocking failure handling creates
+        an ABBA deadlock; the failure transition must return promptly instead.
+        """
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        # Prevent the failure path from starting a real background reconnect.
+        modem._reconnecting_event.set()
+
+        command_held = threading.Event()
+        connection_held = threading.Event()
+        reconnect_waiting_on_command = threading.Event()
+        failure_returned = threading.Event()
+        reconnect_acquired_command = threading.Event()
+
+        def failed_command():
+            with modem._command_lock:
+                command_held.set()
+                assert connection_held.wait(1.0)
+                modem._mark_serial_failure("simulated overlapping write failure")
+                failure_returned.set()
+
+        def reconnect_handshake():
+            assert command_held.wait(1.0)
+            with modem._connection_lock:
+                connection_held.set()
+                reconnect_waiting_on_command.set()
+                with modem._command_lock:
+                    reconnect_acquired_command.set()
+
+        command_thread = threading.Thread(target=failed_command, daemon=True)
+        reconnect_thread = threading.Thread(target=reconnect_handshake, daemon=True)
+        command_thread.start()
+        reconnect_thread.start()
+
+        assert reconnect_waiting_on_command.wait(1.0)
+        assert failure_returned.wait(0.5)
+        assert reconnect_acquired_command.wait(0.5)
+        command_thread.join(timeout=0.5)
+        reconnect_thread.join(timeout=0.5)
+        assert not command_thread.is_alive()
+        assert not reconnect_thread.is_alive()
+
+    def test_mark_serial_failure_does_not_deadlock_with_reconnect_write(self):
+        """A failed UART write must not wait for a reconnect UART write.
+
+        _write_frame holds _serial_write_lock while it invokes failure handling.
+        A reconnect handshake holds _connection_lock while it waits to write its
+        PING. Waiting for _connection_lock in the failure path would deadlock the
+        two workers just as it does for SetHardware's _command_lock.
+        """
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem._reconnecting_event.set()
+        serial_conn = MagicMock()
+        serial_conn.is_open = True
+        serial_conn.write.side_effect = lambda data: len(data)
+        modem.serial_conn = serial_conn
+
+        connection_held = threading.Event()
+        serial_write_held = threading.Event()
+        failure_returned = threading.Event()
+        reconnect_wrote = threading.Event()
+
+        def failed_write():
+            with modem._serial_write_lock:
+                serial_write_held.set()
+                assert connection_held.wait(1.0)
+                modem._mark_serial_failure("simulated overlapping write failure")
+                failure_returned.set()
+
+        def reconnect_handshake():
+            with modem._connection_lock:
+                connection_held.set()
+                assert serial_write_held.wait(1.0)
+                assert modem._write_frame(b"reconnect ping") is True
+                reconnect_wrote.set()
+
+        failed_thread = threading.Thread(target=failed_write, daemon=True)
+        reconnect_thread = threading.Thread(target=reconnect_handshake, daemon=True)
+        failed_thread.start()
+        reconnect_thread.start()
+
+        assert failure_returned.wait(0.5)
+        assert reconnect_wrote.wait(0.5)
+        failed_thread.join(timeout=0.5)
+        reconnect_thread.join(timeout=0.5)
+        assert not failed_thread.is_alive()
+        assert not reconnect_thread.is_alive()
+
+    def test_reconnect_worker_clears_gate_after_unexpected_exception(self):
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem._reconnecting_event.set()
+        modem._reconnect_loop = MagicMock(side_effect=RuntimeError("simulated reconnect error"))
+
+        modem._reconnect_worker()
+
+        assert modem._reconnecting_event.is_set() is False
+
     def test_connect_clears_reconnecting_gate_after_success(self):
         modem = KissModemWrapper(port="/dev/null", auto_configure=False)
         modem._reconnecting_event.set()

--- a/tests/test_path_ack_handler.py
+++ b/tests/test_path_ack_handler.py
@@ -298,7 +298,7 @@ async def test_path_handler_updates_matched_contact_sends_reciprocal_and_resolve
         extra=ack_crc.to_bytes(4, "little") + b"\x02\xa5",
         path_len_encoded=encoded_out_path_len,
     )
-    packet.set_path(b"\xC3", PathUtils.encode_path_len(1, 1))
+    packet.set_path(b"\xc3", PathUtils.encode_path_len(1, 1))
 
     dispatcher = Dispatcher(_CallbackRadio())
     dispatcher.local_identity = LOCAL_IDENTITY
@@ -320,6 +320,7 @@ async def test_path_handler_updates_matched_contact_sends_reciprocal_and_resolve
         ack_handler=ack_handler,
         protocol_response_handler=response_handler,
     )(packet)
+    await response_handler.wait_for_pending_reciprocals()
 
     assert result.authenticated is True
     assert waiting.is_set()

--- a/tests/test_return_path_teacher.py
+++ b/tests/test_return_path_teacher.py
@@ -442,6 +442,65 @@ async def test_shorter_route_wins_when_extra_hop_buys_little_signal():
 
 
 @pytest.mark.asyncio
+async def test_zero_hop_copy_beats_materially_stronger_one_hop_copy():
+    """A healthy direct route must not be replaced by a nearby relay.
+
+    Captured regression: HOWL Repeater's flood reply arrived zero-hop at
+    -46 dBm, then through B5B5 at -12 dBm. The routed-dependency plus per-hop
+    penalties preserve the direct route.
+    """
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+    direct_len = PathUtils.encode_path_len(2, 0)
+    relayed_len = PathUtils.encode_path_len(2, 1)
+    base = _response_packet(flood=True)
+    direct = _copy_of(base, in_path=b"", rssi=-46, len_byte=direct_len)
+    relayed = _copy_of(base, in_path=b"\xb5\xb5", rssi=-12, len_byte=relayed_len)
+
+    async def fake_settle(_seconds):
+        teacher.note_flood_copy(relayed)
+
+    teacher._settle_s = 3.0
+    teacher._settle = fake_settle
+
+    assert await teacher.maybe_teach_from_flood_reply(direct, PEER_KEY, PEER_HASH, reason="test")
+    await teacher.wait_for_pending()
+
+    embedded_len, embedded = _decode_teach(injector.packets[-1])
+    assert embedded_len == direct_len
+    assert embedded == b""
+
+
+@pytest.mark.asyncio
+async def test_materially_stronger_one_hop_copy_beats_tenuous_zero_hop_copy():
+    """The direct preference is finite, not an absolute zero-hop rule.
+
+    A direct copy near -120 dBm is tenuous enough that a one-hop copy at
+    -60 dBm pays both routing penalties and still wins.
+    """
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+    direct_len = PathUtils.encode_path_len(2, 0)
+    relayed_len = PathUtils.encode_path_len(2, 1)
+    base = _response_packet(flood=True)
+    direct = _copy_of(base, in_path=b"", rssi=-120, len_byte=direct_len)
+    relayed = _copy_of(base, in_path=b"\xb5\xb5", rssi=-60, len_byte=relayed_len)
+
+    async def fake_settle(_seconds):
+        teacher.note_flood_copy(relayed)
+
+    teacher._settle_s = 3.0
+    teacher._settle = fake_settle
+
+    assert await teacher.maybe_teach_from_flood_reply(direct, PEER_KEY, PEER_HASH, reason="test")
+    await teacher.wait_for_pending()
+
+    embedded_len, embedded = _decode_teach(injector.packets[-1])
+    assert embedded_len == relayed_len
+    assert embedded == b"\xb5\xb5"
+
+
+@pytest.mark.asyncio
 async def test_longer_route_wins_when_it_is_materially_stronger():
     """When the shorter route's final hop is genuinely weak, the extra hop is
     earned: a 3-hop copy at -13 beats a 2-hop copy at -60."""

--- a/tests/test_return_path_teacher.py
+++ b/tests/test_return_path_teacher.py
@@ -1,0 +1,702 @@
+"""Return-path teaching parity with MeshCore's BaseChatMesh::handleReturnPathRetry.
+
+A MeshCore server answers a DIRECT request from the ``out_path`` stored in its
+ACL, never by reversing the inbound path. A client that never teaches that route
+leaves the server replying into a dead route, which is what breaks CLI/protocol
+requests over a user-forced path: the login goes out DIRECT, so the server
+answers with a plain flood RESPONSE rather than the flood PATH that normally
+carries the reciprocal, and nothing else in the stack teaches the route back.
+"""
+
+import asyncio
+
+import pytest
+
+from openhop_core.companion.base_send import _SendOpsMixin
+from openhop_core.companion.contact_store import ContactStore
+from openhop_core.companion.models import Contact
+from openhop_core.node.handlers.login_response import LoginResponseHandler
+from openhop_core.node.handlers.protocol_response import ProtocolResponseHandler
+from openhop_core.node.handlers.registry import create_core_handlers
+from openhop_core.node.handlers.return_path import ReturnPathTeacher, reverse_path
+from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet
+from openhop_core.protocol.constants import (
+    PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_RESPONSE,
+    ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
+)
+from openhop_core.protocol.packet_utils import PathUtils
+
+LOCAL_IDENTITY = LocalIdentity(bytes(32))
+PEER = LocalIdentity(bytes([0x5A]) + bytes(31))
+PEER_HASH = PEER.get_public_key()[0]
+PEER_KEY = PEER.get_public_key()
+
+# Route from us to the peer (what a user's "force path" sets).
+OUT_PATH = bytes([0xAA, 0xBB])
+OUT_PATH_LEN = PathUtils.encode_path_len(1, 2)
+
+# Route the peer's flood reply accumulated on its way back to us. Deliberately
+# different from OUT_PATH so a test can tell the embedded path (peer -> us) from
+# the routing path (us -> peer); swapping the two is the classic failure here.
+IN_PATH = bytes([0xCC, 0xDD])
+IN_PATH_LEN = PathUtils.encode_path_len(1, 2)
+
+
+def _shared_secret():
+    return Identity(PEER_KEY).calc_shared_secret(LOCAL_IDENTITY.get_private_key())
+
+
+def _contacts(out_path=OUT_PATH, out_path_len=OUT_PATH_LEN):
+    contacts = ContactStore()
+    contact = Contact(public_key=PEER_KEY, name="FarRepeater")
+    contact.out_path = out_path
+    contact.out_path_len = out_path_len
+    contacts.add(contact)
+    return contacts
+
+
+def _response_packet(*, flood: bool, in_path=IN_PATH, in_path_len=IN_PATH_LEN, tag=0x11223344):
+    """A PAYLOAD_TYPE_RESPONSE from PEER addressed to us."""
+    secret = _shared_secret()
+    plaintext = tag.to_bytes(4, "little") + b"ok"
+    packet = Packet()
+    packet.header = (PAYLOAD_TYPE_RESPONSE << 2) | (
+        ROUTE_TYPE_FLOOD if flood else ROUTE_TYPE_DIRECT
+    )
+    packet.path = bytearray(in_path) if flood else bytearray()
+    packet.path_len = in_path_len if flood else 0
+    packet.payload = bytearray(
+        bytes([LOCAL_IDENTITY.get_public_key()[0], PEER_HASH])
+        + CryptoUtils.encrypt_then_mac(secret[:16], secret, plaintext)
+    )
+    packet.payload_len = len(packet.payload)
+    return packet
+
+
+def _decode_teach(packet: Packet):
+    """Return (embedded_path_len_byte, embedded_path) from a teach packet."""
+    secret = _shared_secret()
+    plaintext = CryptoUtils.mac_then_decrypt(secret[:16], secret, bytes(packet.payload[2:]))
+    assert plaintext, "teach packet did not authenticate against the peer secret"
+    path_len_byte = plaintext[0]
+    byte_len = PathUtils.get_path_byte_len(path_len_byte)
+    return path_len_byte, bytes(plaintext[1 : 1 + byte_len])
+
+
+class _Injector:
+    """Captures injected packets; can be made to fail or to block.
+
+    ``slow=True`` models a real transmit path (TX lock, airtime budget, on-air
+    time) so tests can observe behaviour across the injector's await point.
+    """
+
+    def __init__(self, fail=False, slow=False):
+        self.packets = []
+        self.fail = fail
+        self._gate = asyncio.Event() if slow else None
+
+    def release(self) -> None:
+        if self._gate is not None:
+            self._gate.set()
+
+    async def __call__(self, packet, *args, **kwargs):
+        if self._gate is not None:
+            await asyncio.sleep(0)  # let concurrent callers all reach here
+            if not self._gate.is_set():
+                await asyncio.wait_for(self._gate.wait(), timeout=2.0)
+        if self.fail:
+            raise RuntimeError("radio down")
+        self.packets.append(packet)
+        return True
+
+
+def _teacher(contacts=None, injector=None, **kwargs):
+    teacher = ReturnPathTeacher(
+        lambda _m: None, LOCAL_IDENTITY, contacts if contacts is not None else _contacts(), **kwargs
+    )
+    teacher.set_injector(injector if injector is not None else _Injector())
+    return teacher
+
+
+async def _teach_flood(teacher, **kwargs):
+    """Trigger a flood-reply teach and wait for it to reach the injector."""
+    sent = await teacher.maybe_teach_from_flood_reply(
+        _response_packet(flood=True, **kwargs), PEER_KEY, PEER_HASH, reason="test"
+    )
+    await teacher.wait_for_pending()
+    return sent
+
+
+# --------------------------------------------------------------------------- #
+# reverse_path
+# --------------------------------------------------------------------------- #
+
+
+def test_reverse_path_reverses_whole_hashes_not_bytes():
+    """A 2-byte-hash path must reverse hop order, keeping each hash intact."""
+    path = bytes([0x11, 0x22, 0x33, 0x44])
+    assert reverse_path(path, PathUtils.encode_path_len(2, 2)) == bytes([0x33, 0x44, 0x11, 0x22])
+    # Byte-wise reversal would give 44332211 and corrupt every hop.
+
+
+def test_reverse_path_three_byte_hashes():
+    path = bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+    assert reverse_path(path, PathUtils.encode_path_len(3, 2)) == bytes(
+        [0x04, 0x05, 0x06, 0x01, 0x02, 0x03]
+    )
+
+
+def test_reverse_path_single_byte_hashes():
+    assert reverse_path(bytes([0xA1, 0xB2, 0xC3]), PathUtils.encode_path_len(1, 3)) == bytes(
+        [0xC3, 0xB2, 0xA1]
+    )
+
+
+def test_reverse_path_zero_hop_is_empty_not_none():
+    """A zero-hop path is valid (direct neighbour), distinct from malformed."""
+    assert reverse_path(b"", 0) == b""
+
+
+def test_reverse_path_rejects_length_mismatch():
+    assert reverse_path(bytes([0xAA]), PathUtils.encode_path_len(1, 3)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Flood-reply trigger (firmware parity)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_flood_reply_teaches_inbound_path_routed_via_out_path():
+    """The teach embeds the peer->us path and is routed along the us->peer path."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    assert await _teach_flood(teacher) is True
+    assert len(injector.packets) == 1
+    teach = injector.packets[0]
+
+    # Shape: a PATH packet sent DIRECT (firmware sendDirect of createPathReturn).
+    assert teach.get_payload_type() == PAYLOAD_TYPE_PATH
+    assert teach.get_route_type() == ROUTE_TYPE_DIRECT
+    # Routed along OUR out_path so it actually reaches the peer.
+    assert bytes(teach.path) == OUT_PATH
+    assert teach.path_len == OUT_PATH_LEN
+    # Addressed to the peer, from us.
+    assert teach.payload[0] == PEER_HASH
+    assert teach.payload[1] == LOCAL_IDENTITY.get_public_key()[0]
+    # Embedded: the route the peer should use to reach us == the inbound path.
+    embedded_len, embedded_path = _decode_teach(teach)
+    assert embedded_path == IN_PATH
+    assert embedded_len == IN_PATH_LEN
+
+
+@pytest.mark.asyncio
+async def test_flood_reply_teach_preserves_two_byte_hash_encoding():
+    """path_len encodes hash_size in bits 6-7; a 2-byte-hash route must survive
+    both the embedded payload and the outer routing path intact."""
+    out_path = bytes([0x11, 0x22, 0x33, 0x44])
+    out_len = PathUtils.encode_path_len(2, 2)
+    in_path = bytes([0xA1, 0xA2, 0xB1, 0xB2])
+    in_len = PathUtils.encode_path_len(2, 2)
+
+    injector = _Injector()
+    teacher = _teacher(contacts=_contacts(out_path, out_len), injector=injector)
+
+    assert await _teach_flood(teacher, in_path=in_path, in_path_len=in_len) is True
+    teach = injector.packets[0]
+    assert bytes(teach.path) == out_path
+    assert teach.path_len == out_len
+    embedded_len, embedded_path = _decode_teach(teach)
+    assert embedded_path == in_path
+    assert embedded_len == in_len
+    assert PathUtils.get_path_hash_size(embedded_len) == 2
+
+
+@pytest.mark.asyncio
+async def test_direct_reply_does_not_teach():
+    """Only a flood reply signals the peer has no route back (firmware guard)."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    sent = await teacher.maybe_teach_from_flood_reply(
+        _response_packet(flood=False), PEER_KEY, PEER_HASH, reason="test"
+    )
+    await teacher.wait_for_pending()
+
+    assert sent is False
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_out_path_does_not_teach():
+    """OUT_PATH_UNKNOWN (-1): flood replies are expected, and we have no route
+    to send a direct teach down anyway."""
+    injector = _Injector()
+    teacher = _teacher(contacts=_contacts(out_path=b"", out_path_len=-1), injector=injector)
+
+    assert await _teach_flood(teacher) is False
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_zero_hop_out_path_is_known_and_teaches():
+    """out_path_len == 0 is a known zero-hop route, NOT unknown. Truth-testing
+    the value instead of range-checking it would silently skip direct
+    neighbours."""
+    injector = _Injector()
+    teacher = _teacher(contacts=_contacts(out_path=b"", out_path_len=0), injector=injector)
+
+    assert await _teach_flood(teacher) is True
+    assert bytes(injector.packets[0].path) == b""
+
+
+@pytest.mark.asyncio
+async def test_out_path_shorter_than_declared_length_is_rejected():
+    """A truncated stored path must not be transmitted as a routing path."""
+    injector = _Injector()
+    teacher = _teacher(
+        contacts=_contacts(out_path=bytes([0xAA]), out_path_len=PathUtils.encode_path_len(1, 3)),
+        injector=injector,
+    )
+    assert await _teach_flood(teacher) is False
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_no_injector_is_a_no_op():
+    teacher = ReturnPathTeacher(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    assert teacher.enabled is False
+    assert await _teach_flood(teacher) is False
+
+
+# --------------------------------------------------------------------------- #
+# Rate limiting and dispatch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_immediate_second_teach():
+    clock = {"t": 1000.0}
+    injector = _Injector()
+    teacher = _teacher(injector=injector, cooldown_s=5.0, time_fn=lambda: clock["t"])
+
+    assert await _teach_flood(teacher) is True
+    clock["t"] += 1.0
+    assert await _teach_flood(teacher) is False
+    clock["t"] += 5.0
+    assert await _teach_flood(teacher) is True
+    assert len(injector.packets) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_triggers_transmit_only_one_teach():
+    """The cooldown is claimed synchronously, before anything is awaited, so two
+    triggers racing across the injector's await point cannot both transmit."""
+    injector = _Injector(slow=True)
+    teacher = _teacher(injector=injector, cooldown_s=5.0)
+
+    results = await asyncio.gather(
+        *[
+            teacher.maybe_teach_from_flood_reply(
+                _response_packet(flood=True), PEER_KEY, PEER_HASH, reason="t"
+            )
+            for _ in range(3)
+        ]
+    )
+    injector.release()
+    await teacher.wait_for_pending()
+
+    assert sum(1 for r in results if r) == 1
+    assert len(injector.packets) == 1
+
+
+@pytest.mark.asyncio
+async def test_teach_does_not_block_on_the_injector():
+    """Firmware queues this send; awaiting it inline would stall the RX path and
+    delay the very reply that triggered the teach."""
+    injector = _Injector(slow=True)
+    teacher = _teacher(injector=injector)
+
+    assert await teacher.maybe_teach_from_flood_reply(
+        _response_packet(flood=True), PEER_KEY, PEER_HASH, reason="t"
+    )
+    # Returned while the injector is still blocked.
+    assert injector.packets == []
+
+    injector.release()
+    await teacher.wait_for_pending()
+    assert len(injector.packets) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_inject_releases_cooldown_for_the_next_trigger():
+    """A teach that never made it onto the radio must be retried on the next
+    trigger, not muted for the cooldown window."""
+    clock = {"t": 0.0}
+    teacher = _teacher(injector=_Injector(fail=True), cooldown_s=5.0, time_fn=lambda: clock["t"])
+
+    await _teach_flood(teacher)
+
+    working = _Injector()
+    teacher.set_injector(working)
+    assert await _teach_flood(teacher) is True
+    assert len(working.packets) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Reverse-of-out_path hardening (no firmware equivalent)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_reverse_teach_embeds_reversed_out_path():
+    """With nothing inbound to learn from, assume a symmetric route. Uses 2-byte
+    hashes so a byte-wise reversal would not pass."""
+    out_path = bytes([0x11, 0x22, 0x33, 0x44])
+    out_len = PathUtils.encode_path_len(2, 2)
+    injector = _Injector()
+    teacher = _teacher(contacts=_contacts(out_path, out_len), injector=injector)
+
+    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is True
+    await teacher.wait_for_pending()
+
+    teach = injector.packets[0]
+    assert teach.get_route_type() == ROUTE_TYPE_DIRECT
+    assert bytes(teach.path) == out_path  # still routed outward along out_path
+    _, embedded_path = _decode_teach(teach)
+    assert embedded_path == bytes([0x33, 0x44, 0x11, 0x22])
+
+
+@pytest.mark.asyncio
+async def test_reverse_teach_skipped_without_known_out_path():
+    injector = _Injector()
+    teacher = _teacher(contacts=_contacts(out_path=b"", out_path_len=-1), injector=injector)
+    assert not await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout")
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_reverse_teach_never_overwrites_an_evidence_derived_teach():
+    """THE regression guard. The peer applies whichever path it received last
+    (MyMesh::onPeerPathRecv overwrites unconditionally). If a merely slow first
+    attempt let the symmetry guess replace the route we learned from a real
+    inbound path, and the guess is wrong, the peer would reply into a void — no
+    flood reply would ever arrive again, so nothing could re-teach it. That is
+    strictly worse than never having guessed."""
+    clock = {"t": 0.0}
+    injector = _Injector()
+    teacher = _teacher(injector=injector, cooldown_s=5.0, time_fn=lambda: clock["t"])
+
+    assert await _teach_flood(teacher) is True
+    _, embedded = _decode_teach(injector.packets[0])
+    assert embedded == IN_PATH
+
+    # Well past the cooldown: only the evidence guard can stop this.
+    clock["t"] += 3600.0
+    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is False
+    await teacher.wait_for_pending()
+    assert len(injector.packets) == 1, "the symmetry guess clobbered a known-good route"
+
+
+@pytest.mark.asyncio
+async def test_note_evidence_teach_blocks_the_reverse_guess():
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    teacher.note_evidence_teach(PEER_KEY)
+
+    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is False
+    assert injector.packets == []
+
+
+def _flood_path_packet(inner_path=OUT_PATH, inner_len=OUT_PATH_LEN):
+    """A flood PAYLOAD_TYPE_PATH carrying a RESPONSE — what a *flood* login gets.
+
+    Inner layout: path_len(1) + path(N) + extra_type(1) + extra.
+    """
+    secret = _shared_secret()
+    response = (0x11223344).to_bytes(4, "little") + b"ok"
+    inner = bytes([inner_len]) + inner_path + bytes([PAYLOAD_TYPE_RESPONSE]) + response
+    packet = Packet()
+    packet.header = (PAYLOAD_TYPE_PATH << 2) | ROUTE_TYPE_FLOOD
+    packet.path = bytearray(IN_PATH)
+    packet.path_len = IN_PATH_LEN
+    packet.payload = bytearray(
+        bytes([LOCAL_IDENTITY.get_public_key()[0], PEER_HASH])
+        + CryptoUtils.encrypt_then_mac(secret[:16], secret, inner)
+    )
+    packet.payload_len = len(packet.payload)
+    return packet
+
+
+@pytest.mark.asyncio
+async def test_flood_path_reciprocal_reports_itself_and_blocks_the_reverse_guess():
+    """End-to-end: the pre-existing flood-PATH reciprocal teaches from a real
+    inbound path. If ProtocolResponseHandler did not report it, a normal flood
+    login would leave the symmetry guess free to overwrite a correct route on
+    the very first retry — with no cooldown involved."""
+    injector = _Injector()
+    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    handler.set_packet_injector(injector)
+
+    await handler(_flood_path_packet())
+    await handler.return_path_teacher.wait_for_pending()
+
+    # Exactly one packet: the reciprocal. The RESPONSE-branch teach must not
+    # also fire for a PATH packet.
+    assert len(injector.packets) == 1
+
+    blocked = await handler.return_path_teacher.maybe_teach_reverse_of_out_path(
+        PEER_KEY, reason="timeout"
+    )
+    await handler.return_path_teacher.wait_for_pending()
+    assert blocked is False
+    assert len(injector.packets) == 1
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the handlers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_protocol_response_handler_teaches_on_flood_response():
+    injector = _Injector()
+    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    handler.set_packet_injector(injector)
+
+    await handler(_response_packet(flood=True))
+    await handler.return_path_teacher.wait_for_pending()
+
+    assert len(injector.packets) == 1
+    assert injector.packets[0].get_payload_type() == PAYLOAD_TYPE_PATH
+    _, embedded_path = _decode_teach(injector.packets[0])
+    assert embedded_path == IN_PATH
+
+
+@pytest.mark.asyncio
+async def test_protocol_response_handler_does_not_teach_on_direct_response():
+    injector = _Injector()
+    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    handler.set_packet_injector(injector)
+
+    await handler(_response_packet(flood=False))
+    await handler.return_path_teacher.wait_for_pending()
+
+    assert injector.packets == []
+
+
+def _login_reply_packet(flood=True):
+    """Firmware handleLoginReq reply_data: timestamp(4) + RESP_SERVER_LOGIN_OK +
+    keep_alive + is_admin + permissions + random(4) + firmware_ver_level."""
+    login_reply = (
+        (0x01020304).to_bytes(4, "little") + bytes([0x80, 0x00, 0x01, 0x03]) + b"\x00" * 4 + b"\x05"
+    )
+    secret = _shared_secret()
+    packet = Packet()
+    packet.header = (PAYLOAD_TYPE_RESPONSE << 2) | (
+        ROUTE_TYPE_FLOOD if flood else ROUTE_TYPE_DIRECT
+    )
+    packet.path = bytearray(IN_PATH) if flood else bytearray()
+    packet.path_len = IN_PATH_LEN if flood else 0
+    packet.payload = bytearray(
+        bytes([LOCAL_IDENTITY.get_public_key()[0], PEER_HASH])
+        + CryptoUtils.encrypt_then_mac(secret[:16], secret, login_reply)
+    )
+    packet.payload_len = len(packet.payload)
+    return packet
+
+
+@pytest.mark.asyncio
+async def test_login_response_handler_teaches_on_flood_login_response():
+    """The forced-path regression: a DIRECT login is answered with a flood
+    RESPONSE, and that is the only chance to teach before the first CLI REQ."""
+    injector = _Injector()
+    handler = LoginResponseHandler(LOCAL_IDENTITY, _contacts(), lambda _m: None)
+    handler.set_packet_injector(injector)
+
+    completions = []
+    handler.register_login_callback(PEER_KEY, lambda success, data: completions.append(success))
+
+    await handler(_login_reply_packet())
+    await handler.return_path_teacher.wait_for_pending()
+
+    assert completions == [True], "login response should still be delivered"
+    assert len(injector.packets) == 1
+    _, embedded_path = _decode_teach(injector.packets[0])
+    assert embedded_path == IN_PATH
+
+
+# --------------------------------------------------------------------------- #
+# Wiring
+# --------------------------------------------------------------------------- #
+
+
+def _core(contacts=None):
+    return create_core_handlers(
+        identity=LOCAL_IDENTITY,
+        contacts=contacts if contacts is not None else _contacts(),
+        channels=None,
+        event_service=None,
+        send_packet_fn=lambda *a, **k: None,
+        log_fn=lambda _m: None,
+        node_name="test",
+    )
+
+
+def test_factory_shares_one_teacher_between_response_handlers():
+    """A shared instance keeps the per-contact cooldown and the evidence guard
+    honest — two handlers each with their own teacher would double the transmit
+    rate and lose the guard."""
+    core = _core()
+    assert core.protocol_response_handler.return_path_teacher is core.return_path_teacher
+    assert core.login_response_handler.return_path_teacher is core.return_path_teacher
+
+
+def test_set_packet_injector_also_wires_the_teacher():
+    """Existing companion wiring calls only set_packet_injector; the teacher has
+    to pick the transmit path up from there or it silently never fires."""
+    core = _core()
+    assert core.return_path_teacher.enabled is False
+    core.protocol_response_handler.set_packet_injector(_Injector())
+    assert core.return_path_teacher.enabled is True
+    assert core.login_response_handler.return_path_teacher.enabled is True
+
+
+def test_login_handler_can_wire_its_own_injector_standalone():
+    handler = LoginResponseHandler(LOCAL_IDENTITY, _contacts(), lambda _m: None)
+    assert handler.return_path_teacher.enabled is False
+    handler.set_packet_injector(_Injector())
+    assert handler.return_path_teacher.enabled is True
+
+
+# --------------------------------------------------------------------------- #
+# base_send retry hook
+# --------------------------------------------------------------------------- #
+
+
+class _StubSender(_SendOpsMixin):
+    """Minimal carrier for the retry hook; only the handler accessor is used."""
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    def _get_protocol_response_handler(self):
+        return self._handler
+
+
+@pytest.mark.asyncio
+async def test_retry_hook_asks_the_teacher_to_reverse_the_out_path():
+    injector = _Injector()
+    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    handler.set_packet_injector(injector)
+
+    await _StubSender(handler)._teach_return_path_before_retry(PEER_KEY, "REQ 0x01")
+    await handler.return_path_teacher.wait_for_pending()
+
+    assert len(injector.packets) == 1
+    _, embedded_path = _decode_teach(injector.packets[0])
+    assert embedded_path == bytes(reversed(OUT_PATH))
+
+
+@pytest.mark.asyncio
+async def test_retry_hook_is_best_effort_and_never_raises():
+    """A failing teach must not abort the retry it precedes."""
+
+    class _Boom:
+        @property
+        def return_path_teacher(self):
+            raise RuntimeError("handler exploded")
+
+    await _StubSender(_Boom())._teach_return_path_before_retry(PEER_KEY, "REQ")
+    # No handler at all (companion subclasses may return None).
+    await _StubSender(None)._teach_return_path_before_retry(PEER_KEY, "REQ")
+
+
+@pytest.mark.asyncio
+async def test_request_retry_loop_invokes_the_teach_hook():
+    """Covers the wiring in _request_with_retries itself: without this, deleting
+    the call would leave every other test in this file green."""
+    calls = []
+
+    class _Sender(_SendOpsMixin):
+        async def _teach_return_path_before_retry(self, contact_pubkey, log_label):
+            calls.append(bytes(contact_pubkey))
+
+        def _apply_path_hash_mode(self, pkt):
+            return None
+
+        def _response_timeout_s(self, pkt, proxy):
+            return 0.001
+
+        async def _send_packet(self, pkt, wait_for_ack=False, expected_crc=None):
+            return True
+
+    def _build():
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | ROUTE_TYPE_DIRECT
+        pkt.payload = bytearray(b"\x00" * 8)
+        pkt.payload_len = 8
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        return pkt, None
+
+    async def _always_timeout(_timeout):
+        return {"timeout": True}
+
+    result = await _Sender()._request_with_retries(
+        _build, _always_timeout, object(), log_label="REQ", contact_pubkey=PEER_KEY
+    )
+
+    assert result["timeout"] is True
+    # One teach before every attempt after the first.
+    assert calls and all(c == PEER_KEY for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_started_request_retry_loop_invokes_the_teach_hook():
+    """Same coverage for the background continuation used by the frame-server
+    API path (_finish_started_request)."""
+    calls = []
+
+    class _Sender(_SendOpsMixin):
+        async def _teach_return_path_before_retry(self, contact_pubkey, log_label):
+            calls.append(bytes(contact_pubkey))
+
+        def _apply_path_hash_mode(self, pkt):
+            return None
+
+        def _response_timeout_s(self, pkt, proxy):
+            return 0.001
+
+        async def _send_packet(self, pkt, wait_for_ack=False, expected_crc=None):
+            return True
+
+    def _build():
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | ROUTE_TYPE_DIRECT
+        pkt.payload = bytearray(b"\x00" * 8)
+        pkt.payload_len = 8
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        return pkt, None
+
+    async def _always_timeout(_timeout):
+        return {"timeout": True}
+
+    await _Sender()._finish_started_request(
+        _build,
+        _always_timeout,
+        object(),
+        first_timeout_s=0.001,
+        deadline=None,
+        log_label="REQ",
+        cleanup=None,
+        response_tag_registered=None,
+        contact_pubkey=PEER_KEY,
+    )
+
+    assert calls and all(c == PEER_KEY for c in calls)

--- a/tests/test_return_path_teacher.py
+++ b/tests/test_return_path_teacher.py
@@ -630,6 +630,7 @@ async def test_flood_path_reciprocal_reports_itself_and_blocks_the_reverse_guess
     handler.set_packet_injector(injector)
 
     await handler(_flood_path_packet())
+    await handler.wait_for_pending_reciprocals()
     await handler.return_path_teacher.wait_for_pending()
 
     # Exactly one packet: the reciprocal. The RESPONSE-branch teach must not

--- a/tests/test_return_path_teacher.py
+++ b/tests/test_return_path_teacher.py
@@ -113,11 +113,39 @@ class _Injector:
 
 
 def _teacher(contacts=None, injector=None, **kwargs):
+    # Default the settle window off so tests do not sleep; the settle behaviour
+    # itself is covered explicitly by overriding _settle.
+    kwargs.setdefault("settle_s", 0.0)
     teacher = ReturnPathTeacher(
         lambda _m: None, LOCAL_IDENTITY, contacts if contacts is not None else _contacts(), **kwargs
     )
     teacher.set_injector(injector if injector is not None else _Injector())
     return teacher
+
+
+def _copy_of(pkt: Packet, *, in_path: bytes, rssi: int, len_byte: int = None) -> Packet:
+    """Another flood copy of the SAME reply: identical payload (hence identical
+    packet hash), differing only in the accumulated path and last-hop RSSI —
+    exactly how one flooded reply reaches us over several routes. ``len_byte``
+    overrides the path_len encoding when the copy has a different hop count."""
+    copy = Packet()
+    copy.header = pkt.header
+    copy.path = bytearray(in_path)
+    copy.path_len = pkt.path_len if len_byte is None else len_byte
+    copy.payload = bytearray(pkt.payload)
+    copy.payload_len = pkt.payload_len
+    copy._rssi = rssi
+    return copy
+
+
+# Two-byte-hash routes of differing length, sharing no bytes so a test can tell
+# which one was taught. SHORT is 2 hops, LONG is that route plus a strong final
+# hop (the "desk repeater adds a hop" case).
+# encode_path_len(hash_size, hash_count): both routes use 2-byte hashes.
+SHORT_2HOP = bytes([0x11, 0x22, 0x33, 0x44])
+SHORT_2HOP_LEN = PathUtils.encode_path_len(2, 2)  # 2 hops
+LONG_3HOP = bytes([0x11, 0x22, 0x33, 0x44, 0xEC, 0xF4])
+LONG_3HOP_LEN = PathUtils.encode_path_len(2, 3)  # 3 hops
 
 
 async def _teach_flood(teacher, **kwargs):
@@ -270,6 +298,165 @@ async def test_no_injector_is_a_no_op():
     teacher = ReturnPathTeacher(lambda _m: None, LOCAL_IDENTITY, _contacts())
     assert teacher.enabled is False
     assert await _teach_flood(teacher) is False
+
+
+# --------------------------------------------------------------------------- #
+# Best-copy selection by last-hop RSSI (openHop, no firmware equivalent)
+# --------------------------------------------------------------------------- #
+
+# A second route the same reply can arrive on, distinct from IN_PATH so a test
+# can tell which copy was taught. 2-byte hash, one hop — matches IN_PATH_LEN.
+STRONG_PATH = bytes([0xEE, 0xFF])
+
+
+@pytest.mark.asyncio
+async def test_teaches_from_best_rssi_copy_not_the_first_arrived():
+    """The bug this fixes: dedup hands the handler the first-arrived copy, which
+    on a real mesh is often the weakest route. A stronger copy seen pre-dedup by
+    note_flood_copy must win."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    base = _response_packet(flood=True, in_path=IN_PATH)
+    strong = _copy_of(base, in_path=STRONG_PATH, rssi=-20)
+    weak = _copy_of(base, in_path=IN_PATH, rssi=-100)
+
+    # The strong copy arrives (pre-dedup) before the weak one triggers the teach.
+    teacher.note_flood_copy(strong)
+    assert await teacher.maybe_teach_from_flood_reply(weak, PEER_KEY, PEER_HASH, reason="test")
+    await teacher.wait_for_pending()
+
+    assert len(injector.packets) == 1
+    _, embedded = _decode_teach(injector.packets[0])
+    assert embedded == STRONG_PATH, "taught the marginal first-arrived route, not the best one"
+
+
+@pytest.mark.asyncio
+async def test_first_copy_wins_when_no_better_copy_is_seen():
+    """With nothing better recorded, the teach falls back to the triggering
+    (first-arrived) copy — preserving behaviour where no subscriber is wired."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    assert await _teach_flood(teacher) is True
+    _, embedded = _decode_teach(injector.packets[0])
+    assert embedded == IN_PATH
+
+
+@pytest.mark.asyncio
+async def test_settle_window_lets_a_later_stronger_copy_win():
+    """Firmware's sendDirect(...,3000) is a settle window; a stronger copy that
+    lands during it must be the one taught."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    base = _response_packet(flood=True, in_path=IN_PATH)
+    weak = _copy_of(base, in_path=IN_PATH, rssi=-100)
+    strong = _copy_of(base, in_path=STRONG_PATH, rssi=-20)
+
+    async def fake_settle(_seconds):
+        # A stronger copy arrives while we are holding for the settle window.
+        teacher.note_flood_copy(strong)
+
+    teacher._settle_s = 3.0
+    teacher._settle = fake_settle
+
+    assert await teacher.maybe_teach_from_flood_reply(weak, PEER_KEY, PEER_HASH, reason="t")
+    await teacher.wait_for_pending()
+
+    _, embedded = _decode_teach(injector.packets[0])
+    assert embedded == STRONG_PATH
+
+
+@pytest.mark.asyncio
+async def test_note_flood_copy_ignores_direct_and_misaddressed_and_nonresponse():
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+
+    direct = _response_packet(flood=False)
+    direct._rssi = -10
+    teacher.note_flood_copy(direct)  # direct is never a teach trigger
+
+    other = _response_packet(flood=True, in_path=STRONG_PATH)
+    other.payload[0] = (LOCAL_IDENTITY.get_public_key()[0] + 1) & 0xFF  # addressed elsewhere
+    other._rssi = -10
+    teacher.note_flood_copy(other)
+
+    assert not teacher._recent_copies
+
+
+def test_note_flood_copy_is_a_noop_without_injector():
+    teacher = ReturnPathTeacher(lambda _m: None, LOCAL_IDENTITY, _contacts(), settle_s=0.0)
+    pkt = _response_packet(flood=True)
+    pkt._rssi = -10
+    teacher.note_flood_copy(pkt)
+    assert not teacher._recent_copies
+
+
+def test_recorded_copies_are_pruned_by_ttl():
+    clock = {"t": 0.0}
+    teacher = _teacher(time_fn=lambda: clock["t"])
+    teacher._copy_ttl_s = 8.0
+
+    a = _response_packet(flood=True, in_path=IN_PATH)
+    teacher.note_flood_copy(_copy_of(a, in_path=IN_PATH, rssi=-40))
+    assert len(teacher._recent_copies) == 1
+
+    clock["t"] += 100.0  # well past the TTL
+    b = _response_packet(flood=True, in_path=STRONG_PATH)
+    teacher.note_flood_copy(_copy_of(b, in_path=STRONG_PATH, rssi=-40))
+    assert len(teacher._recent_copies) == 1  # the stale entry was dropped
+
+
+# --------------------------------------------------------------------------- #
+# Hop-penalized selection (a strong nearby repeater must not add a needless hop)
+# --------------------------------------------------------------------------- #
+
+
+async def _teach_choosing_between(teacher, short_rssi, long_rssi):
+    """Record a 2-hop and a 3-hop copy of one reply, trigger the teach, and
+    return the embedded path the teacher chose."""
+    injector = teacher._injector
+    base = _response_packet(flood=True)
+    teacher.note_flood_copy(
+        _copy_of(base, in_path=SHORT_2HOP, rssi=short_rssi, len_byte=SHORT_2HOP_LEN)
+    )
+    teacher.note_flood_copy(
+        _copy_of(base, in_path=LONG_3HOP, rssi=long_rssi, len_byte=LONG_3HOP_LEN)
+    )
+    # Trigger with a weak first-arrived copy; selection must come from the table.
+    trigger = _copy_of(base, in_path=SHORT_2HOP, rssi=-120, len_byte=SHORT_2HOP_LEN)
+    assert await teacher.maybe_teach_from_flood_reply(trigger, PEER_KEY, PEER_HASH, reason="t")
+    await teacher.wait_for_pending()
+    _, embedded = _decode_teach(injector.packets[-1])
+    return embedded
+
+
+@pytest.mark.asyncio
+async def test_shorter_route_wins_when_extra_hop_buys_little_signal():
+    """The ECF4-on-the-desk case: a 3-hop copy at -13 must NOT beat a 2-hop copy
+    at -15 — 2 dB is not worth an extra hop (10 dB/hop default)."""
+    teacher = _teacher(injector=_Injector())
+    embedded = await _teach_choosing_between(teacher, short_rssi=-15, long_rssi=-13)
+    assert embedded == SHORT_2HOP
+
+
+@pytest.mark.asyncio
+async def test_longer_route_wins_when_it_is_materially_stronger():
+    """When the shorter route's final hop is genuinely weak, the extra hop is
+    earned: a 3-hop copy at -13 beats a 2-hop copy at -60."""
+    teacher = _teacher(injector=_Injector())
+    embedded = await _teach_choosing_between(teacher, short_rssi=-60, long_rssi=-13)
+    assert embedded == LONG_3HOP
+
+
+@pytest.mark.asyncio
+async def test_zero_penalty_restores_pure_best_rssi():
+    """With the penalty disabled, selection is pure last-hop RSSI again, so the
+    stronger 3-hop copy wins even for a 2 dB edge."""
+    teacher = _teacher(injector=_Injector(), hop_penalty_db=0.0)
+    embedded = await _teach_choosing_between(teacher, short_rssi=-15, long_rssi=-13)
+    assert embedded == LONG_3HOP
 
 
 # --------------------------------------------------------------------------- #
@@ -467,6 +654,7 @@ async def test_protocol_response_handler_teaches_on_flood_response():
     injector = _Injector()
     handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
     handler.set_packet_injector(injector)
+    handler.return_path_teacher._settle_s = 0.0  # don't sleep the real settle window
 
     await handler(_response_packet(flood=True))
     await handler.return_path_teacher.wait_for_pending()
@@ -517,6 +705,7 @@ async def test_login_response_handler_teaches_on_flood_login_response():
     injector = _Injector()
     handler = LoginResponseHandler(LOCAL_IDENTITY, _contacts(), lambda _m: None)
     handler.set_packet_injector(injector)
+    handler.return_path_teacher._settle_s = 0.0  # don't sleep the real settle window
 
     completions = []
     handler.register_login_callback(PEER_KEY, lambda success, data: completions.append(success))

--- a/tests/test_tx_lock_ack_scope.py
+++ b/tests/test_tx_lock_ack_scope.py
@@ -1,0 +1,463 @@
+"""OH-002: the ACK wait must not hold the dispatcher's global transmit lock.
+
+Firmware reference (MeshCore ``8a69f34``): ``Dispatcher::loop`` owns the radio
+only from ``startSendRaw`` until ``isSendComplete()`` / ``outbound_expiry``
+(1.5x estimated airtime), then immediately services the outbound queue again
+(``Dispatcher.cpp:86-131``, ``checkSend:275-354``). ACK correlation lives a
+layer up in ``BaseChatMesh``: ``sendMessage`` queues the packet and arms a
+non-blocking ``txt_send_timeout`` deadline polled from ``loop()``
+(``BaseChatMesh.cpp:442-483``, ``:958-961``); ``onAckRecv`` just clears it
+(``:347-351``). The send funnel is never held across an ACK wait.
+
+Core previously held ``_tx_lock`` through ``sleep(tx_delay)`` +
+``wait_for_ack(ACK_TIMEOUT=5.0)``, blocking every other funnel user (including
+client-repeat relay forwards) for up to five seconds while the radio sat idle.
+These tests pin the corrected shape: transmit + budget debit + ACK-waiter
+registration under the lock, the wait itself outside it.
+
+Companion invariant note: ``test_tx_budget.py`` already guards "lock held during
+``radio.send``, released after" for ``wait_for_ack=False``; this module extends
+that to the ACK-waiting path and adds the release-before-wait guarantee.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from openhop_core.node import dispatcher as disp_mod
+from openhop_core.node.dispatcher import Dispatcher, DispatcherState
+from openhop_core.protocol import Packet
+from openhop_core.protocol.constants import (
+    PAYLOAD_TYPE_ACK,
+    PAYLOAD_TYPE_ADVERT,
+    PAYLOAD_TYPE_TXT_MSG,
+    ROUTE_TYPE_FLOOD,
+)
+
+SELF_KEY = b"0123456789abcdef0123456789abcdef"
+
+
+class Radio:
+    """Records every transmit; ``gate`` lets a test hold one open mid-send."""
+
+    def __init__(self):
+        self.rx_callback = None
+        self.send_count = 0
+        self.send_starts = []
+        self.tx_data = None
+        self.gate = None  # asyncio.Event: when set (or None), send returns at once
+        self.lock_held_during_send = []
+        self.dispatcher = None
+        self.fail_with = None  # Exception instance to raise instead of sending
+        self.metadata = {"ok": 1}
+
+    def set_rx_callback(self, cb):
+        self.rx_callback = cb
+
+    async def send(self, data):
+        self.send_count += 1
+        self.send_starts.append(time.monotonic())
+        self.tx_data = data
+        if self.dispatcher is not None:
+            self.lock_held_during_send.append(self.dispatcher._tx_lock.locked())
+        if self.fail_with is not None:
+            raise self.fail_with
+        if self.gate is not None:
+            await self.gate.wait()
+        return self.metadata
+
+    def get_last_rssi(self):
+        return -70
+
+    def get_last_snr(self):
+        return 8.0
+
+
+class Identity:
+    def get_public_key(self):
+        return SELF_KEY
+
+
+def _make(*, tx_delay=0.0, client_repeat=False):
+    radio = Radio()
+    d = Dispatcher(radio, tx_delay=tx_delay, dedupe_enabled=True)
+    d.local_identity = Identity()
+    radio.dispatcher = d
+    if client_repeat:
+        d.set_client_repeat_enabled(True)
+    return d, radio
+
+
+def _txt(seq: int = 0) -> Packet:
+    """A flood TXT_MSG packet; ``seq`` varies the payload so CRCs differ."""
+    p = Packet()
+    p.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD
+    p.payload = bytearray([0x77, 0x99, seq & 0xFF]) + bytearray(b"\xAA" * 12)
+    p.payload_len = len(p.payload)
+    return p
+
+
+def _typed(payload_type: int) -> Packet:
+    p = Packet()
+    p.header = (payload_type << 2) | ROUTE_TYPE_FLOOD
+    p.payload = bytearray(b"\xAA" * 8)
+    p.payload_len = len(p.payload)
+    return p
+
+
+async def _spin_until(pred, turns: int = 500) -> bool:
+    """Yield to the event loop until ``pred()`` holds, without wall-clock sleeps."""
+    for _ in range(turns):
+        if pred():
+            return True
+        await asyncio.sleep(0)
+    return pred()
+
+
+# --------------------------------------------------------------------------- #
+# Lock scope: held for the transmit, released for the wait
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_lock_is_held_during_transmit_on_the_ack_path():
+    # Firmware holds the radio for the physical send; so must we. This is the
+    # invariant the OH-002 fix must NOT relax (test_tx_budget covers the same
+    # thing for wait_for_ack=False sends).
+    d, radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: radio.send_count == 1)
+
+    assert radio.lock_held_during_send == [True]
+
+    await d._register_ack_received(crc)
+    assert await task is True
+
+
+@pytest.mark.asyncio
+async def test_tx_lock_is_free_while_parked_in_the_ack_wait():
+    # The core of OH-002: once the physical transmit completes the funnel is
+    # free, exactly as Dispatcher::loop releases `outbound` on isSendComplete().
+    d, radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+
+    assert radio.send_count == 1  # transmit already happened
+    assert not d._tx_lock.locked()  # ...and the lock is already released
+    assert d.state == DispatcherState.WAIT
+    assert not task.done()
+
+    await d._register_ack_received(crc)
+    assert await task is True
+
+
+@pytest.mark.asyncio
+async def test_second_send_transmits_while_first_awaits_its_ack():
+    # Pre-fix, B queued on _tx_lock behind A's up-to-5s ACK wait and the radio
+    # sat idle. Post-fix B transmits immediately.
+    d, radio = _make()
+    pkt_a = _txt(1)
+    crc_a = pkt_a.get_crc()
+
+    task_a = asyncio.create_task(d.send_packet(pkt_a, wait_for_ack=True))
+    assert await _spin_until(lambda: crc_a in d._waiting_acks)
+    assert not task_a.done()
+
+    # B goes out during A's wait window, well inside ACK_TIMEOUT.
+    assert await d.send_packet(_txt(2), wait_for_ack=False) is True
+    assert radio.send_count == 2
+    assert not task_a.done()  # A is still waiting; B did not resolve it
+
+    await d._register_ack_received(crc_a)
+    assert await task_a is True
+
+
+@pytest.mark.asyncio
+async def test_second_ack_waiting_send_overlaps_the_first():
+    # Two independent ACK waits may now be in flight at once; each resolves on
+    # its own CRC.
+    d, radio = _make()
+    pkt_a, pkt_b = _txt(1), _txt(2)
+    crc_a, crc_b = pkt_a.get_crc(), pkt_b.get_crc()
+    assert crc_a != crc_b
+
+    task_a = asyncio.create_task(d.send_packet(pkt_a, wait_for_ack=True))
+    assert await _spin_until(lambda: crc_a in d._waiting_acks)
+    task_b = asyncio.create_task(d.send_packet(pkt_b, wait_for_ack=True))
+    assert await _spin_until(lambda: crc_b in d._waiting_acks)
+
+    assert radio.send_count == 2
+    assert not task_a.done() and not task_b.done()
+
+    await d._register_ack_received(crc_b)
+    assert await task_b is True
+    assert not task_a.done()  # B's ACK must not resolve A
+
+    await d._register_ack_received(crc_a)
+    assert await task_a is True
+    assert d._waiting_acks == {}
+
+
+@pytest.mark.asyncio
+async def test_client_repeat_forward_is_not_blocked_by_an_ack_wait():
+    # The client-repeat branch of send_packet is separate code (budget gate +
+    # under-lock admission recheck); it must release the lock before the wait
+    # too, or relay forwards stall behind every DM awaiting an ACK.
+    d, radio = _make(client_repeat=True)
+    pkt_a = _txt(1)
+    crc_a = pkt_a.get_crc()
+
+    task_a = asyncio.create_task(d.send_packet(pkt_a, wait_for_ack=True))
+    assert await _spin_until(lambda: crc_a in d._waiting_acks)
+    assert not d._tx_lock.locked()
+
+    # A relay forward is a plain wait_for_ack=False send through the funnel.
+    assert await d.send_packet(_txt(2), wait_for_ack=False) is True
+    assert radio.send_count == 2
+
+    await d._register_ack_received(crc_a)
+    assert await task_a is True
+
+
+# --------------------------------------------------------------------------- #
+# Waiter registration happens under the lock (no missed ACKs)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_waiter_is_registered_before_the_lock_is_released():
+    # Registering under _tx_lock is what makes the off-lock wait safe: the CRC
+    # is already in _waiting_acks the instant the funnel reopens, so an ACK that
+    # lands in the gap is matched rather than dropped.
+    d, radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+    radio.gate = asyncio.Event()  # hold the transmit open
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: radio.send_count == 1)
+    assert d._tx_lock.locked()
+    assert crc not in d._waiting_acks  # not yet -- transmit hasn't completed
+
+    radio.gate.set()
+    assert await _spin_until(lambda: not d._tx_lock.locked())
+    assert crc in d._waiting_acks  # registered by the time the lock frees
+
+    await d._register_ack_received(crc)
+    assert await task is True
+
+
+@pytest.mark.asyncio
+async def test_ack_arriving_during_tx_delay_is_still_matched():
+    # tx_delay now elapses off-lock, and the waiter is registered before it, so
+    # an ACK during that window resolves the send instead of being missed.
+    d, radio = _make(tx_delay=0.05)
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    started = time.monotonic()
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+    assert not d._tx_lock.locked()  # funnel free during tx_delay as well
+    assert not task.done()
+
+    await d._register_ack_received(crc)
+    assert await task is True
+    # The tx_delay pause still happened -- it was moved, not removed.
+    assert time.monotonic() - started >= 0.05
+
+
+@pytest.mark.asyncio
+async def test_ack_already_cached_resolves_without_waiting():
+    # _recent_acks is the belt-and-braces guard for an ACK that beat the
+    # registration; expect_ack() fires the event immediately in that case.
+    d, _radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+    d._recent_acks[crc] = asyncio.get_running_loop().time()
+
+    assert await d.send_packet(pkt, wait_for_ack=True) is True
+    assert crc not in d._waiting_acks
+
+
+@pytest.mark.asyncio
+async def test_expected_crc_override_is_used_for_correlation():
+    # Text sends pass the SHA-derived expected_ack from PacketBuilder rather
+    # than the packet CRC; the override must survive the lock restructure.
+    d, _radio = _make()
+    pkt = _txt()
+    override = 0x1234ABCD
+    assert override != pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True, expected_crc=override))
+    assert await _spin_until(lambda: override in d._waiting_acks)
+    assert pkt.get_crc() not in d._waiting_acks
+
+    await d._register_ack_received(override)
+    assert await task is True
+
+
+@pytest.mark.asyncio
+async def test_waiting_ack_registration_marks_relayed_ack_do_not_retransmit():
+    # AckHandler.__call__ keys `markDoNotRetransmit` off membership in
+    # _waiting_acks (firmware BaseChatMesh::onAckRecv, which marks when
+    # processAck matches). Registering under the lock only widens that window.
+    d, _radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+
+    ack_pkt = Packet()
+    ack_pkt.header = (PAYLOAD_TYPE_ACK << 2) | ROUTE_TYPE_FLOOD
+    ack_pkt.payload = bytearray(crc.to_bytes(4, "little")) + bytearray(b"\x01\x5A")
+    ack_pkt.payload_len = len(ack_pkt.payload)
+
+    handler = disp_mod.AckHandler(d._log, dispatcher=d)
+    handler.set_ack_received_callback(d._register_ack_received)
+    await handler(ack_pkt)
+
+    assert ack_pkt.is_marked_do_not_retransmit() is True
+    assert await task is True
+
+
+# --------------------------------------------------------------------------- #
+# Failure, timeout and cancellation paths
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ack_timeout_returns_false_and_cleans_up(monkeypatch):
+    monkeypatch.setattr(disp_mod, "ACK_TIMEOUT", 0.05)
+    d, _radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    assert await d.send_packet(pkt, wait_for_ack=True) is False
+    assert crc not in d._waiting_acks
+    assert not d._tx_lock.locked()
+    assert d.state == DispatcherState.IDLE
+    assert d._current_expected_crc is None
+
+
+@pytest.mark.asyncio
+async def test_transmit_exception_registers_no_waiter():
+    d, radio = _make()
+    radio.fail_with = RuntimeError("radio down")
+    pkt = _txt()
+
+    assert await d.send_packet(pkt, wait_for_ack=True) is False
+    assert d._waiting_acks == {}
+    assert not d._tx_lock.locked()
+    assert d.state == DispatcherState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_missing_tx_metadata_registers_no_waiter():
+    d, radio = _make()
+    radio.metadata = None
+    pkt = _txt()
+
+    assert await d.send_packet(pkt, wait_for_ack=True) is False
+    assert d._waiting_acks == {}
+    assert not d._tx_lock.locked()
+    assert d.state == DispatcherState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_ack_wait_frees_lock_and_registration():
+    d, radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+    assert not d._tx_lock.locked()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert crc not in d._waiting_acks
+    assert not d._tx_lock.locked()
+    # The funnel is still usable after a cancelled ACK wait.
+    assert await d.send_packet(_txt(2), wait_for_ack=False) is True
+    assert radio.send_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_tx_delay_does_not_strand_the_waiter():
+    # The waiter is now registered under _tx_lock, one await *earlier* than
+    # _await_ack_event's own try/finally. A cancel landing in that gap -- the
+    # tx_delay pause, which is non-zero by default -- must still unregister the
+    # CRC. Nothing prunes _waiting_acks (unlike _recent_acks, cleaned in
+    # run_forever), so a stranded entry would make AckHandler mark every relayed
+    # ACK for that CRC do-not-retransmit for the life of the process.
+    d, _radio = _make(tx_delay=0.5)
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: crc in d._waiting_acks)
+    assert d.state == DispatcherState.WAIT  # parked in tx_delay, not yet awaiting
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert crc not in d._waiting_acks
+    assert d._waiting_acks == {}
+    assert not d._tx_lock.locked()
+
+
+# --------------------------------------------------------------------------- #
+# Paths that never wait
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("payload_type", [PAYLOAD_TYPE_ADVERT, PAYLOAD_TYPE_ACK])
+@pytest.mark.asyncio
+async def test_advert_and_ack_never_register_a_waiter(payload_type):
+    # Firmware never awaits an ACK for an ADVERT or an ACK; wait_for_ack=True
+    # from a caller must stay a no-op for these types.
+    d, radio = _make()
+
+    assert await d.send_packet(_typed(payload_type), wait_for_ack=True) is True
+    assert radio.send_count == 1
+    assert d._waiting_acks == {}
+    assert d.state == DispatcherState.IDLE
+    assert not d._tx_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ack_false_returns_after_transmit():
+    d, radio = _make()
+
+    assert await d.send_packet(_txt(), wait_for_ack=False) is True
+    assert radio.send_count == 1
+    assert d._waiting_acks == {}
+    assert d.state == DispatcherState.IDLE
+    assert not d._tx_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_state_returns_to_idle_after_a_successful_ack_wait():
+    d, _radio = _make()
+    pkt = _txt()
+    crc = pkt.get_crc()
+
+    task = asyncio.create_task(d.send_packet(pkt, wait_for_ack=True))
+    assert await _spin_until(lambda: d.state == DispatcherState.WAIT)
+
+    await d._register_ack_received(crc)
+    assert await task is True
+    assert d.state == DispatcherState.IDLE
+    assert d._current_expected_crc is None


### PR DESCRIPTION
- Teach return paths so servers reply DIRECT instead of re-flooding (new return_path.py). A server answers from its stored out_path; with a forced-direct login it's never taught, so replies flood forever. Add ReturnPathTeacher, shared by the login and protocol-response handlers, triggered from both flood-RESPONSE paths. It collects every pre-dedup copy of a flood reply (via a raw-packet subscriber), then teaches from the best one after a settle window, ranked by hop-penalized last-hop RSSI so a nearby re-flooding repeater can't insert itself as an extra hop. Prefers direct paths over relays, completes late flood login replies, and guards a symmetric-path guess so it never overwrites an observed route. (2ad9cbd, 68d2a54, 564d553, 6f96d8f)
- Scope flood requests and replies to their region (10db26d). Mirror the persisted default scope + unscoped flag onto the dispatcher (fixes plain-flood sends when only a default is configured), and re-scope each flood reply to its request's region rather than the node default — matching firmware sendFloodScoped/sendFloodReply. Companions leave region_map None (inert); the repeater activates it.
- Release the TX lock before waiting for the ACK (c10b878). send_packet held the global _tx_lock through tx_delay + the up-to-5s ACK wait, blocking all other funnel users (including relay forwards) while the radio sat idle. Split out _transmit_locked and run the ACK wait unlocked, with the waiter registered before release so a fast ACK still matches.
- Check direct next-hop ownership before dedup (b798e4b). A node that overheard a longer-path variant marked the hash seen and dropped the copy it was actually next hop for. Skip dedup tracking for routed-direct packets this node isn't the next hop for, per Mesh::onRecvPacket.
- Prevent KISS recovery lock inversion (1a0d874). A serial write failure while holding _command_lock/_serial_write_lock could ABBA-deadlock against the reconnect worker's _connection_lock. Mark failures immediately and close the port only when the lock is free. (Thanks cupid_stunt_1!)
- Accept 6-byte plain-DM ACKs (f9c7dce). MeshCore emits 6-byte ACKs for plain direct messages; the bridge required exactly 4 and dropped them, so send_confirmed never fired. Accept ≥4 bytes and correlate on the first four.

Each fix ships regression tests (new test_return_path_teacher.py, test_tx_lock_ack_scope.py, test_flood_scope_fix.py, and additions to the KISS/handler/bridge suites).