### PR TITLE
fix: flood scoping, path-hash width, and RX reliability (firmware parity)

### DIFF
--- a/src/openhop_core/companion/base_callbacks.py
+++ b/src/openhop_core/companion/base_callbacks.py
@@ -216,6 +216,34 @@ class _CallbackMixin:
             "context": context or {},
         }
 
+    def has_pending_request_tag(self, tag: int, contact_pubkey: bytes) -> bool:
+        """True when ``tag`` is the reflected tag of a request we are waiting on.
+
+        Wired into :meth:`LoginResponseHandler.set_foreign_request_probe` so a
+        status/telemetry/neighbours reply is never mistaken for a login reply
+        while a login to the same contact is still pending. Covers both places a
+        pending tag can live:
+
+        * ``_pending_binary_requests`` — ``send_binary_req`` (neighbours, owner
+          info, ACL, MMA), keyed by the little-endian tag hex;
+        * the protocol handler's per-(contact, tag) waiters — ``send_status`` /
+          ``send_telemetry`` via ``_start_protocol_request``.
+
+        Expired entries are pruned first, so a long-dead request cannot keep
+        diverting replies away from a genuine login.
+        """
+        try:
+            self.cleanup_expired_binary_requests()
+            if (int(tag) & 0xFFFFFFFF).to_bytes(4, "little").hex() in self._pending_binary_requests:
+                return True
+            handler = self._get_protocol_response_handler()
+            waiters = getattr(handler, "_response_waiters", None)
+            if waiters and (bytes(contact_pubkey), int(tag) & 0xFFFFFFFF) in waiters:
+                return True
+        except Exception as e:
+            logger.debug("has_pending_request_tag failed: %s", e)
+        return False
+
     def cleanup_expired_binary_requests(self) -> None:
         """Remove expired entries from _pending_binary_requests."""
         now = time.time()

--- a/src/openhop_core/companion/base_config.py
+++ b/src/openhop_core/companion/base_config.py
@@ -8,8 +8,8 @@ import time
 from typing import Optional
 
 from ..protocol import Packet
-from ..protocol.constants import ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD
-from ..protocol.transport_keys import calc_transport_code, get_auto_key_for
+from ..protocol.constants import ROUTE_TYPE_FLOOD
+from ..protocol.transport_keys import get_auto_key_for, scope_packet
 from .constants import (
     DEFAULT_ALLOWED_REPEAT_FREQ_RANGES,
     DEFAULT_MAX_TX_POWER_DBM,
@@ -324,10 +324,12 @@ class _DeviceConfigMixin:
         return self._default_scope_key()
 
     def _scope_packet(self, pkt: Packet, key: bytes) -> None:
-        """Attach transport codes for ``key`` and switch FLOOD -> TRANSPORT_FLOOD."""
-        pkt.transport_codes[0] = calc_transport_code(key, pkt)
-        pkt.transport_codes[1] = 0  # reserved for home region (firmware TODO)
-        pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD
+        """Attach transport codes for ``key`` and switch FLOOD -> TRANSPORT_FLOOD.
+
+        Delegates to the shared :func:`scope_packet` primitive so the companion
+        and dispatcher resolvers compute the wire format identically.
+        """
+        scope_packet(pkt, key)
 
     def _apply_flood_scope(self, pkt: Packet) -> None:
         """Apply flood scope transport codes to a packet in-place.

--- a/src/openhop_core/companion/base_contacts.py
+++ b/src/openhop_core/companion/base_contacts.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Optional
 
-from ..protocol import Packet, PacketBuilder
+from ..protocol import Packet, PacketBuilder, is_self_advert
 from ..protocol.constants import (
     ADVERT_FLAG_HAS_LOCATION,
     ADVERT_FLAG_HAS_NAME,
@@ -145,7 +145,7 @@ class _ContactChannelMixin:
     async def _loopback_imported_advert(self, packet: Packet) -> None:
         """Deliver an imported ADVERT through the normal verified handler."""
         payload = packet.get_payload()
-        if len(payload) >= 32 and payload[:32] == self._identity.get_public_key():
+        if is_self_advert(payload, self._identity.get_public_key()):
             # Mesh::onRecvPacket ignores a self ADVERT after import, while the
             # command itself has already succeeded because its packet parsed.
             return

--- a/src/openhop_core/companion/base_events.py
+++ b/src/openhop_core/companion/base_events.py
@@ -46,6 +46,12 @@ class _RxEventsMixin:
                 # -> one store update and at most one advert_received (Bridge and Radio).
                 now = int(time.time())
                 contact = Contact.from_dict(data, now=now)
+                if contact.public_key == self.get_public_key():
+                    # Backstop: the ADVERT handler already drops a self advert the way
+                    # Mesh::onRecvPacket does (Mesh.cpp:263).  This event is a public
+                    # seam, and a node must never contact-book or path-cache itself
+                    # however the event was produced.
+                    return
                 # Wire advert flags (ADVERT_FLAG_IS_CHAT_NODE=0x01, etc.) must not
                 # be stored as local contact flags (bit 0 = favourite).  For new
                 # contacts the flags start at 0; for existing contacts

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -714,7 +714,6 @@ class _SendOpsMixin:
         log_label: str,
         cleanup: Optional[Callable[[], None]],
         response_tag_registered: Optional[Callable[[int], None]],
-        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Finish a request after its first packet has already been sent."""
         try:
@@ -723,9 +722,9 @@ class _SendOpsMixin:
                 return result
 
             for attempt in range(1, DEFAULT_MAX_ATTEMPTS):
-                if contact_pubkey is not None:
-                    await self._teach_return_path_before_retry(contact_pubkey, log_label)
-                pkt, packet_tag = build_packet()
+                # Every retry floods, whatever route the contact holds; the first
+                # attempt already went out before this method was called.
+                pkt, packet_tag = self._build_retry_packet(build_packet, proxy, log_label)
                 if response_tag_registered is not None and packet_tag is not None:
                     response_tag_registered(packet_tag)
                 self._apply_path_hash_mode(pkt)
@@ -768,7 +767,6 @@ class _SendOpsMixin:
         sent_tag: Optional[int] = None,
         cleanup: Optional[Callable[[], None]] = None,
         response_tag_registered: Optional[Callable[[int], None]] = None,
-        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Send the first packet and return its metadata plus a waiter task."""
         deadline = time.monotonic() + total_timeout_s if total_timeout_s is not None else None
@@ -808,7 +806,6 @@ class _SendOpsMixin:
                     log_label=log_label,
                     cleanup=cleanup,
                     response_tag_registered=response_tag_registered,
-                    contact_pubkey=contact_pubkey,
                 ),
                 f"{log_label} response",
             )
@@ -1187,7 +1184,6 @@ class _SendOpsMixin:
         total_timeout_s: Optional[float] = None,
         log_label: str = "request",
         response_tag_registered: Optional[Callable[[int], None]] = None,
-        contact_pubkey: Optional[bytes] = None,
     ) -> dict:
         """Send a request up to DEFAULT_MAX_ATTEMPTS times until a response lands.
 
@@ -1199,15 +1195,16 @@ class _SendOpsMixin:
         attempt's wait is clipped to the remaining budget and no new attempt
         starts once the budget is spent.
 
-        A timed-out attempt also re-teaches our return path when ``contact_pubkey``
-        is known; see :meth:`_teach_return_path_before_retry`.
+        Every attempt after the first floods, whatever route the contact holds;
+        see :meth:`_build_retry_packet`.
         """
         result: dict = {"timeout": True}
         deadline = time.monotonic() + total_timeout_s if total_timeout_s else None
         for attempt in range(DEFAULT_MAX_ATTEMPTS):
-            if attempt > 0 and contact_pubkey is not None:
-                await self._teach_return_path_before_retry(contact_pubkey, log_label)
-            pkt, packet_tag = build_packet()
+            if attempt == 0:
+                pkt, packet_tag = build_packet()
+            else:
+                pkt, packet_tag = self._build_retry_packet(build_packet, proxy, log_label)
             if response_tag_registered is not None and packet_tag is not None:
                 response_tag_registered(packet_tag)
             self._apply_path_hash_mode(pkt)
@@ -1232,27 +1229,64 @@ class _SendOpsMixin:
                 break
         return result
 
-    async def _teach_return_path_before_retry(self, contact_pubkey: bytes, log_label: str) -> None:
-        """Re-teach our return path after a request attempt timed out.
+    def _build_retry_packet(
+        self,
+        build_packet: Callable[[], tuple[Packet, Optional[int]]],
+        proxy: Any,
+        log_label: str,
+    ) -> tuple[Packet, Optional[int]]:
+        """Build a retry attempt as a FLOOD request, whatever route the contact holds.
 
-        openHop hardening with no firmware equivalent. When a server answers
-        DIRECT down a route that no longer reaches us, *nothing* arrives — there
-        is no flood reply to trigger the normal re-teach and no inbound path to
-        embed. A timeout against a contact we hold an ``out_path`` for is the
-        only evidence available, so the teacher falls back to reversing our own
-        ``out_path`` (see ``maybe_teach_reverse_of_out_path``). Best-effort: any
-        failure just leaves the retry to proceed as before.
+        A first attempt that timed out leaves the stored ``out_path`` suspect in
+        both directions: either the request never reached the peer, or the peer
+        answered DIRECT down a route back to us that no longer works. Flooding
+        the retry addresses both — it reaches the peer without depending on the
+        stored path, and a peer answers a *flood* request with a PATH-return
+        (``simple_repeater``/``BaseChatMesh`` ``onPeerDataRecv``), which is a real
+        observed inbound path for the return-path teacher to teach from. The
+        alternative — assuming the route is symmetric and teaching its reverse —
+        is wrong whenever it is not, and a peer taught a wrong route answers into
+        a void with no flood reply left to correct it.
+
+        Mirrors how firmware forces a single request to flood
+        (``companion_radio/MyMesh.cpp``)::
+
+            auto save = recipient->out_path_len;  // temporarily force sendRequest() to flood
+            recipient->out_path_len = OUT_PATH_UNKNOWN;
+            int result = sendRequest(*recipient, req_data, sizeof(req_data), tag, est_timeout);
+            recipient->out_path_len = save;
+
+        The stored path is only masked, never cleared: a contact stays direct for
+        every other caller, and a successful flood round-trip re-teaches the route
+        rather than discarding it. ``build_packet`` is synchronous, so no other
+        task can observe the mask, and it is restored on every exit path.
+
+        The forced flood is sent **unscoped**, marked ``_flood_scope_applied`` so
+        neither the companion nor the dispatcher resolver stamps a region on it.
+        A region-scoped retry is worse than no retry at all on a mixed mesh: a
+        repeater that has no regions configured cannot match the transport code,
+        so ``allowPacketForward`` refuses it (``simple_repeater/MyMesh.cpp``:
+        ``recv_pkt_region == NULL`` for a flood packet) and the retry dies at the
+        first hop — while the direct attempt it replaces at least had a route. The
+        trade-off is a mesh whose repeaters deny unscoped floods outright, where
+        the reverse holds; reach in the common case wins.
         """
+        saved = getattr(proxy, "out_path_len", None)
+        if saved is None or saved < 0:
+            return build_packet()  # already floods; nothing to force
         try:
-            proto_handler = self._get_protocol_response_handler()
-            teacher = getattr(proto_handler, "return_path_teacher", None)
-            if teacher is None:
-                return
-            await teacher.maybe_teach_reverse_of_out_path(
-                contact_pubkey, reason=f"{log_label} retry after timeout"
-            )
-        except Exception as e:
-            logger.debug("[PATHDIAG] return-path teach before retry failed: %s", e)
+            proxy.out_path_len = -1
+        except Exception as e:  # not a settable proxy: fall back to its own route
+            logger.debug("[PATHDIAG] %s: cannot force flood retry: %s", log_label, e)
+            return build_packet()
+        try:
+            pkt, tag = build_packet()
+        finally:
+            proxy.out_path_len = saved
+        if pkt is not None and pkt.is_route_flood():
+            pkt._flood_scope_applied = True
+            logger.debug("[PATHDIAG] %s: retry forced to unscoped FLOOD", log_label)
+        return pkt, tag
 
     async def _wait_for_path_propagation(self, proxy: Any, request_type: str) -> None:
         """Log the pre-send path; no longer sleeps.
@@ -1327,7 +1361,6 @@ class _SendOpsMixin:
                 log_label=log_label,
                 cleanup=_clear_response_tags,
                 response_tag_registered=_register_response_tag,
-                contact_pubkey=pub_key,
             )
             if not started.get("success"):
                 return started
@@ -1476,7 +1509,6 @@ class _SendOpsMixin:
                 proxy,
                 log_label=f"protocol REQ 0x{protocol_code:02X}",
                 response_tag_registered=_register_response_tag,
-                contact_pubkey=pub_key,
             )
             return {
                 "success": result.get("success", False),

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -207,7 +207,7 @@ class CompanionBridge(CompanionBase):
         )
         self._packet_injector = packet_injector
 
-        # Region registry for reply-region capture (OH-026). None by default so a
+        # Region registry for reply-region capture. None by default so a
         # standalone bridge captures nothing (replies fall through to plain). The
         # host repeater points this at its dispatcher's region_map so incoming
         # request regions are captured and mirrored onto replies.
@@ -428,7 +428,7 @@ class CompanionBridge(CompanionBase):
         is_flood = route_type in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD)
         self.stats.record_rx(is_flood=is_flood)
 
-        # Capture the region this request arrived under (OH-026) before the handler
+        # Capture the region this request arrived under before the handler
         # builds any reply, so a flood reply is scoped to that region (or plain).
         # No-op when no RegionMap is configured (standalone bridge).
         capture_recv_region(self.region_map, packet)

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -32,6 +32,7 @@ from ..protocol.constants import (
     ROUTE_TYPE_TRANSPORT_FLOOD,
 )
 from ..protocol.packet_utils import PathUtils
+from ..protocol.region_map import RegionMap, capture_recv_region
 from .companion_base import CompanionBase
 from .constants import (
     ADV_TYPE_CHAT,
@@ -205,6 +206,12 @@ class CompanionBridge(CompanionBase):
             initial_contacts=initial_contacts,
         )
         self._packet_injector = packet_injector
+
+        # Region registry for reply-region capture (OH-026). None by default so a
+        # standalone bridge captures nothing (replies fall through to plain). The
+        # host repeater points this at its dispatcher's region_map so incoming
+        # request regions are captured and mirrored onto replies.
+        self.region_map: Optional[RegionMap] = None
 
         async def _handler_send_packet(pkt: Packet, wait_for_ack: bool = False) -> bool:
             return await self._packet_injector(pkt, wait_for_ack=wait_for_ack)
@@ -420,6 +427,11 @@ class CompanionBridge(CompanionBase):
         route_type = packet.get_route_type()
         is_flood = route_type in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD)
         self.stats.record_rx(is_flood=is_flood)
+
+        # Capture the region this request arrived under (OH-026) before the handler
+        # builds any reply, so a flood reply is scoped to that region (or plain).
+        # No-op when no RegionMap is configured (standalone bridge).
+        capture_recv_region(self.region_map, packet)
 
         handler = self._handlers.get(ptype)
         if handler:

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -277,6 +277,33 @@ class CompanionBridge(CompanionBase):
         )
 
     # -------------------------------------------------------------------------
+    # Pre-dedup flood-copy feed (host-wired)
+    # -------------------------------------------------------------------------
+
+    def note_flood_copy(self, pkt: Packet, data: Any = None, analysis: Any = None) -> None:
+        """Feed one pre-dedup copy of a flood reply to the return-path teacher.
+
+        The host must wire this into its dispatcher's raw subscribers::
+
+            dispatcher.add_raw_packet_subscriber(bridge.note_flood_copy)
+
+        A bridge does not own a dispatcher, and the host delivers only the
+        *first* copy of a flood reply to :meth:`process_received_packet` — later
+        copies are dropped by the host's own seen-table before they get here. So
+        without this hook the teacher only ever sees the first-arrived route,
+        which on a live mesh is routinely the worst one: observed here, four
+        copies of one login reply landed over ~1.8 s and the teach went out
+        0.4 s in, embedding the marginal first route. See
+        :meth:`ReturnPathTeacher.note_flood_copy` for the selection itself.
+
+        Best-effort and never raises: this runs on the host's hot RX path.
+        """
+        teacher = getattr(self._protocol_response_handler, "return_path_teacher", None)
+        if teacher is None:
+            return
+        teacher.note_flood_copy(pkt, data, analysis)
+
+    # -------------------------------------------------------------------------
     # Handler accessors (used by CompanionBase concrete send methods)
     # -------------------------------------------------------------------------
 

--- a/src/openhop_core/companion/companion_bridge.py
+++ b/src/openhop_core/companion/companion_bridge.py
@@ -270,6 +270,9 @@ class CompanionBridge(CompanionBase):
         self._protocol_response_handler = core.protocol_response_handler
         self._login_response_handler = core.login_response_handler
         self._text_handler_ref = core.text_handler
+        # A pending login must not let the login handler claim an unrelated
+        # status/telemetry/neighbours reply from the same contact.
+        core.login_response_handler.set_foreign_request_probe(self.has_pending_request_tag)
         core.protocol_response_handler.set_binary_response_callback(self._on_binary_response)
         core.protocol_response_handler.set_packet_injector(self._packet_injector)
         core.protocol_response_handler.set_contact_path_updated_callback(

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -147,6 +147,13 @@ class CompanionRadio(CompanionBase):
         self._running = True
         self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
         self.node.dispatcher.rx_delay_base = self.prefs.rx_delay_base
+        # Seed the flood-scope mirrors from persisted prefs at boot (OH-022): the
+        # default, the transient override and the sticky unscoped flag. Without
+        # this, a companion booted with only a persisted default would send every
+        # dispatcher-scoped packet as plain flood until the first set_* call.
+        self.node.dispatcher.default_flood_transport_key = self._default_scope_key()
+        self.node.dispatcher.flood_transport_key = self._flood_transport_key
+        self.node.dispatcher.flood_unscoped = self._flood_unscoped
         # Sync the airtime budget factor before arming the bucket so the initial
         # duty cycle is correct when client-repeat starts enabled.
         self.node.dispatcher.airtime_budget_factor = self.prefs.airtime_factor
@@ -210,24 +217,50 @@ class CompanionRadio(CompanionBase):
     # -------------------------------------------------------------------------
 
     def set_flood_scope(self, transport_key: Optional[bytes] = None) -> None:
-        """Set or clear flood scope and propagate to the dispatcher."""
+        """Set or clear the transient flood scope and propagate to the dispatcher.
+
+        Clears the dispatcher's explicit-unscoped mirror too (base
+        ``set_flood_scope`` clears ``_flood_unscoped``), re-enabling the
+        override/default scope path.
+        """
         super().set_flood_scope(transport_key)
         self.node.dispatcher.flood_transport_key = self._flood_transport_key
+        self.node.dispatcher.flood_unscoped = False
 
     def set_flood_region(self, region_name: Optional[str] = None) -> None:
-        """Set flood region and propagate to the dispatcher."""
+        """Set flood region and propagate to the dispatcher (clears unscoped)."""
         super().set_flood_region(region_name)
         self.node.dispatcher.flood_transport_key = self._flood_transport_key
+        self.node.dispatcher.flood_unscoped = False
 
     def set_flood_unscoped(self) -> None:
-        """Force unscoped floods; clear the dispatcher's scope mirror too.
+        """Force unscoped floods and mirror the sticky flag to the dispatcher.
 
         Firmware's send_unscoped flag suppresses scoping on every flood send,
-        so the node-level mirror must not keep applying a stale override key.
-        The next set_flood_scope()/set_flood_region() re-syncs the mirror.
+        so the dispatcher must stop applying both the transient override and the
+        persisted default. The override mirror is cleared and the flag set; the
+        default mirror is deliberately NOT nulled (the flag suppresses it, and a
+        later set_flood_scope()/set_flood_region() clears the flag to re-enable
+        the default path).
         """
         super().set_flood_unscoped()
         self.node.dispatcher.flood_transport_key = None
+        self.node.dispatcher.flood_unscoped = True
+
+    def set_default_flood_scope(
+        self,
+        scope_name: Optional[str],
+        transport_key: Optional[bytes],
+    ) -> bool:
+        """Persist the default flood scope and mirror it to the dispatcher.
+
+        The mirror is the resolved key (``_default_scope_key`` maps an all-zero
+        or short key to None => plain flood), so sends that rely on the
+        dispatcher to scope at TX time carry the default too (OH-022).
+        """
+        result = super().set_default_flood_scope(scope_name, transport_key)
+        self.node.dispatcher.default_flood_transport_key = self._default_scope_key()
+        return result
 
     def set_path_hash_mode(self, mode: int) -> None:
         """Set path hash mode and sync to dispatcher default."""

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -147,7 +147,7 @@ class CompanionRadio(CompanionBase):
         self._running = True
         self.node.dispatcher.set_default_path_hash_mode(self.prefs.path_hash_mode)
         self.node.dispatcher.rx_delay_base = self.prefs.rx_delay_base
-        # Seed the flood-scope mirrors from persisted prefs at boot (OH-022): the
+        # Seed the flood-scope mirrors from persisted prefs at boot: the
         # default, the transient override and the sticky unscoped flag. Without
         # this, a companion booted with only a persisted default would send every
         # dispatcher-scoped packet as plain flood until the first set_* call.
@@ -256,7 +256,7 @@ class CompanionRadio(CompanionBase):
 
         The mirror is the resolved key (``_default_scope_key`` maps an all-zero
         or short key to None => plain flood), so sends that rely on the
-        dispatcher to scope at TX time carry the default too (OH-022).
+        dispatcher to scope at TX time carry the default too.
         """
         result = super().set_default_flood_scope(scope_name, transport_key)
         self.node.dispatcher.default_flood_transport_key = self._default_scope_key()

--- a/src/openhop_core/companion/companion_radio.py
+++ b/src/openhop_core/companion/companion_radio.py
@@ -404,6 +404,11 @@ class CompanionRadio(CompanionBase):
         dispatcher.set_ack_received_listener(self._on_ack_received)
         dispatcher.add_raw_packet_subscriber(self._on_raw_packet_rx_log)
         dispatcher.raw_data_received_callback = self._on_raw_custom_received
+        login_handler = getattr(dispatcher, "login_response_handler", None)
+        if login_handler is not None:
+            # See CompanionBridge: keep a pending login from swallowing an
+            # unrelated reply from the same contact.
+            login_handler.set_foreign_request_probe(self.has_pending_request_tag)
         if dispatcher.protocol_response_handler:
             dispatcher.protocol_response_handler.set_binary_response_callback(
                 self._on_binary_response

--- a/src/openhop_core/hardware/kiss_modem_wrapper.py
+++ b/src/openhop_core/hardware/kiss_modem_wrapper.py
@@ -539,6 +539,15 @@ class KissModemWrapper(LoRaRadio):
                 logger.warning("KISS modem did not become ready after reconnect")
                 return False
 
+            # Postcondition: this function's whole job is a live link, and the
+            # workers were started before readiness ran. An RX failure in that
+            # window used to leave a dead reader behind while the caller reported
+            # a successful (re)connect, so the node went permanently deaf with
+            # nothing left to re-arm a reconnect.
+            if self.rx_thread is None or not self.rx_thread.is_alive():
+                logger.warning("RX worker did not survive startup on %s", self.port)
+                return False
+
             return True
         except Exception as e:
             logger.error("Failed to connect to %s: %s", self.port, e)
@@ -586,13 +595,38 @@ class KissModemWrapper(LoRaRadio):
             except Exception:
                 pass
 
+    def _is_stopping(self) -> bool:
+        """True when the workers are meant to be winding down."""
+        return self._shutting_down or self.stop_event.is_set()
+
     def _stop_io_threads(self, join_timeout: float = 2.0) -> None:
-        """Join RX/TX threads, skipping current thread to avoid deadlock."""
+        """Stop RX/TX threads, skipping current thread to avoid deadlock.
+
+        Closes the port first: the workers' loop conditions key off it being
+        open, so that is what actually ends them. Joining alone — the previous
+        behaviour — meant a worker blocked in ``read()`` on a port whose close
+        had been deferred (see _mark_serial_failure) simply outlived the join
+        timeout and kept running against the old handle, while the next
+        generation started on the new one. Two RX threads then shared a single
+        KISS decoder buffer.
+        """
+        conn = self.serial_conn
+        if conn is not None:
+            try:
+                if getattr(conn, "is_open", False):
+                    conn.close()
+            except Exception as e:
+                logger.debug("Closing serial port while stopping workers: %s", e)
         current = threading.current_thread()
-        if self.rx_thread and self.rx_thread.is_alive() and self.rx_thread is not current:
-            self.rx_thread.join(timeout=join_timeout)
-        if self.tx_thread and self.tx_thread.is_alive() and self.tx_thread is not current:
-            self.tx_thread.join(timeout=join_timeout)
+        for label, thread in (("RX", self.rx_thread), ("TX", self.tx_thread)):
+            if thread and thread.is_alive() and thread is not current:
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
+                    logger.warning(
+                        "%s worker still running after %.1fs; it will be replaced",
+                        label,
+                        join_timeout,
+                    )
 
     def _stop_reconnect_thread(self, join_timeout: float = 2.0) -> None:
         """Join reconnect thread if it is running."""
@@ -2152,7 +2186,15 @@ class KissModemWrapper(LoRaRadio):
                 self._decode_kiss(chunk)
 
             except Exception as e:
-                if self.is_connected:
+                # Gate on deliberate shutdown, NOT on is_connected. The reconnect
+                # path starts these workers with is_connected still False and only
+                # sets it True after readiness plus the SetHardware handshake, so
+                # the old gate silenced exactly the window a freshly reopened
+                # device is most likely to fail in: the thread died with no log
+                # and no failure marked, nothing re-armed a reconnect, and the
+                # node went permanently deaf while the log read "reconnect
+                # successful". Observed in the field, and reproduced.
+                if not self._is_stopping():
                     logger.error(f"RX worker error: {e}")
                     self._mark_serial_failure(f"RX worker error: {e}")
                 break
@@ -2181,7 +2223,8 @@ class KissModemWrapper(LoRaRadio):
                     threading.Event().wait(0.01)
 
             except Exception as e:
-                if self.is_connected:
+                # See _rx_worker: gated on deliberate shutdown, not is_connected.
+                if not self._is_stopping():
                     logger.error(f"TX worker error: {e}")
                     self._mark_serial_failure(f"TX worker error: {e}")
                 break

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -131,7 +131,7 @@ class Dispatcher:
         # as ROUTE_TYPE_TRANSPORT_FLOOD.  Set via companion set_flood_scope().
         # This is the transient send-scope OVERRIDE mirror.
         self.flood_transport_key: Optional[bytes] = None
-        # Persisted default flood scope mirror (OH-022). Firmware
+        # Persisted default flood scope mirror. Firmware
         # sendFloodScoped(recipient) falls back to prefs.default_scope_key when
         # no transient override is set; the companion applies that at its layer,
         # but several sends build the packet and rely on the dispatcher to scope
@@ -144,7 +144,7 @@ class Dispatcher:
         # set_flood_scope()/set_flood_region().
         self.flood_unscoped: bool = False
 
-        # Optional region registry for reply-region capture (OH-026). Standalone
+        # Optional region registry for reply-region capture. Standalone
         # nodes/companions leave this None (no capture); the repeater populates
         # it so replies carry the incoming request's region.
         self.region_map: Optional[RegionMap] = None
@@ -533,7 +533,7 @@ class Dispatcher:
         pkt._rssi = rssi if rssi is not None else self.radio.get_last_rssi()
         pkt._snr = snr if snr is not None else self.radio.get_last_snr()
 
-        # Capture the region this packet arrived under (OH-026) before any handler
+        # Capture the region this packet arrived under before any handler
         # runs, so a reply builder can scope its reply to that region. No-op when
         # no RegionMap is configured (standalone node/companion).
         capture_recv_region(self.region_map, pkt)

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -110,6 +110,11 @@ class Dispatcher:
         self._handler_instances: dict[int, Any] = (
             {}
         )  # Store actual handler objects for method access
+        # Payload types whose handler consumes the payload for this node (as
+        # opposed to routing or observing it). Populated via
+        # register_handler(..., local_delivery=True); read by
+        # _is_transit_direct_delivery.
+        self._local_delivery_types: set[int] = set()
 
         # Handler references for companion-layer access; populated by
         # register_default_handlers(). Declared here so callers can rely on
@@ -248,10 +253,26 @@ class Dispatcher:
     # Public interface - registering handlers and callbacks
     # ------------------------------------------------------------------
 
-    def register_handler(self, payload_type: int, handler_instance) -> None:
-        """Register a handler for a specific type of packet."""
+    def register_handler(
+        self, payload_type: int, handler_instance, *, local_delivery: bool = False
+    ) -> None:
+        """Register a handler for a specific type of packet.
+
+        ``local_delivery`` marks a handler that *consumes* the payload for this
+        node (decrypt, ACK, display) as opposed to one that routes or observes
+        it. Only those are gated by the firmware rule in
+        :meth:`_is_transit_direct_delivery`: MeshCore never hands a routed-direct
+        packet with hops still on its path to payload processing. It defaults to
+        False so an application handler — a repeater's router, which must see
+        exactly those transit packets — keeps receiving everything, and so an
+        application override of a core payload type takes over that decision.
+        """
         # Keep the handler instance around so we can call methods on it
         self._handler_instances[payload_type] = handler_instance
+        if local_delivery:
+            self._local_delivery_types.add(payload_type)
+        else:
+            self._local_delivery_types.discard(payload_type)
 
         # Figure out what function to call when we get this packet type
         if hasattr(handler_instance, "handle_packet"):
@@ -292,11 +313,16 @@ class Dispatcher:
         self.local_identity = local_identity
 
         # --- ACK handler (dispatcher-specific wiring) ---
+        # Deliberately NOT local_delivery: firmware peeks at a routed-direct ACK
+        # while it is still in transit ("early received ACK", Mesh::onRecvPacket)
+        # before the next-hop check, and CRC correlation is idempotent.
         ack_handler = AckHandler(self._log, self)
         ack_handler.set_ack_received_callback(self._register_ack_received)
         self.register_handler(AckHandler.payload_type(), ack_handler)
 
         # --- Multi-ack handler: extract the embedded ACK from MULTIPART packets ---
+        # Also left un-gated: it only correlates an embedded ACK CRC, the same
+        # idempotent peek as the ACK handler above.
         multipart_ack_handler = MultipartAckHandler(self._log)
         multipart_ack_handler.set_ack_received_callback(self._register_ack_received)
         self.register_handler(MultipartAckHandler.payload_type(), multipart_ack_handler)
@@ -329,24 +355,32 @@ class Dispatcher:
         from .handlers import PathHandler as _Path
         from .handlers import TextMessageHandler as _Txt
 
-        self.register_handler(_Adv.payload_type(), core.advert_handler)
-        self.register_handler(_Txt.payload_type(), core.text_handler)
-        self.register_handler(_Grp.payload_type(), core.group_text_handler)
-        self.register_handler(_Path.payload_type(), core.path_handler)
-        self.register_handler(_Login.payload_type(), core.login_response_handler)
+        # These consume the payload for this node, so they are gated by the
+        # firmware transit rule (see _is_transit_direct_delivery).
+        self.register_handler(_Adv.payload_type(), core.advert_handler, local_delivery=True)
+        self.register_handler(_Txt.payload_type(), core.text_handler, local_delivery=True)
+        self.register_handler(_Grp.payload_type(), core.group_text_handler, local_delivery=True)
+        self.register_handler(_Path.payload_type(), core.path_handler, local_delivery=True)
+        self.register_handler(
+            _Login.payload_type(), core.login_response_handler, local_delivery=True
+        )
 
         # --- Dispatcher-only handlers ---
         self.register_handler(
             AnonReqResponseHandler.payload_type(),
             AnonReqResponseHandler(local_identity, contacts, self._log),
+            local_delivery=True,
         )
 
+        # TRACE is not gated: firmware handles a direct TRACE in its own branch
+        # ahead of the routed-direct block, and this handler owns the path bytes
+        # (they carry per-hop SNR, not routing hashes).
         trace_handler = TraceHandler(self._log, core.protocol_response_handler)
         self.register_handler(TraceHandler.payload_type(), trace_handler)
         self.trace_handler = trace_handler
 
         control_handler = ControlHandler(self._log)
-        self.register_handler(ControlHandler.payload_type(), control_handler)
+        self.register_handler(ControlHandler.payload_type(), control_handler, local_delivery=True)
         self.control_handler = control_handler
 
         # --- RAW_CUSTOM handler: deliver to companion if direct and callback set ---
@@ -358,7 +392,7 @@ class Dispatcher:
             if self.raw_data_received_callback:
                 await self._invoke_callback(self.raw_data_received_callback, pkt)
 
-        self.register_handler(PAYLOAD_TYPE_RAW_CUSTOM, raw_custom_handler)
+        self.register_handler(PAYLOAD_TYPE_RAW_CUSTOM, raw_custom_handler, local_delivery=True)
 
         self._logger.info("Default handlers registered.")
 
@@ -1183,19 +1217,50 @@ class Dispatcher:
             return
 
         try:
-            result = await handler(pkt)
-            # Mirror firmware Mesh::onRecvPacket markDoNotRetransmit: a data or
-            # anon packet genuinely decrypted for this identity is consumed and
-            # must not be re-flooded. HandlerResult.authenticated is that
-            # verdict (False on a bare dest-hash collision), so the client-repeat
-            # flood forward is suppressed only on real consumption. ACK marking
-            # is done inside AckHandler (it does not return a HandlerResult).
-            if isinstance(result, HandlerResult) and result.authenticated:
-                pkt.mark_do_not_retransmit()
+            if self._is_transit_direct_delivery(pkt, payload_type):
+                # Firmware releases this packet without payload processing; the
+                # forwarding decision is made independently (see
+                # _build_client_repeat_forward / an application router).
+                self._log(
+                    f"Transit {type_name}: routed-direct with "
+                    f"{pkt.get_path_hash_count()} hop(s) left, not delivered locally"
+                )
+            else:
+                result = await handler(pkt)
+                # Mirror firmware Mesh::onRecvPacket markDoNotRetransmit: a data or
+                # anon packet genuinely decrypted for this identity is consumed and
+                # must not be re-flooded. HandlerResult.authenticated is that
+                # verdict (False on a bare dest-hash collision), so the client-repeat
+                # flood forward is suppressed only on real consumption. ACK marking
+                # is done inside AckHandler (it does not return a HandlerResult).
+                if isinstance(result, HandlerResult) and result.authenticated:
+                    pkt.mark_do_not_retransmit()
             if self.packet_received_callback:
                 await self._invoke_callback(self.packet_received_callback, pkt)
         except Exception as err:
             self._log(f"Handler error for {type_name}: {err}")
+
+    def _is_transit_direct_delivery(self, pkt: Packet, payload_type: int) -> bool:
+        """True when a local-delivery handler must be skipped for a transit packet.
+
+        MeshCore ``Mesh::onRecvPacket`` never runs payload processing for a
+        routed-direct packet that still has hops on its path: it peeks at an
+        early ACK, forwards the packet if this node is the next hop (stripping
+        itself first, so delivery only ever happens at hop count 0), and
+        otherwise releases it. Payload delivery for a direct packet therefore
+        only happens once the path is exhausted.
+
+        openHop's ``_dispatch`` serves both local delivery and, for applications
+        like the repeater, routing — so the rule is applied only to handlers
+        registered with ``local_delivery=True``. Without it a node that hears
+        both a peer's pre-relay transmission and the relay's retransmission
+        delivers the same DM twice: the copies share a path-independent packet
+        hash, and dedup no longer suppresses the un-stripped one (it must not,
+        or an overheard route variant would suppress a copy this node owns).
+        """
+        if payload_type not in self._local_delivery_types:
+            return False
+        return pkt.is_route_direct() and pkt.get_path_hash_count() > 0
 
     # ------------------------------------------------------------------
     # ACK registration system

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -18,7 +18,8 @@ from ..protocol.constants import (  # Payload types
     ROUTE_TYPE_TRANSPORT_FLOOD,
 )
 from ..protocol.packet_utils import PathUtils, calculate_lora_airtime_ms, flood_rx_metrics
-from ..protocol.transport_keys import calc_transport_code
+from ..protocol.region_map import RegionMap, capture_recv_region
+from ..protocol.transport_keys import scope_packet
 from ..protocol.utils import PAYLOAD_TYPES, ROUTE_TYPES
 from ..util.callbacks import invoke_maybe_awaitable
 
@@ -128,7 +129,25 @@ class Dispatcher:
         # Flood scope: 16-byte transport key for region-scoped flooding.
         # When set, flood packets are tagged with a transport code and sent
         # as ROUTE_TYPE_TRANSPORT_FLOOD.  Set via companion set_flood_scope().
+        # This is the transient send-scope OVERRIDE mirror.
         self.flood_transport_key: Optional[bytes] = None
+        # Persisted default flood scope mirror (OH-022). Firmware
+        # sendFloodScoped(recipient) falls back to prefs.default_scope_key when
+        # no transient override is set; the companion applies that at its layer,
+        # but several sends build the packet and rely on the dispatcher to scope
+        # it at TX time. Mirror the default here so those sends carry it too.
+        # A null/short default resolves to None (=> plain flood).
+        self.default_flood_transport_key: Optional[bytes] = None
+        # Explicit-unscoped flag mirror (firmware send_unscoped, FW #2492). When
+        # True it suppresses BOTH the override and the default at TX time; it is
+        # not nulled by the default mirror, only cleared by a later
+        # set_flood_scope()/set_flood_region().
+        self.flood_unscoped: bool = False
+
+        # Optional region registry for reply-region capture (OH-026). Standalone
+        # nodes/companions leave this None (no capture); the repeater populates
+        # it so replies carry the incoming request's region.
+        self.region_map: Optional[RegionMap] = None
 
         # Default path hash mode for flood packets with 0 hops that have not
         # had path hash mode set by the companion. 0=1-byte, 1=2-byte, 2=3-byte.
@@ -514,6 +533,11 @@ class Dispatcher:
         pkt._rssi = rssi if rssi is not None else self.radio.get_last_rssi()
         pkt._snr = snr if snr is not None else self.radio.get_last_snr()
 
+        # Capture the region this packet arrived under (OH-026) before any handler
+        # runs, so a reply builder can scope its reply to that region. No-op when
+        # no RegionMap is configured (standalone node/companion).
+        capture_recv_region(self.region_map, pkt)
+
         # Let the node know about this packet for analysis (statistics, caching, etc.)
         if self.packet_analysis_callback:
             try:
@@ -585,28 +609,46 @@ class Dispatcher:
     # Public interface - sending and receiving packets
     # ------------------------------------------------------------------
 
-    def _apply_flood_scope(self, pkt: Packet) -> None:
-        """Apply flood scope transport codes to a packet in-place.
+    def _scope_packet(self, pkt: Packet, key: bytes) -> None:
+        """Attach transport codes for ``key`` and switch FLOOD -> TRANSPORT_FLOOD.
 
-        If ``flood_transport_key`` is set and the packet uses flood routing,
-        calculates the transport code, attaches it to the packet, and
-        switches the route type to ``ROUTE_TYPE_TRANSPORT_FLOOD``.
+        Delegates to the shared :func:`scope_packet` primitive so the dispatcher
+        and companion resolvers compute the wire format identically.
+        """
+        scope_packet(pkt, key)
+
+    def _apply_flood_scope(self, pkt: Packet) -> None:
+        """Apply flood scope transport codes to a packet in-place at TX time.
+
+        Mirrors firmware ``sendFloodScoped(recipient)`` precedence
+        (companion_radio/MyMesh.cpp): a packet the companion/reply layer already
+        decided is left untouched; explicit-unscoped wins first; otherwise the
+        transient override is used, else the persisted default. A null default
+        (None) leaves the packet a plain flood.
 
         Packets the companion layer already scoped (or deliberately left as
-        plain flood, e.g. explicit-unscoped mode or default-scoped adverts)
-        are marked ``_flood_scope_applied`` and skipped here.
+        plain flood, e.g. explicit-unscoped mode or default-scoped adverts) —
+        and replies whose region the reply helper already decided — are marked
+        ``_flood_scope_applied`` and skipped here.
         """
-        if self.flood_transport_key is None:
-            return
+        # Checked FIRST: a companion/reply decision is authoritative and must
+        # never be re-scoped, even when the node has an override/default set.
         if getattr(pkt, "_flood_scope_applied", False):
             return
-        route_type = pkt.get_route_type()
-        if route_type != ROUTE_TYPE_FLOOD:
+        if pkt.get_route_type() != ROUTE_TYPE_FLOOD:
             return
-        code = calc_transport_code(self.flood_transport_key, pkt)
-        pkt.transport_codes[0] = code
-        pkt.transport_codes[1] = 0  # reserved for home region
-        pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD
+        # Explicit-unscoped wins (firmware checks send_unscoped before scope).
+        if self.flood_unscoped:
+            return
+        # Transient override else persisted default (override else DEFAULT).
+        key = (
+            self.flood_transport_key
+            if self.flood_transport_key is not None
+            else self.default_flood_transport_key
+        )
+        if key is None:
+            return
+        self._scope_packet(pkt, key)
 
     def set_default_path_hash_mode(self, mode: Optional[int]) -> None:
         """Set or clear the default path hash mode for flood packets with 0 hops.

--- a/src/openhop_core/node/handlers/advert.py
+++ b/src/openhop_core/node/handlers/advert.py
@@ -2,7 +2,7 @@ import struct
 import time
 from typing import Any, Dict, Optional
 
-from ...protocol import Identity, Packet, decode_appdata, parse_advert_payload
+from ...protocol import Identity, Packet, decode_appdata, is_self_advert, parse_advert_payload
 from ...protocol.constants import (
     MAX_ADVERT_DATA_SIZE,
     PAYLOAD_TYPE_ADVERT,
@@ -21,9 +21,10 @@ class AdvertHandler(BaseHandler):
     def payload_type() -> int:
         return PAYLOAD_TYPE_ADVERT
 
-    def __init__(self, log_fn, event_service=None):
+    def __init__(self, log_fn, event_service=None, local_identity=None):
         self.log = log_fn
         self.event_service = event_service
+        self.local_identity = local_identity
 
     def _verify_advert_signature(
         self, pubkey: bytes, timestamp: bytes, appdata: bytes, signature: bytes
@@ -84,6 +85,20 @@ class AdvertHandler(BaseHandler):
                     f"truncating to {MAX_ADVERT_DATA_SIZE}"
                 )
                 appdata = appdata[:MAX_ADVERT_DATA_SIZE]
+
+            # Drop our own advert before anything reads it, matching the
+            # self_id.matches(id.pub_key) test at the top of Mesh::onRecvPacket's
+            # ADVERT branch (Mesh.cpp:263) — ahead of signature verification, which
+            # a self-signed advert would pass.  Firmware also gets in ahead of
+            # wasSeen(); openHop's equivalent dedupe has already run by here, in
+            # Dispatcher.handle_packet, which is a harmless divergence. A software node
+            # hears its own advert routinely: a neighbouring repeater re-floods it,
+            # or a host loops our own TX back.  Read-side only: the packet is left
+            # exactly as it arrived so the forwarding decision is unchanged.
+            self_key = self.local_identity.get_public_key() if self.local_identity else b""
+            if is_self_advert(payload, self_key):
+                self.log(f"Ignoring self advert (pubkey={pubkey_hex[:8]}...)")
+                return None
 
             # Verify cryptographic signature
             if not self._verify_advert_signature(

--- a/src/openhop_core/node/handlers/anon_request.py
+++ b/src/openhop_core/node/handlers/anon_request.py
@@ -313,6 +313,25 @@ class AnonRequestHandler(BaseHandler):
                     extra=reply_data,
                     path_len_encoded=(packet.path_len if packet.path_len > 0 else None),
                 )
+                # Accumulate this reply's path at the *request's* hash width.
+                # Firmware: sendFloodReply(path, SERVER_RESPONSE_DELAY,
+                # packet->getPathHashSize()) (simple_repeater onAnonDataRecv).
+                # The node's own path_hash_mode governs self-originated floods,
+                # not replies, so mark it applied to keep the dispatcher default
+                # from stamping over the mirror. Distinct from ``hash_size``
+                # above, which is the client's *reply-path* descriptor.
+                #
+                # This branch is currently unreachable: every discovery sub-type
+                # is gated route-direct in ``__call__`` (firmware gates all three
+                # the same way), and the login sub-type is delegated to
+                # LoginServerHandler, which mirrors the width itself. Kept correct
+                # so relaxing that gate cannot silently reintroduce the mismatch.
+                in_hash_size = (
+                    PathUtils.get_path_hash_size(packet.path_len)
+                    if PathUtils.is_valid_path_len(packet.path_len)
+                    else 1
+                )
+                response_pkt.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
             else:
                 # Direct reply routed along the path supplied in the request.
                 response_pkt = PacketBuilder.create_datagram(

--- a/src/openhop_core/node/handlers/anon_request.py
+++ b/src/openhop_core/node/handlers/anon_request.py
@@ -38,6 +38,7 @@ from ...protocol.constants import (
     PAYLOAD_TYPE_RESPONSE,
 )
 from ...protocol.packet_utils import PathUtils
+from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
 from .login_server import LoginServerHandler
 from .result import HandlerResult
@@ -325,6 +326,10 @@ class AnonRequestHandler(BaseHandler):
                 if reply_path_len > 0 and path_bytes:
                     encoded = PathUtils.encode_path_len(hash_size, reply_path_len)
                     response_pkt.set_path(path_bytes, encoded)
+
+            # Scope the flood path-return reply to the region the request arrived
+            # under (OH-026); a direct reply captures no region and stays plain.
+            apply_reply_scope(response_pkt, packet)
 
             self._send_packet_callback(response_pkt, SERVER_RESPONSE_DELAY_MS)
             route = "flood" if packet.is_route_flood() else "direct"

--- a/src/openhop_core/node/handlers/anon_request.py
+++ b/src/openhop_core/node/handlers/anon_request.py
@@ -328,7 +328,7 @@ class AnonRequestHandler(BaseHandler):
                     response_pkt.set_path(path_bytes, encoded)
 
             # Scope the flood path-return reply to the region the request arrived
-            # under (OH-026); a direct reply captures no region and stays plain.
+            # under; a direct reply captures no region and stays plain.
             apply_reply_scope(response_pkt, packet)
 
             self._send_packet_callback(response_pkt, SERVER_RESPONSE_DELAY_MS)

--- a/src/openhop_core/node/handlers/login_response.py
+++ b/src/openhop_core/node/handlers/login_response.py
@@ -52,6 +52,9 @@ class LoginResponseHandler(BaseHandler):
         self._active_login_passwords = {}  # dest_hash -> password
         # Protocol response handler for forwarding telemetry responses
         self._protocol_response_handler = None
+        # See set_foreign_request_probe: distinguishes a login reply from any
+        # other reply that happens to arrive while a login is pending.
+        self._foreign_request_probe: Optional[Callable[[int, bytes], bool]] = None
 
     def set_packet_injector(self, injector) -> None:
         """Wire the transmit path used for return-path teaching.
@@ -91,6 +94,30 @@ class LoginResponseHandler(BaseHandler):
         pk = contact.public_key
         return pk if isinstance(pk, bytes) else bytes.fromhex(pk)
 
+    def _is_foreign_request_reply(self, response_data: Optional[dict], contact) -> bool:
+        """True when this reply answers some *other* pending request, not a login.
+
+        Best-effort: with no probe wired, or no decodable tag, behaviour is
+        unchanged (the login branch decides), so a standalone handler keeps
+        working exactly as before.
+        """
+        if self._foreign_request_probe is None or not response_data:
+            return False
+        tag = response_data.get("timestamp")
+        if tag is None:
+            return False
+        try:
+            if not self._foreign_request_probe(int(tag) & 0xFFFFFFFF, self._pubkey_bytes(contact)):
+                return False
+        except Exception as e:
+            self.log(f"Foreign-request probe failed: {e}")
+            return False
+        self.log(
+            f"Response from '{getattr(contact, 'name', '?')}' reflects tag "
+            f"0x{int(tag) & 0xFFFFFFFF:08X} of a pending request, not a login; forwarding"
+        )
+        return True
+
     def _has_pending_login_for_hash(self, lookup_hash: int) -> bool:
         """True when any pending login (or stored password) targets this hash."""
         if lookup_hash in self._active_login_passwords:
@@ -122,6 +149,31 @@ class LoginResponseHandler(BaseHandler):
         """Clear stored password for destination hash."""
         if dest_hash in self._active_login_passwords:
             del self._active_login_passwords[dest_hash]
+
+    def set_foreign_request_probe(self, probe: Optional[Callable[[int, bytes], bool]]) -> None:
+        """Wire a check for "this reflected tag belongs to some other request".
+
+        ``probe(tag, contact_pubkey)`` returns True when the tag matches a pending
+        binary/protocol request rather than a login. Without it, a pending login
+        makes this handler claim *every* authenticated RESPONSE from that contact,
+        because a login reply and a status/telemetry/neighbours reply are
+        indistinguishable by contact alone.
+
+        Firmware has the same ambiguity but a one-response window — MyMesh
+        ``onContactResponse`` clears ``pending_login`` on the first response from
+        the contact, so at most one packet can be misread. openHop deliberately
+        keeps a login waiter alive far longer (``FRAME_LOGIN_PENDING_TTL_S``, so a
+        late flood login reply still completes), which without this probe turns
+        that one-packet window into a two-minute one: observed live, a 148-byte
+        neighbours reply was consumed here and reported as ``Login failed (code:
+        0x2F)`` — 0x2F being the low byte of its ``neighbours_count`` of 47.
+
+        The reflected request tag is the discriminator firmware itself points at
+        (``// FUTURE: tag == pending_status``): every protocol/binary request
+        reflects its timestamp in the response's first four bytes, and the sender
+        registered that tag when it sent the request.
+        """
+        self._foreign_request_probe = probe
 
     async def __call__(self, packet: Packet) -> HandlerResult:
         """Handle RESPONSE/ANON_REQ packets and report MAC ownership."""
@@ -187,6 +239,15 @@ class LoginResponseHandler(BaseHandler):
                 break
 
         if authenticated and matched_contact:
+            # A reply whose reflected tag belongs to a pending binary/protocol
+            # request is not a login reply, even though a login is pending for
+            # this contact. Checked before the login branch so the payload is
+            # never parsed with the login layout — doing so reads a foreign field
+            # as a response code and reports a bogus login failure, and the real
+            # request's data is lost. Forwarding also leaves the return-path teach
+            # to the protocol handler, which does it for its own responses.
+            if self._is_foreign_request_reply(response_data, matched_contact):
+                return await self._forward_to_protocol_handler(packet)
             if self._pubkey_bytes(matched_contact) not in self._pending_logins:
                 # Authenticated, but this contact has no login pending: not a
                 # login response. Mirrors firmware onContactResponse, where a

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -328,8 +328,8 @@ class LoginServerHandler(BaseHandler):
 
             # Scope the flood reply (PATH-return for a flood login, or the flood
             # RESPONSE datagram for a direct login) to the region the request
-            # arrived under (OH-026). Both branches build a flood reply; a
-            # direct request captures no region and stays plain.
+            # arrived under. Both branches build a flood reply; a direct request
+            # captures no region and stays plain.
             apply_reply_scope(response_pkt, original_packet)
 
             # Send with delay (matches C++ SERVER_RESPONSE_DELAY)

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional
 
 from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder
 from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE
+from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
 from .result import HandlerResult
 
@@ -324,6 +325,12 @@ class LoginServerHandler(BaseHandler):
                 f"path_len={response_pkt.path_len}, "
                 f"payload[0:2]={bytes(response_pkt.payload[:2]).hex()}"
             )
+
+            # Scope the flood reply (PATH-return for a flood login, or the flood
+            # RESPONSE datagram for a direct login) to the region the request
+            # arrived under (OH-026). Both branches build a flood reply; a
+            # direct request captures no region and stays plain.
+            apply_reply_scope(response_pkt, original_packet)
 
             # Send with delay (matches C++ SERVER_RESPONSE_DELAY)
             delay_ms = 300

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -15,7 +15,7 @@ import struct
 import time
 from typing import Callable, Optional
 
-from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder
+from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder, PathUtils
 from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE
 from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
@@ -316,6 +316,22 @@ class LoginServerHandler(BaseHandler):
                 )
                 packet_type_name = "RESPONSE(flood)"
                 self.log("[LoginServer] Creating RESPONSE datagram (direct login, flood reply)")
+
+            # Accumulate the reply's path at the *request's* hash width, not this
+            # node's own preference. Firmware sends both branches through
+            # sendFloodReply(..., packet->getPathHashSize()) (simple_repeater
+            # onAnonDataRecv); the node's path_hash_mode governs only packets it
+            # originates itself (sendFloodScoped(default_scope, ..., _prefs
+            # .path_hash_mode + 1)). Marked applied so the dispatcher's node
+            # default cannot stamp over the mirror, the same way apply_reply_scope
+            # protects the region decision below.
+            in_path_len = getattr(original_packet, "path_len", 0) if original_packet else 0
+            in_hash_size = (
+                PathUtils.get_path_hash_size(in_path_len)
+                if PathUtils.is_valid_path_len(in_path_len)
+                else 1
+            )
+            response_pkt.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
 
             # Debug: Log packet details
             self.log(

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -337,7 +337,13 @@ class ProtocolRequestHandler:
                     if PathUtils.is_valid_path_len(path_len_byte)
                     else 1
                 )
-                reply_packet.apply_path_hash_mode(hash_size - 1)
+                # mark_applied: without it the dispatcher's node-default
+                # path_hash_mode (_apply_default_path_hash_mode, called from
+                # send_packet) overwrites this mirror on the way out, and the
+                # reply accumulates at the node's own width instead of the
+                # request's — which is what firmware's sendFloodReply(...,
+                # packet->getPathHashSize()) exists to avoid.
+                reply_packet.apply_path_hash_mode(hash_size - 1, mark_applied=True)
                 # Scope the flood PATH-return to the region the REQ arrived
                 # under: TRANSPORT_FLOOD with the code re-hashed over this
                 # reply's payload, or plain when the request was unscoped/direct.
@@ -379,6 +385,20 @@ class ProtocolRequestHandler:
                 # no RegionMap this is inert and the reply falls through to the
                 # node default, matching BaseChatMesh's sendFloodScoped(from).
                 apply_reply_scope(reply_packet, original_packet)
+                # Same sendFloodReply call, same third argument: accumulate at
+                # the REQ's hash width, not this node's own preference. A DIRECT
+                # request that reached us has had its hops consumed, but
+                # removeSelfFromPath only decrements the count — path_len bits
+                # 6-7 still carry the width it was routed at. Only the flood
+                # branch: the direct branch's path_len comes from the client's
+                # out_path above and must not be stamped over.
+                in_path_len = getattr(original_packet, "path_len", 0) or 0
+                in_hash_size = (
+                    PathUtils.get_path_hash_size(in_path_len)
+                    if PathUtils.is_valid_path_len(in_path_len)
+                    else 1
+                )
+                reply_packet.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
 
             self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")
             return reply_packet

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -12,6 +12,7 @@ from openhop_core.protocol import PacketBuilder
 from openhop_core.protocol.constants import MAX_PATH_SIZE, PAYLOAD_TYPE_REQ, PAYLOAD_TYPE_RESPONSE
 from openhop_core.protocol.crypto import CryptoUtils
 from openhop_core.protocol.packet_utils import PathUtils
+from openhop_core.protocol.region_map import apply_reply_scope
 
 from .result import HandlerResult
 
@@ -337,6 +338,10 @@ class ProtocolRequestHandler:
                     else 1
                 )
                 reply_packet.apply_path_hash_mode(hash_size - 1)
+                # Scope the flood PATH-return to the region the REQ arrived under
+                # (OH-026): TRANSPORT_FLOOD with the code re-hashed over this
+                # reply's payload, or plain when the request was unscoped/direct.
+                apply_reply_scope(reply_packet, original_packet)
                 self.log(f"PATH (path-return) built for 0x{client_hash:02X} via FLOOD")
                 return reply_packet
 

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -369,6 +369,16 @@ class ProtocolRequestHandler:
             )
             if path_bytes is not None and path_len_encoded is not None:
                 reply_packet.set_path(path_bytes, path_len_encoded)
+            if route_type == "flood":
+                # No out_path, so this RESPONSE floods. Firmware sends it via
+                # sendFloodReply (simple_repeater onPeerDataRecv, the
+                # OUT_PATH_UNKNOWN branch), which for a DIRECT request means
+                # recv_pkt_region is NULL => plain, unscoped flood. Decide it
+                # here so the dispatcher's node default/override cannot stamp a
+                # region firmware would never put on this reply. On a node with
+                # no RegionMap this is inert and the reply falls through to the
+                # node default, matching BaseChatMesh's sendFloodScoped(from).
+                apply_reply_scope(reply_packet, original_packet)
 
             self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")
             return reply_packet

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -338,8 +338,8 @@ class ProtocolRequestHandler:
                     else 1
                 )
                 reply_packet.apply_path_hash_mode(hash_size - 1)
-                # Scope the flood PATH-return to the region the REQ arrived under
-                # (OH-026): TRANSPORT_FLOOD with the code re-hashed over this
+                # Scope the flood PATH-return to the region the REQ arrived
+                # under: TRANSPORT_FLOOD with the code re-hashed over this
                 # reply's payload, or plain when the request was unscoped/direct.
                 apply_reply_scope(reply_packet, original_packet)
                 self.log(f"PATH (path-return) built for 0x{client_hash:02X} via FLOOD")

--- a/src/openhop_core/node/handlers/protocol_request.py
+++ b/src/openhop_core/node/handlers/protocol_request.py
@@ -376,6 +376,20 @@ class ProtocolRequestHandler:
             if path_bytes is not None and path_len_encoded is not None:
                 reply_packet.set_path(path_bytes, path_len_encoded)
             if route_type == "flood":
+                # Same sendFloodReply call as the PATH-return above, same third
+                # argument: accumulate at the REQ's hash width, not this node's
+                # own preference. A DIRECT request that reached us has had its
+                # hops consumed, but removeSelfFromPath only decrements the
+                # count — path_len bits 6-7 still carry the width it was routed
+                # at. Only the flood branch: the direct branch's path_len comes
+                # from the client's out_path above and must not be stamped over.
+                in_path_len = getattr(original_packet, "path_len", 0) or 0
+                in_hash_size = (
+                    PathUtils.get_path_hash_size(in_path_len)
+                    if PathUtils.is_valid_path_len(in_path_len)
+                    else 1
+                )
+                reply_packet.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
                 # No out_path, so this RESPONSE floods. Firmware sends it via
                 # sendFloodReply (simple_repeater onPeerDataRecv, the
                 # OUT_PATH_UNKNOWN branch), which for a DIRECT request means
@@ -385,20 +399,6 @@ class ProtocolRequestHandler:
                 # no RegionMap this is inert and the reply falls through to the
                 # node default, matching BaseChatMesh's sendFloodScoped(from).
                 apply_reply_scope(reply_packet, original_packet)
-                # Same sendFloodReply call, same third argument: accumulate at
-                # the REQ's hash width, not this node's own preference. A DIRECT
-                # request that reached us has had its hops consumed, but
-                # removeSelfFromPath only decrements the count — path_len bits
-                # 6-7 still carry the width it was routed at. Only the flood
-                # branch: the direct branch's path_len comes from the client's
-                # out_path above and must not be stamped over.
-                in_path_len = getattr(original_packet, "path_len", 0) or 0
-                in_hash_size = (
-                    PathUtils.get_path_hash_size(in_path_len)
-                    if PathUtils.is_valid_path_len(in_path_len)
-                    else 1
-                )
-                reply_packet.apply_path_hash_mode(in_hash_size - 1, mark_applied=True)
 
             self.log(f"RESPONSE built for 0x{client_hash:02X} via {route_type.upper()}")
             return reply_packet

--- a/src/openhop_core/node/handlers/protocol_response.py
+++ b/src/openhop_core/node/handlers/protocol_response.py
@@ -464,6 +464,10 @@ class ProtocolResponseHandler:
             # The inbound flood path (pkt.path) tells the remote repeater
             # "to reach me, go through these intermediate hops".
             in_path = list(pkt.path) if pkt.path else []
+            # Key for the pre-dedup copy table, so the re-teach below can look up
+            # the best-received copy of *this* reply. Path-independent, so every
+            # copy hashes alike.
+            reciprocal_hash_key = bytes(pkt.calculate_packet_hash())
 
             # Build the reciprocal PATH packet.  create_path_return produces a
             # FLOOD PATH by default; we convert it to DIRECT below.
@@ -484,16 +488,14 @@ class ProtocolResponseHandler:
             reciprocal.header = (reciprocal.header & ~0x03) | ROUTE_TYPE_DIRECT
             reciprocal.set_path(out_path_bytes, path_len_byte)
 
-            evidence_resolved = False
-
             async def _dispatch_reciprocal() -> None:
-                nonlocal evidence_resolved
                 try:
                     sent = await injector(reciprocal)
                     if sent is False:
                         raise RuntimeError("packet injector rejected reciprocal PATH")
+                    # Claims the teacher's cooldown so it does not immediately
+                    # re-teach this contact the same route.
                     self.return_path_teacher.note_evidence_teach(contact_pubkey)
-                    evidence_resolved = True
                     self._log(
                         f"[ProtocolResponse] Sending reciprocal PATH to 0x{src_hash:02X} "
                         f"via DIRECT (out_path_len={path_len_byte}, "
@@ -505,33 +507,32 @@ class ProtocolResponseHandler:
                         f"embedded_in_path={bytes(in_path).hex() or '(empty)'} "
                         f"path_len_byte=0x{path_len_byte:02X}"
                     )
+                    # The teach above had to go out now, on the first-arrived
+                    # copy, so the peer has a usable route immediately. Copies of
+                    # this same reply keep landing for a second or two, and the
+                    # first is routinely the worst route; correct ourselves once
+                    # the window closes. Scheduled, not awaited, so this send task
+                    # ends with the wire write. Teaching twice is safe — see
+                    # ReturnPathTeacher.maybe_reteach_better_copy.
+                    self.return_path_teacher.schedule_reteach_better_copy(
+                        contact_pubkey=contact_pubkey,
+                        dest_hash=src_hash,
+                        taught_path=bytes(in_path),
+                        taught_len_byte=pkt.path_len,
+                        out_path=out_path_bytes,
+                        out_path_len=path_len_byte,
+                        shared_secret=shared_secret,
+                        hash_key=reciprocal_hash_key,
+                        reason="reciprocal PATH",
+                    )
                 except asyncio.CancelledError:
-                    if not evidence_resolved:
-                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
-                        evidence_resolved = True
                     raise
                 except Exception as e:
-                    if not evidence_resolved:
-                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
-                        evidence_resolved = True
                     self._log(f"[ProtocolResponse] Failed to send reciprocal PATH: {e}")
 
-            self.return_path_teacher.begin_evidence_teach(contact_pubkey)
-            try:
-                task = asyncio.create_task(_dispatch_reciprocal())
-                self._pending_reciprocals.add(task)
-
-                def _reciprocal_done(done: asyncio.Task) -> None:
-                    nonlocal evidence_resolved
-                    self._pending_reciprocals.discard(done)
-                    if done.cancelled() and not evidence_resolved:
-                        self.return_path_teacher.fail_evidence_teach(contact_pubkey)
-                        evidence_resolved = True
-
-                task.add_done_callback(_reciprocal_done)
-            except Exception:
-                self.return_path_teacher.fail_evidence_teach(contact_pubkey)
-                raise
+            task = asyncio.create_task(_dispatch_reciprocal())
+            self._pending_reciprocals.add(task)
+            task.add_done_callback(self._pending_reciprocals.discard)
         except Exception as e:
             self._log(f"[ProtocolResponse] Failed to queue reciprocal PATH: {e}")
 

--- a/src/openhop_core/node/handlers/registry.py
+++ b/src/openhop_core/node/handlers/registry.py
@@ -15,7 +15,7 @@ from .group_text import GroupTextHandler
 from .login_response import LoginResponseHandler
 from .path import PathHandler
 from .protocol_response import ProtocolResponseHandler
-from .return_path import ReturnPathTeacher
+from .return_path import RETURN_PATH_DEFAULT_SF, ReturnPathTeacher
 from .text import TextMessageHandler
 
 
@@ -66,10 +66,21 @@ def create_core_handlers(
         group_packet_seen_callback: Optional shared full-hash cache callback
             for companion group text/data loopback suppression.
     """
+
     # Shared by both response handlers so the per-contact re-teach cooldown is
     # accounted once, not once per handler. Its transmit path is wired later,
     # via ProtocolResponseHandler.set_packet_injector.
-    return_path_teacher = ReturnPathTeacher(log_fn, identity, contacts)
+    #
+    # The spreading factor is read through a callable, not captured: it sets the
+    # demodulator SNR limit every copy's margin is measured against, and a radio
+    # reconfigure at runtime must move that limit with it. Falls back to SF7 when
+    # the host supplies no radio config.
+    def _sf_from_radio_config() -> int:
+        return int((radio_config or {}).get("spreading_factor", RETURN_PATH_DEFAULT_SF))
+
+    return_path_teacher = ReturnPathTeacher(
+        log_fn, identity, contacts, sf_getter=_sf_from_radio_config
+    )
 
     protocol_response_handler = ProtocolResponseHandler(
         log_fn, identity, contacts, return_path_teacher=return_path_teacher

--- a/src/openhop_core/node/handlers/registry.py
+++ b/src/openhop_core/node/handlers/registry.py
@@ -108,7 +108,7 @@ def create_core_handlers(
         radio_config,
     )
 
-    advert_handler = AdvertHandler(log_fn, event_service=event_service)
+    advert_handler = AdvertHandler(log_fn, event_service=event_service, local_identity=identity)
 
     group_text_handler = GroupTextHandler(
         identity,

--- a/src/openhop_core/node/handlers/return_path.py
+++ b/src/openhop_core/node/handlers/return_path.py
@@ -48,22 +48,39 @@ Deliberate deviations from firmware, each documented at its definition:
   task rather than inline on the RX path: the injector may block on a TX lock and
   an airtime budget, and awaiting it inline would delay delivery of the very reply
   that triggered the teach, potentially past its own response timeout.
-* openHop picks the teach source by a hop-penalized last-hop RSSI across every
-  copy of the flood reply, collected pre-dedup via ``note_flood_copy``. Firmware
-  embeds whichever copy it processed first, and only its (SNR-scored,
-  ships-disabled) reception hold makes that the best one; neither firmware mode
-  weighs hop count, so a strong nearby repeater can append itself as an extra
-  hop. openHop does not lean on the hold; it applies a fixed dependency penalty
-  before considering any routed copy, then discounts each hop. See
-  ``RETURN_PATH_SETTLE_S``, ``RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB``, and
-  ``RETURN_PATH_HOP_PENALTY_DB``. There is deliberately no cross-reply downgrade
-  guard:
+* openHop chooses the teach source across every copy of the flood reply,
+  collected pre-dedup via ``note_flood_copy``, and ranks them by **decodability
+  rather than signal strength**: a copy's SNR margin over the demodulator limit
+  decides whether its link is reliable, and among reliable copies the shortest
+  route wins. Firmware embeds whichever copy it processed first, and only its
+  (SNR-scored, ships-disabled) reception hold makes that the best one; neither
+  firmware mode weighs hop count, so a strong nearby repeater can append itself
+  as an extra hop. See ``SF_DEMOD_SNR_LIMIT_DB``,
+  ``RETURN_PATH_RELIABLE_MARGIN_DB`` and ``_copy_rank`` for the model and the
+  measurements behind it. There is deliberately no cross-reply downgrade guard:
   firmware has none, and a flood reply from a peer we hold an ``out_path`` for is
   by this module's own premise a broken return route, so refusing to re-teach it
   because a newer copy is weaker than a previous (non-working) one would prolong
   the failure.
-* ``maybe_teach_reverse_of_out_path`` has no firmware counterpart at all. See its
-  docstring for the guard that keeps a guess from overwriting a known-good route.
+* The reciprocal teach that follows a flood login cannot wait for that window —
+  the peer needs a usable route immediately — so it goes out on the copy in hand
+  and then corrects itself once the window closes
+  (``maybe_reteach_better_copy``). Firmware never re-teaches, but it is safe
+  against firmware: ``onPeerPathRecv`` stores the path with an unconditional
+  ``copyPath``, touches no replay watermark, and returns ``false`` so no
+  reciprocal bounces back. The correction only transmits when the better copy
+  differs, so the common case costs nothing.
+
+Every teach this module sends embeds a path it actually observed. It deliberately
+does **not** guess one: an earlier revision, on a request timeout, taught the
+reverse of our own ``out_path`` on the assumption that routes are symmetric.
+Real routes frequently are not, and ``onPeerPathRecv`` overwrites
+``client->out_path`` unconditionally (``BaseChatMesh.cpp``), so a wrong guess
+replaced a working route with a dead one and the peer then answered DIRECT into a
+void — leaving no flood reply to correct it. The timeout case is handled where the
+evidence can actually be obtained instead: the request itself is re-sent as a
+flood on retry (``_SendOpsMixin._build_retry_packet``), and the peer answers a
+flood request with a PATH-return, which is a real inbound path to teach from.
 
 Not yet covered: firmware also re-teaches from ``onAckRecv``. A discrete ACK on
 the wire is a bare 4-byte CRC with no source hash, and openHop's dispatcher
@@ -80,9 +97,20 @@ from collections import OrderedDict
 from typing import Any, Callable, Optional, Set
 
 from ...protocol import Identity, Packet
-from ...protocol.constants import PAYLOAD_TYPE_RESPONSE, PH_ROUTE_MASK, ROUTE_TYPE_DIRECT
+from ...protocol.constants import (
+    PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_RESPONSE,
+    PH_ROUTE_MASK,
+    ROUTE_TYPE_DIRECT,
+)
 from ...protocol.packet_builder import PacketBuilder
 from ...protocol.packet_utils import PathUtils
+
+# Flood payload types whose arrival can trigger a return-path teach, and whose
+# copies are therefore worth collecting: RESPONSE (a server answering a direct
+# request by flood) and PATH (the path-return that answers a flood request or
+# flood login). Both carry ``dest_hash | src_hash | encrypted``.
+_TEACHABLE_COPY_TYPES = (PAYLOAD_TYPE_RESPONSE, PAYLOAD_TYPE_PATH)
 
 # Minimum gap between two return-path teaches aimed at the same contact.
 # Firmware has no equivalent throttle: it re-teaches on every qualifying flood
@@ -119,42 +147,68 @@ RETURN_PATH_COOLDOWN_S = 5.0
 # the enabling line is commented "enable once new algo fixed"), so on a stock
 # node firmware embeds the first-arrived copy -- and its 3 s delay only defers
 # the transmit, it does not re-pick the copy. openHop therefore selects the
-# teach source itself, by a hop-penalized last-hop RSSI (see
-# ``RETURN_PATH_HOP_PENALTY_DB`` and ``note_flood_copy``), during this window
+# teach source itself, by decodability margin and hop count (see
+# ``_copy_rank`` and ``note_flood_copy``), during this window
 # instead of leaning on the hold. Unchanged on the wire, strictly better than
 # firmware when the hold is off and no worse when it is on.
 RETURN_PATH_SETTLE_S = 3.0
 
-# Deliberate firmware divergence: fixed cost, in dB of last-hop RSSI, charged
-# once to every routed copy. Firmware embeds whichever flood copy it processes;
-# it does not give direct reception an explicit preference.
+# --- Copy selection: decodability, not raw signal strength -------------------
 #
-# This penalty represents the new forwarding dependency introduced by replacing
-# a proven zero-hop route with any routed route. It is intentionally finite:
-# HOWL Repeater's observed zero-hop -46 dBm copy should beat its one-hop B5B5
-# copy at -12 dBm, but a tenuous zero-hop copy around -120 dBm should still lose
-# to a materially stronger routed copy. Applying the same fixed cost to every
-# non-zero-hop candidate leaves comparisons among routed paths unchanged.
-RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB = 30.0
+# LoRa demodulates below the noise floor, so what decides whether a copy's link
+# works is its SNR margin over the demodulator limit for the spreading factor --
+# not its absolute RSSI. Measured on this mesh (SF7/62.5 kHz): four copies of one
+# reply arrived at -16, -21, -69 and -80 dBm and *every one* reported +11.25 to
+# +12.5 dB SNR, i.e. ~19 dB of margin. RSSI spanned 86 dB while decodability was
+# pinned at "certain" for all of them. Ranking those by RSSI ranks noise.
+#
+# The PER-vs-SNR curve is a waterfall: it goes from ~0 to ~1 across roughly 3-6 dB
+# around the limit. Above ~6 dB of margin, loss is dominated by collisions rather
+# than signal, so extra dB buy nothing and an extra hop can never be an RF
+# improvement. Below the limit the link is dead. dB are only currency inside that
+# narrow band, which is why selection is a threshold rule rather than the linear
+# dB-per-hop trade this replaced (that trade was calibrated around -56 dBm, some
+# 60 dB above where decodability actually changes).
+#
+# Semtech SX126x LoRa demodulator SNR limits, dB, by spreading factor.
+SF_DEMOD_SNR_LIMIT_DB = {
+    5: -2.5,
+    6: -5.0,
+    7: -7.5,
+    8: -10.0,
+    9: -12.5,
+    10: -15.0,
+    11: -17.5,
+    12: -20.0,
+}
+RETURN_PATH_DEFAULT_SF = 7
 
-# Additional cost, in dB of last-hop RSSI, charged per hop when choosing between
-# copies of a flood reply. Together with the fixed dependency penalty above,
-# copies are ranked by:
-#
-#   rssi - ROUTED_DEPENDENCY_PENALTY_DB - HOP_PENALTY_DB * hop_count
-#
-# (The fixed term is omitted for zero-hop copies.) A longer route therefore only
-# wins when it is materially stronger, not merely a couple dB.
-#
-# Neither firmware mode weighs hop count: the default embeds the first-arrived
-# copy (Mesh.cpp notes the path "may not be the best in terms of hops"), and the
-# optional SNR hold would embed the strongest copy regardless of length. Without
-# this penalty, a strong nearby repeater -- e.g. one on the same desk as the
-# node -- re-floods almost every reply and appends itself as a final hop, so
-# pure best-RSSI would route returns through it even when a shorter route is
-# adequate. ~10 dB/hop keeps that extra hop only when it genuinely buys signal:
-# a 3-hop copy at -13 still beats a 2-hop copy at -40, but loses to one at -15.
-RETURN_PATH_HOP_PENALTY_DB = 10.0
+# Fallback noise floor for turning an RSSI into a margin when SNR is unavailable.
+# Measured floor on this mesh ran -100 to -114 dBm (typical -107/-108), i.e. ~18 dB
+# above thermal for SF7/62.5 kHz -- these nodes are noise-limited, not
+# sensitivity-limited (datasheet sensitivity would be ~-126 dBm).
+RETURN_PATH_ASSUMED_NOISE_FLOOR_DBM = -108.0
+
+# Hard floor: below this margin a copy is not a route at all, so it is never
+# recorded as a teach candidate. Sits just above the demodulator limit, inside the
+# waterfall, where PER is already climbing steeply.
+RETURN_PATH_MIN_MARGIN_DB = 2.0
+
+# Margin at which a link is "reliable enough": past the waterfall, into the region
+# where loss is collision-driven and further dB are worthless. Copies at or above
+# this are ranked by HOP COUNT alone -- the whole point of the policy.
+RETURN_PATH_RELIABLE_MARGIN_DB = 6.0
+
+# Why hops are penalised at all, given the signal says they are free:
+#   1. We only ever measure the LAST hop. For a zero-hop copy that is the entire
+#      path; for an N-hop copy it is 1 of N links, and the others are known only
+#      to have worked once. Confidence is structurally lower.
+#   2. Each hop adds airtime plus MeshCore's randomised getDirectRetransmitDelay,
+#      and consumes shared channel capacity on a mesh where collisions dominate.
+#   3. The relay has to be *willing* to forward routed traffic (disable_fwd, ACL,
+#      region policy). No signal metric can see that -- observed here: the
+#      strongest-RSSI relay on the mesh forwarded none of it.
+# So a hop is only ever bought when the shorter alternative is genuinely marginal.
 
 # Bounds for the best-copy table (``note_flood_copy``): entries older than the
 # TTL are dropped and the table never holds more than ``_MAX`` hashes (oldest
@@ -164,44 +218,33 @@ RETURN_PATH_COPY_TTL_S = 8.0
 RETURN_PATH_COPY_CACHE_MAX = 128
 
 
-def reverse_path(path: bytes, path_len_byte: int) -> Optional[bytes]:
-    """Reverse a routing path hash-by-hash.
-
-    A path is ``hash_count`` entries of ``hash_size`` bytes each, ordered from
-    the sender outward. The route back is the same repeaters in the opposite
-    order, so the reversal has to work on whole hashes — reversing the raw bytes
-    would corrupt any path using 2- or 3-byte hashes.
-
-    Returns ``None`` when ``path_len_byte`` is malformed or does not describe
-    exactly ``path``.
-    """
-    if not PathUtils.is_valid_path_len(path_len_byte):
-        return None
-    hash_size = PathUtils.get_path_hash_size(path_len_byte)
-    hash_count = PathUtils.get_path_hash_count(path_len_byte)
-    if len(path) != hash_size * hash_count:
-        return None
-    hops = [path[i * hash_size : (i + 1) * hash_size] for i in range(hash_count)]
-    return b"".join(reversed(hops))
-
-
 class _FloodCopy:
     """The best-received copy of one flood reply, keyed by its packet hash.
 
-    ``rssi`` is the last-hop RSSI of the copy (higher is stronger); ``path`` /
-    ``len_byte`` are the flood accumulation path that copy arrived on — the route
-    the peer should be taught to use back to us. ``score`` is the hop-penalized
-    rank, including the fixed routed-dependency penalty documented above.
-    ``ts`` is the monotonic time the entry was last improved, for TTL pruning.
+    ``path`` / ``len_byte`` are the flood accumulation path that copy arrived on —
+    the route the peer should be taught to use back to us. ``rssi`` and ``margin``
+    are the last-hop measurements kept for logging and tie-breaks; ``rank`` is the
+    comparable tuple copies are ordered by (see
+    :meth:`ReturnPathTeacher._copy_rank`). ``ts`` is the monotonic time the entry
+    was last improved, for TTL pruning.
     """
 
-    __slots__ = ("path", "len_byte", "rssi", "score", "ts")
+    __slots__ = ("path", "len_byte", "rssi", "margin", "rank", "ts")
 
-    def __init__(self, path: bytes, len_byte: int, rssi: int, score: float, ts: float) -> None:
+    def __init__(
+        self,
+        path: bytes,
+        len_byte: int,
+        rssi: int,
+        margin: float,
+        rank: tuple,
+        ts: float,
+    ) -> None:
         self.path = path
         self.len_byte = len_byte
         self.rssi = rssi
-        self.score = score
+        self.margin = margin
+        self.rank = rank
         self.ts = ts
 
 
@@ -221,7 +264,10 @@ class ReturnPathTeacher:
         *,
         cooldown_s: float = RETURN_PATH_COOLDOWN_S,
         settle_s: float = RETURN_PATH_SETTLE_S,
-        hop_penalty_db: float = RETURN_PATH_HOP_PENALTY_DB,
+        sf_getter: Optional[Callable[[], int]] = None,
+        noise_floor_dbm: float = RETURN_PATH_ASSUMED_NOISE_FLOOR_DBM,
+        min_margin_db: float = RETURN_PATH_MIN_MARGIN_DB,
+        reliable_margin_db: float = RETURN_PATH_RELIABLE_MARGIN_DB,
         time_fn: Callable[[], float] = time.monotonic,
     ) -> None:
         self._log = log_fn
@@ -229,21 +275,18 @@ class ReturnPathTeacher:
         self._contact_book = contact_book
         self._cooldown_s = cooldown_s
         self._settle_s = settle_s
-        self._hop_penalty_db = hop_penalty_db
+        # Spreading factor decides the demodulator limit every margin is measured
+        # against. A callable so a runtime radio reconfigure is picked up; falls
+        # back to SF7 when the host does not supply one.
+        self._sf_getter = sf_getter
+        self._noise_floor_dbm = noise_floor_dbm
+        self._min_margin_db = min_margin_db
+        self._reliable_margin_db = reliable_margin_db
         self._time = time_fn
         self._injector: Optional[Callable] = None
         # contact pubkey -> monotonic timestamp of the last teach dispatched.
         # Bounded by the contact book: keys only come from resolved contacts.
         self._last_taught: dict[bytes, float] = {}
-        # Contacts we have taught from a real inbound path. Once a contact is in
-        # here, the reverse-of-out_path guess is permanently disabled for it —
-        # see maybe_teach_reverse_of_out_path.
-        self._taught_from_evidence: Set[bytes] = set()
-        # Reciprocal PATH sends are now queued so response delivery is never
-        # blocked by TX. Count queued evidence teaches per contact so a request
-        # timeout cannot launch a speculative reverse-path teach while a real
-        # observed-path teach is still in flight.
-        self._pending_evidence_teaches: dict[bytes, int] = {}
         # In-flight teach tasks, so callers (and tests) can await completion.
         self._pending_teaches: Set[asyncio.Task] = set()
         # packet hash -> best-received copy, populated pre-dedup by
@@ -262,34 +305,14 @@ class ReturnPathTeacher:
         self._injector = injector
 
     def note_evidence_teach(self, contact_pubkey: bytes) -> None:
-        """Record that a return path was taught to ``contact_pubkey`` from a real
-        inbound path by some *other* code path.
+        """Record that a return path was taught to ``contact_pubkey`` elsewhere.
 
         :meth:`ProtocolResponseHandler._send_reciprocal_path` also teaches a
-        return path (its flood-PATH reciprocal). It must report that here, or
-        this teacher would believe the contact has never been taught and would
-        let the reverse-of-out_path guess overwrite a route that is known good.
+        return path (its flood-PATH reciprocal). Reporting it here claims the
+        cooldown, so this teacher does not immediately re-teach the same contact
+        the same route.
         """
-        key = bytes(contact_pubkey)
-        self._finish_pending_evidence_teach(key)
-        self._taught_from_evidence.add(key)
-        self._last_taught[key] = self._time()
-
-    def begin_evidence_teach(self, contact_pubkey: bytes) -> None:
-        """Record one observed-path teach queued by another handler."""
-        key = bytes(contact_pubkey)
-        self._pending_evidence_teaches[key] = self._pending_evidence_teaches.get(key, 0) + 1
-
-    def fail_evidence_teach(self, contact_pubkey: bytes) -> None:
-        """Release one queued evidence teach that failed before transmission."""
-        self._finish_pending_evidence_teach(bytes(contact_pubkey))
-
-    def _finish_pending_evidence_teach(self, key: bytes) -> None:
-        count = self._pending_evidence_teaches.get(key, 0)
-        if count <= 1:
-            self._pending_evidence_teaches.pop(key, None)
-        else:
-            self._pending_evidence_teaches[key] = count - 1
+        self._last_taught[bytes(contact_pubkey)] = self._time()
 
     def note_flood_copy(self, pkt: Packet, data: Any = None, analysis: Any = None) -> None:
         """Record a flood reply copy for best-route selection (raw RX subscriber).
@@ -297,20 +320,29 @@ class ReturnPathTeacher:
         Wired via ``dispatcher.add_raw_packet_subscriber``, which fires for every
         received packet *before* dedup — the only place later copies of a flood
         reply are visible, since dedup drops them before any handler runs. Keeps,
-        per packet hash, the highest-scoring copy (hop-penalized last-hop RSSI,
-        see :meth:`_copy_score`) so a teach triggered on the first-arrived copy
+        per packet hash, the best-ranked copy (decodability margin then hop count,
+        see :meth:`_copy_rank`) so a teach triggered on the first-arrived copy
         can still embed the best route (see :meth:`maybe_teach_from_flood_reply`).
 
-        Best-effort and cheap: only flood ``RESPONSE`` packets addressed to us are
-        recorded (exactly what triggers a teach), and any error is swallowed —
-        this runs on the hot RX path and must never disturb packet processing.
+        Best-effort and cheap: only flood packets addressed to us whose type can
+        trigger a teach are recorded (``RESPONSE`` and ``PATH``), and any error is
+        swallowed — this runs on the hot RX path and must never disturb packet
+        processing.
+
+        ``PATH`` is included because a *flood login* is answered with a flood
+        PATH-return, and the reciprocal teach that follows it
+        (``ProtocolResponseHandler._send_reciprocal_path``) is the single most
+        consequential teach we send: it decides the route the peer will use for
+        every later direct reply. Both types share the
+        ``dest_hash | src_hash | encrypted`` payload prefix, and the packet hash
+        is path-independent, so copies of either key together.
         """
         if self._injector is None:
             return
         try:
             if not pkt.is_route_flood():
                 return
-            if pkt.get_payload_type() != PAYLOAD_TYPE_RESPONSE:
+            if pkt.get_payload_type() not in _TEACHABLE_COPY_TYPES:
                 return
             payload = getattr(pkt, "payload", None)
             if payload is None or len(payload) < 2:
@@ -323,7 +355,8 @@ class ReturnPathTeacher:
                 return
             packet_hash = bytes(pkt.calculate_packet_hash())
             rssi = int(getattr(pkt, "_rssi", 0) or 0)
-            self._record_copy(packet_hash, path, len_byte, rssi)
+            snr = float(getattr(pkt, "_snr", 0) or 0)
+            self._record_copy(packet_hash, path, len_byte, rssi, snr)
         except Exception as e:  # never let a bad copy disturb RX
             self._log(f"[ReturnPath] note_flood_copy ignored a packet: {e}")
 
@@ -391,7 +424,11 @@ class ReturnPathTeacher:
         # note_flood_copy improves it with better copies during the settle window.
         packet_hash = bytes(pkt.calculate_packet_hash())
         self._record_copy(
-            packet_hash, embedded_path, in_len_byte, int(getattr(pkt, "_rssi", 0) or 0)
+            packet_hash,
+            embedded_path,
+            in_len_byte,
+            int(getattr(pkt, "_rssi", 0) or 0),
+            float(getattr(pkt, "_snr", 0) or 0),
         )
 
         return await self._teach(
@@ -403,80 +440,112 @@ class ReturnPathTeacher:
             out_path_len=out_path_len,
             shared_secret=shared_secret,
             reason=reason,
-            from_evidence=True,
             hash_key=packet_hash,
             settle_s=self._settle_s,
         )
 
     # ------------------------------------------------------------------
-    # openHop hardening: re-teach when nothing comes back at all
+    # Refine a teach that was already sent from the first-arrived copy
     # ------------------------------------------------------------------
 
-    async def maybe_teach_reverse_of_out_path(
+    def schedule_reteach_better_copy(self, **kwargs: Any) -> None:
+        """Run :meth:`maybe_reteach_better_copy` as a tracked background task.
+
+        The corrective teach waits out the settle window, so it must not be
+        awaited by the caller: the reciprocal's own send task should complete as
+        soon as the wire write does, or ``wait_for_pending_reciprocals`` (and
+        shutdown behind it) would block for the whole window. The task is tracked
+        in ``_pending_teaches``, so :meth:`wait_for_pending` still covers it.
+        """
+        if self._injector is None:
+            return
+        task = asyncio.ensure_future(self.maybe_reteach_better_copy(**kwargs))
+        self._pending_teaches.add(task)
+        task.add_done_callback(self._pending_teaches.discard)
+
+    async def maybe_reteach_better_copy(
         self,
-        contact_pubkey: bytes,
         *,
+        contact_pubkey: bytes,
+        dest_hash: int,
+        taught_path: bytes,
+        taught_len_byte: int,
+        out_path: bytes,
+        out_path_len: int,
+        shared_secret: bytes,
+        hash_key: bytes,
         reason: str,
     ) -> bool:
-        """Teach the reverse of our own ``out_path`` as the peer's route back.
+        """Re-teach once if the settle window found a better route than ``taught_path``.
 
-        This has no firmware equivalent and covers the case firmware cannot:
-        when the peer answers DIRECT down a stale route, *nothing* arrives, so
-        there is no flood reply to trigger :meth:`maybe_teach_from_flood_reply`
-        and no inbound path to embed. The best available guess is that the route
-        is symmetric — the same repeaters traversed in reverse — which is
-        exactly what a user-forced path asserts.
+        A flood reply arrives as several copies over a couple of seconds, but the
+        teach it triggers must go out immediately — the peer needs *some* usable
+        route, and delaying the reciprocal would delay the login that carries it.
+        So the caller teaches from the first-arrived copy and then calls this to
+        correct itself once the better copies have landed.
 
-        It is only ever a guess, and the peer applies whatever it last received
-        (``MyMesh::onPeerPathRecv`` overwrites ``client->out_path``
-        unconditionally). So it is strictly a **last resort**: once we have
-        taught this contact from a real inbound path, the guess is disabled for
-        good. Without that guard a merely slow first attempt would replace a
-        correct, evidence-derived route with a symmetry assumption — and if the
-        assumption is wrong the peer then replies into a void, no flood reply
-        ever arrives again, and nothing can re-teach it. That is strictly worse
-        than the pre-existing behaviour, where an untaught peer falls back to
-        flood replies that do reach us.
+        Teaching twice is safe against firmware. ``simple_repeater``'s
+        ``onPeerPathRecv`` (and ``simple_room_server``'s) stores the path with an
+        unconditional ``copyPath`` — last write wins, no comparison — touches only
+        ``last_activity`` so the REQ replay watermark is unaffected, and returns
+        ``false`` with an explicit ``// NOTE: no reciprocal path send!!``, so there
+        is no ping-pong. ``Mesh.cpp`` gates its own reciprocal on
+        ``isRouteFlood()`` too, and this teach is DIRECT, so even a
+        ``BaseChatMesh`` peer will not bounce one back.
 
-        Only meaningful when we already hold an ``out_path``; a contact still on
-        flood needs no teach because flood replies reach us anyway.
+        The residual risk is wire-order inversion: ``copyPath`` has no sequence
+        number, so if the first (worse) teach somehow landed *after* this one the
+        peer would keep the worse route. The settle window's seconds of separation
+        make that far beyond normal relay jitter, and this only transmits when the
+        route actually differs, so the common case sends nothing at all.
 
-        Returns True when a teach was dispatched.
+        Returns True when a corrective teach was transmitted.
         """
         if self._injector is None:
             return False
+        if self._settle_s > 0.0:
+            await self._settle(self._settle_s)
+
+        best = self._recent_copies.pop(bytes(hash_key), None)
+        if best is None:
+            return False
+        if best.path == taught_path and best.len_byte == taught_len_byte:
+            return False  # first copy was already the best; nothing to correct
 
         key = bytes(contact_pubkey)
-        if key in self._taught_from_evidence or key in self._pending_evidence_teaches:
-            self._log(
-                f"[ReturnPath] Skip reverse teach to 0x{key[0]:02X} ({reason}): "
-                "already taught, or being taught, from an observed inbound path"
+        try:
+            teach = PacketBuilder.create_path_return(
+                dest_hash=dest_hash,
+                src_hash=self._local_identity.get_public_key()[0],
+                secret=shared_secret,
+                path=best.path,
+                extra_type=0xFF,  # no extra payload (firmware passes NULL/0)
+                extra=b"",
+                path_len_encoded=best.len_byte,
             )
+            teach.header = (teach.header & ~PH_ROUTE_MASK) | ROUTE_TYPE_DIRECT
+            teach.set_path(out_path, out_path_len)
+            await self._injector(teach)
+        except Exception as e:
+            self._log(f"[ReturnPath] Failed to re-teach 0x{dest_hash:02X}: {e}")
             return False
 
-        out_path, out_path_len = self._known_out_path(contact_pubkey)
-        if out_path is None:
-            return False
-
-        embedded = reverse_path(out_path, out_path_len)
-        if embedded is None:
-            self._log(
-                "[ReturnPath] Skip reverse teach: stored out_path "
-                f"({len(out_path)}B) does not match path_len 0x{out_path_len:02X}"
-            )
-            return False
-
-        return await self._teach(
-            contact_pubkey=contact_pubkey,
-            dest_hash=contact_pubkey[0],
-            embedded_path=embedded,
-            embedded_len_byte=out_path_len,
-            out_path=out_path,
-            out_path_len=out_path_len,
-            shared_secret=None,
-            reason=reason,
-            from_evidence=False,
+        # Deliberately does NOT consult the cooldown: this is a correction to a
+        # teach just sent (which claimed it), not a new one. It does refresh the
+        # claim so an unrelated trigger still gets throttled.
+        self._last_taught[key] = self._time()
+        try:
+            hops = PathUtils.get_path_hash_count(best.len_byte)
+        except Exception:
+            hops = "?"
+        self._log(
+            f"[ReturnPath] Re-taught 0x{dest_hash:02X} its route back ({reason}): "
+            f"better copy {best.path.hex() or '(zero-hop)'} "
+            f"(path_len=0x{best.len_byte:02X}, {hops} hop(s), last-hop margin "
+            f"{best.margin:.1f}dB, RSSI {best.rssi}) replaces "
+            f"{taught_path.hex() or '(zero-hop)'}"
         )
+        return True
 
     # ------------------------------------------------------------------
     # Internals
@@ -527,24 +596,70 @@ class ReturnPathTeacher:
             return None
 
     def _cooldown_active(self, key: bytes) -> bool:
+        """Whether ``key``'s cooldown blocks the teach about to be dispatched.
+
+        Every teach now embeds an observed path, so there is one kind of claim
+        and the window is a plain rate limit.
+        """
         last = self._last_taught.get(key)
         return last is not None and (self._time() - last) < self._cooldown_s
 
-    # ---- best-copy collection (hop-penalized RSSI selection) ---------------
+    # ---- best-copy collection (decodability-threshold selection) ------------
 
-    def _copy_score(self, rssi: int, len_byte: int) -> float:
-        """Rank a flood copy by last-hop RSSI and routing dependency.
+    def _demod_limit_db(self) -> float:
+        """SNR limit of the demodulator at the current spreading factor."""
+        sf = RETURN_PATH_DEFAULT_SF
+        if self._sf_getter is not None:
+            try:
+                sf = int(self._sf_getter())
+            except Exception:
+                sf = RETURN_PATH_DEFAULT_SF
+        return SF_DEMOD_SNR_LIMIT_DB.get(sf, SF_DEMOD_SNR_LIMIT_DB[RETURN_PATH_DEFAULT_SF])
 
-        A routed copy pays one fixed dependency penalty plus the per-hop
-        penalty. A zero-hop copy pays neither. Both costs are finite, so a
-        materially stronger routed copy can still beat a tenuous direct link.
+    def _copy_margin_db(self, rssi: int, snr: float) -> float:
+        """How many dB of margin this copy's last hop had over the demod limit.
+
+        Two independent estimates, and the **pessimistic** one is used:
+
+        * from SNR directly — ``snr - demod_limit`` — which self-normalises for
+          whatever the noise floor happens to be;
+        * from RSSI against an assumed noise floor, for radios or paths that
+          report no SNR.
+
+        Taking the minimum means a copy counts as reliable only when neither
+        estimate calls it marginal, and it removes any need to guess whether a
+        reported ``0`` means "0 dB" or "not measured": at a genuine 0 dB SNR the
+        RSSI sits at about the noise floor, so the two estimates agree anyway.
+        """
+        limit = self._demod_limit_db()
+        from_snr = float(snr) - limit
+        from_rssi = float(rssi) - (self._noise_floor_dbm + limit)
+        return min(from_snr, from_rssi)
+
+    def _copy_rank(self, margin: float, len_byte: int, rssi: int) -> tuple:
+        """Comparable rank for a copy; larger is better.
+
+        Lexicographic, because dB only matter inside the waterfall:
+
+        * A copy at or above ``reliable_margin_db`` outranks every copy below it,
+          however strong the weaker one's signal looks. Within that reliable tier
+          the order is **fewest hops**, then margin, then RSSI — extra dB above
+          the waterfall buy nothing, so hop count decides.
+        * Below the threshold the copy is in the steep region, where each dB does
+          change delivery odds: order by margin, then fewest hops, then RSSI.
+
+        The two tiers never compare their later elements against each other (the
+        leading tier flag decides first), so an extra hop is only ever bought when
+        every shorter copy is genuinely marginal and the longer one clears the
+        threshold.
         """
         try:
             hops = PathUtils.get_path_hash_count(len_byte)
         except Exception:
             hops = 0
-        dependency_penalty = RETURN_PATH_ROUTED_DEPENDENCY_PENALTY_DB if hops else 0.0
-        return rssi - dependency_penalty - self._hop_penalty_db * hops
+        if margin >= self._reliable_margin_db:
+            return (1, -hops, margin, rssi)
+        return (0, margin, -hops, rssi)
 
     def _addressed_to_us(self, dest_hash: int) -> bool:
         """True when ``dest_hash`` is our own hash (or our hash is unknown).
@@ -574,23 +689,34 @@ class ReturnPathTeacher:
             return None
         return raw[:byte_len]
 
-    def _record_copy(self, packet_hash: bytes, path: bytes, len_byte: int, rssi: int) -> None:
-        """Keep the highest-scoring copy of a flood reply, keyed by packet hash.
+    def _record_copy(
+        self,
+        packet_hash: bytes,
+        path: bytes,
+        len_byte: int,
+        rssi: int,
+        snr: float = 0.0,
+    ) -> None:
+        """Keep the best-ranked copy of a flood reply, keyed by packet hash.
 
-        Copies are ranked by :meth:`_copy_score`, including the finite
-        routed-dependency and per-hop penalties. A routed copy can displace a
-        direct or shorter copy only when its last-hop RSSI advantage is large
-        enough to pay those costs.
+        Copies are ordered by :meth:`_copy_rank`. A copy whose margin is below
+        ``min_margin_db`` is discarded outright rather than recorded: below the
+        waterfall it is not a route, and teaching it would hand the peer a link
+        that cannot carry its replies. Discarding leaves whatever the caller
+        seeded (the first-arrived copy) as the fallback, so a teach is never lost.
         """
+        margin = self._copy_margin_db(rssi, snr)
+        if margin < self._min_margin_db:
+            return
         now = self._time()
         self._prune_copies(now)
-        score = self._copy_score(rssi, len_byte)
+        rank = self._copy_rank(margin, len_byte, rssi)
         existing = self._recent_copies.get(packet_hash)
-        if existing is not None and score <= existing.score:
+        if existing is not None and rank <= existing.rank:
             existing.ts = now  # refresh so the winning copy outlives the window
             self._recent_copies.move_to_end(packet_hash)
             return
-        self._recent_copies[packet_hash] = _FloodCopy(path, len_byte, rssi, score, now)
+        self._recent_copies[packet_hash] = _FloodCopy(path, len_byte, rssi, margin, rank, now)
         self._recent_copies.move_to_end(packet_hash)
         if len(self._recent_copies) > self._copy_cache_max:
             self._recent_copies.popitem(last=False)  # evict least-recently-touched
@@ -621,7 +747,6 @@ class ReturnPathTeacher:
         out_path_len: int,
         shared_secret: Optional[bytes],
         reason: str,
-        from_evidence: bool,
         hash_key: Optional[bytes] = None,
         settle_s: float = 0.0,
     ) -> bool:
@@ -670,7 +795,6 @@ class ReturnPathTeacher:
                 out_path=out_path,
                 out_path_len=out_path_len,
                 reason=reason,
-                from_evidence=from_evidence,
                 hash_key=hash_key,
                 settle_s=settle_s,
             )
@@ -691,7 +815,6 @@ class ReturnPathTeacher:
         out_path: bytes,
         out_path_len: int,
         reason: str,
-        from_evidence: bool,
         hash_key: Optional[bytes],
         settle_s: float,
     ) -> None:
@@ -736,12 +859,6 @@ class ReturnPathTeacher:
                 self._last_taught[key] = previous_cooldown
             self._log(f"[ReturnPath] Failed to send teach to 0x{dest_hash:02X}: {e}")
             return
-
-        # Only a confirmed send counts as evidence: marking it optimistically
-        # would permanently disable the reverse-path fallback on a teach that
-        # never left the node.
-        if from_evidence:
-            self._taught_from_evidence.add(key)
 
         if chosen_rssi is not None:
             try:

--- a/src/openhop_core/node/handlers/text.py
+++ b/src/openhop_core/node/handlers/text.py
@@ -133,12 +133,21 @@ class TextMessageHandler(BaseHandler):
         """
 
         if is_flood:
-            incoming_path = list(packet.path if hasattr(packet, "path") else [])
-            path_len_encoded = (
-                getattr(packet, "path_len", None)
-                if PathUtils.is_valid_path_len(getattr(packet, "path_len", -1))
-                else None
-            )
+            # One decision for both halves: the path bytes and the path_len byte
+            # declaring their hash width have to agree, or create_path_return
+            # rejects the pair. Deriving them from separate guards let an invalid
+            # path_len yield a non-empty path with no declared width. That cannot
+            # reach here from the wire (Packet.from_bytes rejects an invalid
+            # path_len), but the correct handling is to teach no path rather than
+            # one whose hash width we would be guessing.
+            in_path_len = getattr(packet, "path_len", 0) or 0
+            if PathUtils.is_valid_path_len(in_path_len):
+                path_len_encoded = in_path_len
+                raw_path = bytes(getattr(packet, "path", b"") or b"")
+                incoming_path = list(raw_path[: PathUtils.get_path_byte_len(in_path_len)])
+            else:
+                path_len_encoded = None
+                incoming_path = []
             ack_packet = PacketBuilder.create_path_return(
                 dest_hash=PacketBuilder._hash_byte(pubkey),
                 src_hash=PacketBuilder._hash_byte(self.local_identity.get_public_key()),

--- a/src/openhop_core/node/handlers/text.py
+++ b/src/openhop_core/node/handlers/text.py
@@ -8,6 +8,7 @@ from ...protocol.constants import (
     TXT_TYPE_PLAIN,
     TXT_TYPE_SIGNED_PLAIN,
 )
+from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
 from .result import HandlerResult
 
@@ -148,7 +149,10 @@ class TextMessageHandler(BaseHandler):
                 path_len_encoded=path_len_encoded,
             )
             # Firmware sends the flood PATH-return (carrying the ACK) via
-            # sendFloodScoped(from, path, TXT_ACK_DELAY).
+            # sendFloodScoped(from, path, TXT_ACK_DELAY): scope the reply to the
+            # region the request arrived under (OH-026), decided synchronously
+            # here from the request packet before the delayed send task runs.
+            apply_reply_scope(ack_packet, packet)
             self.log(f"FLOOD ACK timing - delay:{TXT_ACK_DELAY_MS}ms")
             return [(ack_packet, TXT_ACK_DELAY_MS / 1000.0)]
 
@@ -168,6 +172,8 @@ class TextMessageHandler(BaseHandler):
             # dispatcher applies flood scope at send time.
             ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash, route_type="flood")
             # Firmware sendAckTo with OUT_PATH_UNKNOWN floods the ACK at TXT_ACK_DELAY.
+            # Scope the discrete flood ACK to the request's region (OH-026).
+            apply_reply_scope(ack_packet, packet)
             self.log(f"FLOOD ACK timing (no out_path) - delay:{TXT_ACK_DELAY_MS}ms")
             return [(ack_packet, TXT_ACK_DELAY_MS / 1000.0)]
 

--- a/src/openhop_core/node/handlers/text.py
+++ b/src/openhop_core/node/handlers/text.py
@@ -150,8 +150,8 @@ class TextMessageHandler(BaseHandler):
             )
             # Firmware sends the flood PATH-return (carrying the ACK) via
             # sendFloodScoped(from, path, TXT_ACK_DELAY): scope the reply to the
-            # region the request arrived under (OH-026), decided synchronously
-            # here from the request packet before the delayed send task runs.
+            # region the request arrived under, decided synchronously here from
+            # the request packet before the delayed send task runs.
             apply_reply_scope(ack_packet, packet)
             self.log(f"FLOOD ACK timing - delay:{TXT_ACK_DELAY_MS}ms")
             return [(ack_packet, TXT_ACK_DELAY_MS / 1000.0)]
@@ -172,7 +172,7 @@ class TextMessageHandler(BaseHandler):
             # dispatcher applies flood scope at send time.
             ack_packet = PacketBuilder.create_ack_from_bytes(ack_hash, route_type="flood")
             # Firmware sendAckTo with OUT_PATH_UNKNOWN floods the ACK at TXT_ACK_DELAY.
-            # Scope the discrete flood ACK to the request's region (OH-026).
+            # Scope the discrete flood ACK to the request's region.
             apply_reply_scope(ack_packet, packet)
             self.log(f"FLOOD ACK timing (no out_path) - delay:{TXT_ACK_DELAY_MS}ms")
             return [(ack_packet, TXT_ACK_DELAY_MS / 1000.0)]

--- a/src/openhop_core/protocol/__init__.py
+++ b/src/openhop_core/protocol/__init__.py
@@ -75,8 +75,15 @@ from .packet_utils import (
     PathUtils,
     RouteTypeUtils,
 )
-from .region_map import REGION_DENY_DIRECT, REGION_DENY_FLOOD, RegionEntry, RegionMap
-from .transport_keys import calc_transport_code, get_auto_key_for
+from .region_map import (
+    REGION_DENY_DIRECT,
+    REGION_DENY_FLOOD,
+    RegionEntry,
+    RegionMap,
+    apply_reply_scope,
+    capture_recv_region,
+)
+from .transport_keys import calc_transport_code, get_auto_key_for, scope_packet
 from .utils import decode_appdata, parse_advert_payload
 
 __all__ = [
@@ -93,12 +100,15 @@ __all__ = [
     "RegionEntry",
     "REGION_DENY_FLOOD",
     "REGION_DENY_DIRECT",
+    "capture_recv_region",
+    "apply_reply_scope",
     # Utility functions
     "parse_advert_payload",
     "decode_appdata",
     "describe_advert_flags",
     "get_auto_key_for",
     "calc_transport_code",
+    "scope_packet",
     # Utility classes
     "PacketValidationUtils",
     "PacketDataUtils",

--- a/src/openhop_core/protocol/__init__.py
+++ b/src/openhop_core/protocol/__init__.py
@@ -84,7 +84,7 @@ from .region_map import (
     capture_recv_region,
 )
 from .transport_keys import calc_transport_code, get_auto_key_for, scope_packet
-from .utils import decode_appdata, parse_advert_payload
+from .utils import decode_appdata, is_self_advert, parse_advert_payload
 
 __all__ = [
     # Core classes
@@ -106,6 +106,7 @@ __all__ = [
     "parse_advert_payload",
     "decode_appdata",
     "describe_advert_flags",
+    "is_self_advert",
     "get_auto_key_for",
     "calc_transport_code",
     "scope_packet",

--- a/src/openhop_core/protocol/identity.py
+++ b/src/openhop_core/protocol/identity.py
@@ -118,7 +118,20 @@ class LocalIdentity(Identity):
         else:
             # Standard 32-byte seed or None
             self._firmware_key = None
-            self.signing_key = SigningKey(seed) if seed else SigningKey.generate()
+            if seed:
+                self.signing_key = SigningKey(seed)
+            else:
+                # Firmware reserves 0x00 and 0xFF as public-key prefixes and
+                # refuses to import a keypair with either (Identity.cpp
+                # validatePrivateKey: "disallow 00 or FF prefixed public keys"),
+                # because the first byte doubles as the 1-byte routing hash and
+                # those two values are sentinels. Re-roll rather than mint an
+                # identity that cannot interoperate.
+                while True:
+                    candidate = SigningKey.generate()
+                    if candidate.verify_key.encode()[0] not in (0x00, 0xFF):
+                        break
+                self.signing_key = candidate
             self.verify_key = self.signing_key.verify_key
 
             # Build 64-byte Ed25519 secret key: seed + pub

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -244,14 +244,35 @@ class Packet:
     ) -> None:
         """Set path_len bits 6-7 from path_hash_mode for 0-hop packets (skip TRACE).
 
-        Used by companion and dispatcher so the rule lives in one place. TRACE
-        packets are excluded because the repeater's trace handler uses path/path_len
-        for SNR values, not routing hashes.
+        Used by companion, handlers and dispatcher so the rule lives in one place.
+        TRACE packets are excluded because the repeater's trace handler uses
+        path/path_len for SNR values, not routing hashes.
 
         Args:
             mode: Path hash mode: 0=1-byte, 1=2-byte, 2=3-byte per hop.
-            mark_applied: If True, set _path_hash_mode_applied so dispatcher
-                does not overwrite (used when companion applies its preference).
+            mark_applied: If True, set ``_path_hash_mode_applied``, which stops
+                ``Dispatcher._apply_default_path_hash_mode`` overwriting this
+                width with the node default on the way out. Three callers claim
+                it, for the same reason -- the width was decided by something
+                that outranks the node preference:
+
+                * the companion applying its own configured preference
+                  (``base_config._apply_path_hash_mode``);
+                * a server handler mirroring the width of the request it is
+                  answering, which is what firmware's ``sendFloodReply(...,
+                  packet->getPathHashSize())`` does -- the node preference
+                  governs only self-originated floods;
+                * the dispatcher itself on a packet being forwarded, whose width
+                  belongs to the originator.
+
+                Leave it False to let the node default decide (the dispatcher's
+                own call site, which is that default).
+
+        Note:
+            ``_path_hash_mode_applied`` is an in-memory attribute, not part of
+            the wire format, so it does not survive a serialize/parse round trip.
+            Anything between a handler and the radio must pass the Packet object
+            itself, or the marked width is silently replaced by the node default.
 
         Raises:
             ValueError: If mode not in (0, 1, 2).

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -146,7 +146,7 @@ class Packet:
         # (scoped or deliberately plain); the dispatcher must not re-scope it.
         self._flood_scope_applied = False
         self._injected_for_tx = False  # Set by repeater inject path; skip engine on route
-        # Region captured from this packet on receive (OH-026). Only set True when
+        # Region captured from this packet on receive. Only set True when
         # a RegionMap was actually consulted; the matched region key (or None =>
         # reply plain) is read by region_map.apply_reply_scope when a handler
         # builds a flood reply. Lives on the Packet, never a shared dispatcher

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -117,6 +117,7 @@ class Packet:
         "_path_hash_mode_applied",
         "_flood_scope_applied",
         "_injected_for_tx",
+        "_injected_origin_hash",
         "_recv_region_captured",
         "_recv_region_key",
     )
@@ -146,6 +147,11 @@ class Packet:
         # (scoped or deliberately plain); the dispatcher must not re-scope it.
         self._flood_scope_applied = False
         self._injected_for_tx = False  # Set by repeater inject path; skip engine on route
+        # Companion that originated this injected TX, as the "0xHH" hash string the
+        # host keys its frame servers by (None for host-originated injects). Set by
+        # the repeater inject path so the companion fan-out can withhold the packet
+        # from its own sender -- a node never hears its own transmission.
+        self._injected_origin_hash: Optional[str] = None
         # Region captured from this packet on receive. Only set True when
         # a RegionMap was actually consulted; the matched region key (or None =>
         # reply plain) is read by region_map.apply_reply_scope when a handler

--- a/src/openhop_core/protocol/packet.py
+++ b/src/openhop_core/protocol/packet.py
@@ -117,6 +117,8 @@ class Packet:
         "_path_hash_mode_applied",
         "_flood_scope_applied",
         "_injected_for_tx",
+        "_recv_region_captured",
+        "_recv_region_key",
     )
 
     def __init__(self):
@@ -144,6 +146,13 @@ class Packet:
         # (scoped or deliberately plain); the dispatcher must not re-scope it.
         self._flood_scope_applied = False
         self._injected_for_tx = False  # Set by repeater inject path; skip engine on route
+        # Region captured from this packet on receive (OH-026). Only set True when
+        # a RegionMap was actually consulted; the matched region key (or None =>
+        # reply plain) is read by region_map.apply_reply_scope when a handler
+        # builds a flood reply. Lives on the Packet, never a shared dispatcher
+        # member, because replies are sent from background tasks that would race.
+        self._recv_region_captured: bool = False
+        self._recv_region_key: Optional[bytes] = None
 
     def get_route_type(self) -> int:
         """

--- a/src/openhop_core/protocol/packet_builder.py
+++ b/src/openhop_core/protocol/packet_builder.py
@@ -894,10 +894,20 @@ class PacketBuilder:
         two-way communication, with optional additional data.
 
         The inner payload first byte is the encoded path_len (bits 6-7 = hash
-        size - 1, bits 0-5 = hop count). When path_len_encoded is provided
-        and valid, it is used so 2- and 3-byte path hashes match firmware.
-        When path_len_encoded is None, the first byte is len(path) (1-byte
-        hash semantics).
+        size - 1, bits 0-5 = hop count), so ``path_len_encoded`` is required
+        for a non-empty path: ``path`` is a flat byte sequence and its length
+        alone cannot distinguish N 1-byte hashes from one N-byte hash.
+
+        Guessing 1-byte semantics here is unrecoverable in the field.  Firmware
+        stores a taught path verbatim (``simple_repeater`` ``onPeerPathRecv``:
+        ``client->out_path_len = copyPath(...)``), persists it to flash, and
+        never re-derives it — ``onPeerPathRecv`` is its only writer.  A path
+        taught with the wrong hash size therefore makes the peer answer down a
+        route that resolves to nobody, for every subsequent DIRECT exchange,
+        until something re-teaches it or a *flood* login resets it
+        (``handleLoginReq``: ``if (is_flood) client->out_path_len =
+        OUT_PATH_UNKNOWN;``).  Failing loudly at build time is the only place
+        the mistake is still cheap.
 
         Args:
             dest_hash: Destination node hash (1 byte).
@@ -906,20 +916,36 @@ class PacketBuilder:
             path: Sequence of node hashes for the return path.
             extra_type: Type identifier for extra data (default: 0xFF).
             extra: Additional binary data to include.
-            path_len_encoded: Encoded path_len byte from the original packet.
-                If None, first byte of inner payload is len(path) (1-byte hashes).
+            path_len_encoded: Encoded path_len byte, normally the ``path_len``
+                of the packet the path was observed on.  Required whenever
+                ``path`` is non-empty; for a 1-byte-hash path pass
+                ``PathUtils.encode_path_len(1, hop_count)``.  May be None only
+                for an empty path.
 
         Returns:
             Packet: Encrypted return path packet.
 
         Raises:
             ValueError: If combined path and extra data exceed packet limits,
-                or if path_len_encoded is provided but path length does not match.
+                if path_len_encoded is omitted for a non-empty path, if it is
+                not a valid encoded path_len, or if it disagrees with the
+                actual path length.
         """
         if len(path) + len(extra) + 5 > (MAX_PACKET_PAYLOAD - 2 - CIPHER_BLOCK_SIZE):
             raise ValueError("Combined path/extra too long")
 
-        if path_len_encoded is not None and PathUtils.is_valid_path_len(path_len_encoded):
+        if path_len_encoded is None:
+            if len(path) > 0:
+                raise ValueError(
+                    f"path_len_encoded is required for a non-empty path "
+                    f"({len(path)} bytes): the byte count cannot distinguish "
+                    f"N 1-byte hashes from one N-byte hash. Pass the observed "
+                    f"packet's path_len, or PathUtils.encode_path_len(hash_size, hops)."
+                )
+            first_byte = 0
+        else:
+            if not PathUtils.is_valid_path_len(path_len_encoded):
+                raise ValueError(f"invalid path_len_encoded 0x{path_len_encoded:02X}")
             expected_len = PathUtils.get_path_byte_len(path_len_encoded)
             if len(path) != expected_len:
                 raise ValueError(
@@ -927,8 +953,6 @@ class PacketBuilder:
                     f"(expected {expected_len} bytes)"
                 )
             first_byte = path_len_encoded
-        else:
-            first_byte = len(path)
 
         if extra:
             inner = bytes([first_byte]) + bytes(path) + bytes([extra_type]) + extra

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Sequence
 
+from .constants import ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD
 from .packet import Packet
-from .transport_keys import calc_transport_code, get_auto_key_for
+from .transport_keys import calc_transport_code, get_auto_key_for, scope_packet
 
 # Region flags mirror the MeshCore C++ definitions in RegionMap.h
 REGION_DENY_FLOOD = 0x01
@@ -85,6 +86,20 @@ class RegionMap:
             # Invalid region name; ignore it rather than raising in callers.
             return
 
+    def first_key_for(self, region: Optional[RegionEntry]) -> Optional[bytes]:
+        """Return the first transport key for ``region``, or None.
+
+        Mirrors MeshCore ``RegionMap::getTransportKeysFor(..., max_num=1)``: a
+        region resolves to at most one key here (the first one yielded), and a
+        region with no usable key (e.g. an empty private ``$`` region) yields
+        None => the caller replies plain.
+        """
+        if region is None:
+            return None
+        for key in self._iter_region_keys(region):
+            return key
+        return None
+
     def find_match(self, packet: Packet, *, mask: int = 0) -> Optional[RegionEntry]:
         """Return the first RegionEntry whose scope matches this packet.
 
@@ -116,3 +131,53 @@ class RegionMap:
                 if expected == code:
                     return region
         return None
+
+
+def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
+    """Record the region a received packet arrived under, onto the packet (OH-026).
+
+    Shared by both RX entrypoints (``Dispatcher._process_received_packet`` and
+    ``CompanionBridge.process_received_packet``) so capture is identical.
+    Mirrors firmware ``recv_pkt_region`` capture:
+
+    - ``TRANSPORT_FLOOD``: match against ``REGION_DENY_FLOOD``-honouring regions
+      and record that region's (single) key.
+    - ``FLOOD`` (wildcard) or direct: record None => a reply is sent plain,
+      never the node default.
+
+    A ``None`` region_map (standalone companion) is a no-op: ``_recv_region_captured``
+    stays False, so a reply falls through to the dispatcher default (OH-022).
+    """
+    if region_map is None:
+        return
+    pkt._recv_region_captured = True
+    if pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD:
+        entry = region_map.find_match(pkt, mask=REGION_DENY_FLOOD)
+        pkt._recv_region_key = region_map.first_key_for(entry)
+    else:
+        pkt._recv_region_key = None
+
+
+def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
+    """Scope a freshly-built flood reply to the region its request arrived under.
+
+    OH-026: a repeater/room-server reply carries the request's region (or plain
+    when the request was unscoped/direct), re-hashing the transport code over
+    the reply's own payload — never the request's code, never the node default.
+
+    - Not captured (standalone companion, ``region_map`` None): return without
+      marking, so the reply falls through to the dispatcher default (OH-022).
+    - Captured with a key and the reply is a plain FLOOD: scope it
+      (=> TRANSPORT_FLOOD).
+    - Captured with no key (plain-flood/direct request, or unknown region):
+      leave the reply plain.
+
+    In every captured case the reply is marked ``_flood_scope_applied`` so the
+    dispatcher's node-default scope cannot override this decision.
+    """
+    if not getattr(request_pkt, "_recv_region_captured", False):
+        return
+    key = getattr(request_pkt, "_recv_region_key", None)
+    if key is not None and reply_pkt.get_route_type() == ROUTE_TYPE_FLOOD:
+        scope_packet(reply_pkt, key)
+    reply_pkt._flood_scope_applied = True

--- a/src/openhop_core/protocol/region_map.py
+++ b/src/openhop_core/protocol/region_map.py
@@ -134,7 +134,7 @@ class RegionMap:
 
 
 def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
-    """Record the region a received packet arrived under, onto the packet (OH-026).
+    """Record the region a received packet arrived under, onto the packet.
 
     Shared by both RX entrypoints (``Dispatcher._process_received_packet`` and
     ``CompanionBridge.process_received_packet``) so capture is identical.
@@ -146,7 +146,7 @@ def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
       never the node default.
 
     A ``None`` region_map (standalone companion) is a no-op: ``_recv_region_captured``
-    stays False, so a reply falls through to the dispatcher default (OH-022).
+    stays False, so a reply falls through to the dispatcher default.
     """
     if region_map is None:
         return
@@ -161,12 +161,12 @@ def capture_recv_region(region_map: Optional[RegionMap], pkt: Packet) -> None:
 def apply_reply_scope(reply_pkt: Packet, request_pkt: Optional[Packet]) -> None:
     """Scope a freshly-built flood reply to the region its request arrived under.
 
-    OH-026: a repeater/room-server reply carries the request's region (or plain
-    when the request was unscoped/direct), re-hashing the transport code over
-    the reply's own payload — never the request's code, never the node default.
+    A repeater/room-server reply carries the request's region (or plain when
+    the request was unscoped/direct), re-hashing the transport code over the
+    reply's own payload — never the request's code, never the node default.
 
     - Not captured (standalone companion, ``region_map`` None): return without
-      marking, so the reply falls through to the dispatcher default (OH-022).
+      marking, so the reply falls through to the dispatcher default.
     - Captured with a key and the reply is a plain FLOOD: scope it
       (=> TRANSPORT_FLOOD).
     - Captured with no key (plain-flood/direct request, or unknown region):

--- a/src/openhop_core/protocol/transport_keys.py
+++ b/src/openhop_core/protocol/transport_keys.py
@@ -8,6 +8,7 @@ Simple implementation matching the C++ MeshCore transport key functionality:
 
 import struct
 
+from .constants import ROUTE_TYPE_TRANSPORT_FLOOD
 from .crypto import CryptoUtils
 
 
@@ -72,3 +73,23 @@ def calc_transport_code(key: bytes, packet) -> int:
         code = 0xFFFE
 
     return code
+
+
+def scope_packet(pkt, key: bytes) -> None:
+    """Attach transport codes for ``key`` and switch FLOOD -> TRANSPORT_FLOOD.
+
+    The single shared scoping primitive: the companion resolver
+    (``base_config._apply_flood_scope``), the dispatcher resolver
+    (``Dispatcher._apply_flood_scope``) and the reply-scope helper
+    (``region_map.apply_reply_scope``) all funnel through this so the wire
+    format is computed in exactly one place. The code is (re-)hashed from the
+    packet's own payload via :func:`calc_transport_code`, so a reply's code is
+    derived from the reply payload, never copied from the request.
+
+    Does not set ``_flood_scope_applied``: the double-scope gate stays the
+    responsibility of the calling resolver (which must mark plain-flood
+    decisions too).
+    """
+    pkt.transport_codes[0] = calc_transport_code(key, pkt)
+    pkt.transport_codes[1] = 0  # reserved for home region (firmware TODO)
+    pkt.header = (pkt.header & ~0x03) | ROUTE_TYPE_TRANSPORT_FLOOD

--- a/src/openhop_core/protocol/utils.py
+++ b/src/openhop_core/protocol/utils.py
@@ -103,6 +103,19 @@ def parse_advert_payload(payload: bytes):
     }
 
 
+def is_self_advert(payload: bytes, self_public_key: bytes) -> bool:
+    """Return True when an ADVERT payload carries our own public key.
+
+    Mesh::onRecvPacket tests ``self_id.matches(id.pub_key)`` in its ADVERT
+    branch before wasSeen() and before signature verification (Mesh.cpp:263),
+    and never routes the packet on.  A self advert is self-signed, so every
+    other check downstream passes it.
+    """
+    if not self_public_key:
+        return False
+    return len(payload) >= PUB_KEY_SIZE and payload[:PUB_KEY_SIZE] == self_public_key
+
+
 def decode_appdata(appdata: bytes) -> dict:
     result = {}
     if len(appdata) < 1:

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -208,6 +208,58 @@ class TestCompanionBridgeChannelUpdated:
 
 
 @pytest.mark.asyncio
+class TestCompanionBridgeFloodCopyFeed:
+    """The host-wired pre-dedup feed that lets the teacher pick the best route.
+
+    A bridge owns no dispatcher, and the host delivers only the *first* copy of a
+    flood reply to ``process_received_packet`` — later copies die in the host's
+    seen-table. Observed on a live mesh: four copies of one login reply over
+    ~1.8 s, the teach going out 0.4 s in on the marginal first route, and the
+    peer's later direct replies then failing while flood replies kept working.
+    So the host wires ``dispatcher.add_raw_packet_subscriber(bridge.note_flood_copy)``
+    and this method has to reach the teacher.
+    """
+
+    def _flood_response_to(self, bridge, *, in_path: bytes, rssi: int) -> Packet:
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | ROUTE_TYPE_FLOOD
+        # payload[0] must be OUR dest hash for the teacher to record the copy.
+        pkt.payload = bytearray([bridge._identity.get_public_key()[0], 0x5A]) + bytearray(
+            b"\xcc" * 12
+        )
+        pkt.payload_len = len(pkt.payload)
+        pkt.path = bytearray(in_path)
+        pkt.path_len = PathUtils.encode_path_len(1, len(in_path))
+        pkt._rssi = rssi
+        return pkt
+
+    async def test_note_flood_copy_reaches_the_return_path_teacher(self):
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        teacher = bridge._get_protocol_response_handler().return_path_teacher
+        # The teacher ignores copies until a transmit path is wired.
+        teacher.set_injector(injector)
+
+        first = self._flood_response_to(bridge, in_path=b"\xaa\xbb\xcc", rssi=-100)
+        better = self._flood_response_to(bridge, in_path=b"\xdd", rssi=-40)
+        bridge.note_flood_copy(first)
+        bridge.note_flood_copy(better)
+
+        # Both copies of the same reply share a packet hash; the stronger,
+        # shorter route must be the one retained.
+        assert len(teacher._recent_copies) == 1
+        kept = next(iter(teacher._recent_copies.values()))
+        assert kept.path == b"\xdd"
+        assert kept.rssi == -40
+
+    async def test_note_flood_copy_is_safe_without_a_teacher(self):
+        """It runs on the host's hot RX path; a missing handler must not raise."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        bridge._protocol_response_handler = None
+        bridge.note_flood_copy(self._flood_response_to(bridge, in_path=b"\xaa", rssi=-50))
+
+
 class TestCompanionBridgeProcessReceivedPacket:
     async def test_process_packet_records_rx_stats(self):
         injector = MockPacketInjector()

--- a/tests/test_companion_bridge.py
+++ b/tests/test_companion_bridge.py
@@ -33,6 +33,12 @@ def _make_peer_contact(name: str) -> Contact:
     return Contact(public_key=peer.get_public_key(), name=name)
 
 
+async def _drain_events() -> None:
+    """Allow the EventService task a handler published to run to completion."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
 class MockPacketInjector:
     """Records injected packets and returns True by default."""
 
@@ -316,6 +322,37 @@ class TestCompanionBridgeProcessReceivedPacket:
         assert payload_bytes == b"\x01\x02\x03\x04"
         assert snr == 6.0
         assert rssi == -75
+
+    async def test_bridge_receiving_own_advert_adds_no_contact(self):
+        """A repeater re-flooding our advert delivers it straight back; the handler
+        drops it the way Mesh::onRecvPacket does (Mesh.cpp:263), so we never become
+        a contact of ourselves."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        await bridge.start()
+
+        await bridge.process_received_packet(PacketBuilder.create_advert(bridge._identity, "Me"))
+        await _drain_events()
+        await bridge.stop()
+
+        assert bridge.contacts.get_count() == 0
+
+    async def test_peer_advert_still_stored_after_self_guard(self):
+        """Control for the self-advert guard: a peer's advert through the same
+        entrypoint is still discovered and stored exactly once."""
+        injector = MockPacketInjector()
+        bridge = CompanionBridge(LocalIdentity(), injector)
+        await bridge.start()
+        discovered_calls = []
+        bridge.on_node_discovered(discovered_calls.append)
+
+        peer = LocalIdentity()
+        await bridge.process_received_packet(PacketBuilder.create_advert(peer, "Peer"))
+        await _drain_events()
+        await bridge.stop()
+
+        assert len(discovered_calls) == 1
+        assert bridge.contacts.get_by_key(peer.get_public_key()) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -708,6 +745,32 @@ class TestCompanionBridgeNodeDiscoveredAdvertPipeline:
         assert len(advert_received_calls) == 1
         assert advert_received_calls[0].name == "DiscoveredNode"
         assert advert_received_calls[0].public_key == peer.get_public_key()
+
+    async def test_node_discovered_for_own_public_key_is_ignored(self):
+        """The event seam is public: however a NODE_DISCOVERED carrying our own key
+        was produced, we must never contact-book or path-cache ourselves."""
+        injector = MockPacketInjector()
+        identity = LocalIdentity()
+        bridge = CompanionBridge(identity, injector)
+        advert_received_calls = []
+        discovered_calls = []
+        bridge.on_advert_received(advert_received_calls.append)
+        bridge.on_node_discovered(discovered_calls.append)
+        event_data = {
+            "public_key": identity.get_public_key().hex(),
+            "name": "Myself",
+            "contact_type": ADV_TYPE_CHAT,
+            "lat": 0.0,
+            "lon": 0.0,
+            "advert_timestamp": 1000,
+            "timestamp": 1000,
+            "snr": 0.0,
+            "rssi": 0,
+        }
+        await bridge._handle_mesh_event(MeshEvents.NODE_DISCOVERED, event_data)
+        assert advert_received_calls == []
+        assert discovered_calls == []
+        assert bridge.contacts.get_count() == 0
 
     async def test_one_node_discovered_event_produces_exactly_one_advert_received(self):
         """Single-path guarantee: one NODE_DISCOVERED event yields exactly one

--- a/tests/test_companion_contact_exchange.py
+++ b/tests/test_companion_contact_exchange.py
@@ -17,7 +17,7 @@ from openhop_core.companion.constants import (
 )
 from openhop_core.companion.frame_server import CompanionFrameServer
 from openhop_core.companion.models import Contact
-from openhop_core.protocol import Identity, LocalIdentity, Packet
+from openhop_core.protocol import Identity, LocalIdentity, Packet, PacketBuilder
 from openhop_core.protocol.constants import PAYLOAD_TYPE_ADVERT, ROUTE_TYPE_FLOOD
 
 # Literal MeshCore Packet::writeTo layout: header | path_len | pubkey |
@@ -120,6 +120,22 @@ async def test_import_uses_normal_autoadd_policy_instead_of_direct_store_mutatio
     assert bridge.import_contact(MESHCORE_ADVERT_WIRE) is True
     await _drain_loopback()
     assert bridge.get_contact_by_key(MESHCORE_ADVERT_PUBKEY) is None
+
+
+@pytest.mark.asyncio
+async def test_import_contact_of_own_advert_is_still_ignored():
+    """Importing our own advert reports success (the packet parsed) but never
+    reaches the advert handler, matching Mesh::onRecvPacket (Mesh.cpp:263)."""
+    identity = LocalIdentity()
+    bridge = CompanionBridge(identity, AsyncMock(return_value=True))
+    handler = AsyncMock()
+    bridge._get_advert_handler = lambda: handler
+
+    assert bridge.import_contact(PacketBuilder.create_advert(identity, "Me").write_to()) is True
+    await _drain_loopback()
+
+    handler.assert_not_awaited()
+    assert bridge.get_contact_by_key(identity.get_public_key()) is None
 
 
 def test_legacy_export_record_and_non_advert_are_rejected_before_loopback():

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -583,6 +583,60 @@ class TestDispatcherSendPacket:
         assert path_len_byte == 0x40
 
     @pytest.mark.asyncio
+    async def test_server_reply_width_survives_to_the_wire(self, dispatcher):
+        """A handler's mirrored reply width reaches the radio, node default and all.
+
+        The seam test for the rest of this behaviour: LoginServerHandler marks
+        ``_path_hash_mode_applied`` and the dispatcher honours the marker, but
+        each half is otherwise asserted in its own file. This drives a real
+        handler-built login reply through ``send_packet`` with a *conflicting*
+        node default and checks the serialized ``path_len`` byte, so a future
+        change that reconstructs the reply between handler and radio -- dropping
+        an attribute that is not part of the wire format -- fails here rather
+        than silently reverting to the node's own width on the air.
+        """
+        import struct
+        import time
+
+        from openhop_core.node.handlers.login_server import LoginServerHandler
+        from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity
+        from openhop_core.protocol.constants import PAYLOAD_TYPE_ANON_REQ, PH_TYPE_SHIFT
+
+        server, client = LocalIdentity(), LocalIdentity()
+        secret = Identity(server.get_public_key()).calc_shared_secret(client.get_private_key())
+
+        sent = []
+        handler = LoginServerHandler(
+            server, lambda *_: None, authenticate_callback=lambda *a, **k: (True, 0x03)
+        )
+        handler.set_send_packet_callback(lambda pkt, delay: sent.append(pkt))
+
+        # Flood login carrying two hops of 3-byte hashes.
+        plaintext = struct.pack("<I", int(time.time())) + b"admin123\x00"
+        login = Packet()
+        login.header = (PAYLOAD_TYPE_ANON_REQ << PH_TYPE_SHIFT) | ROUTE_TYPE_FLOOD
+        login.payload = bytearray(
+            bytes([server.get_public_key()[0]])
+            + client.get_public_key()
+            + CryptoUtils.encrypt_then_mac(secret[:16], secret, plaintext)
+        )
+        login.payload_len = len(login.payload)
+        login.path = bytearray(range(6))
+        login.path_len = PathUtils.encode_path_len(3, 2)
+
+        await handler(login)
+        assert len(sent) == 1
+
+        # Node prefers 1-byte; the request's 3-byte width must win on the wire.
+        dispatcher.set_default_path_hash_mode(0)
+        await dispatcher.send_packet(sent[0])
+
+        raw = dispatcher.radio.tx_data
+        assert raw is not None
+        assert PathUtils.get_path_hash_size(raw[1]) == 3
+        assert PathUtils.get_path_hash_count(raw[1]) == 0
+
+    @pytest.mark.asyncio
     async def test_trace_flood_rejected(self, dispatcher):
         """TRACE payload with flood route is rejected; send_packet returns False and no TX."""
         from openhop_core.protocol.constants import PH_TYPE_SHIFT

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -24,6 +24,10 @@ from openhop_core.companion import CompanionBridge, CompanionRadio
 from openhop_core.companion.models import Contact
 from openhop_core.node.dispatcher import Dispatcher
 from openhop_core.node.handlers.login_server import LoginServerHandler
+from openhop_core.node.handlers.protocol_request import (
+    REQ_TYPE_GET_STATUS,
+    ProtocolRequestHandler,
+)
 from openhop_core.protocol import (
     CryptoUtils,
     Identity,
@@ -34,7 +38,9 @@ from openhop_core.protocol import (
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ANON_REQ,
     PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_REQ,
     PAYLOAD_TYPE_TXT_MSG,
+    ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
     ROUTE_TYPE_TRANSPORT_FLOOD,
     TXT_TYPE_PLAIN,
@@ -82,9 +88,7 @@ def _make_companion(node_name: str = "test") -> CompanionRadio:
 
 def _make_flood_packet() -> Packet:
     """A minimal flood-routed advert packet (for dispatcher-level unit tests)."""
-    return PacketBuilder.create_advert(
-        local_identity=LocalIdentity(), name="x", route_type="flood"
-    )
+    return PacketBuilder.create_advert(local_identity=LocalIdentity(), name="x", route_type="flood")
 
 
 def _build_login_req(
@@ -258,9 +262,9 @@ class TestSetASendsCarryDefault:
 
     def _assert_scoped_with_default(self, pkt: Packet, default_key: bytes, label: str):
         assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD, f"{label} not TRANSPORT_FLOOD"
-        assert pkt.transport_codes[0] == calc_transport_code(default_key, pkt), (
-            f"{label} transport code does not match the default key"
-        )
+        assert pkt.transport_codes[0] == calc_transport_code(
+            default_key, pkt
+        ), f"{label} transport code does not match the default key"
 
     @pytest.mark.asyncio
     async def test_flood_sends_carry_default(self):
@@ -493,6 +497,172 @@ class TestRepeaterReplyCarriesRegion:
         # Cross-check: each reply matches only its own region.
         assert reply_a.transport_codes[0] != calc_transport_code(b_key, reply_a)
         assert reply_b.transport_codes[0] != calc_transport_code(a_key, reply_b)
+
+
+class TestRepeaterReqReplyScope:
+    """Both REQ reply shapes in ``ProtocolRequestHandler._build_response``.
+
+    Firmware ``simple_repeater::onPeerDataRecv`` (PAYLOAD_TYPE_REQ) has two
+    flood reply branches, and both go through ``sendFloodReply``::
+
+        if (packet->isRouteFlood()) {
+          path = createPathReturn(...);  sendFloodReply(path, ...);          // (a)
+        } else {
+          reply = createDatagram(PAYLOAD_TYPE_RESPONSE, ...);
+          if (client->out_path_len != OUT_PATH_UNKNOWN) sendDirect(...);
+          else                                          sendFloodReply(reply, ...);  // (b)
+        }
+
+    ``sendFloodReply`` scopes to ``recv_pkt_region`` — which is NULL for a DIRECT
+    request — so branch (b) is a plain, unscoped flood. Branch (b) used to be the
+    one reply builder that never marked its decision, so the dispatcher's node
+    default/override stamped a region onto it that firmware would never use. It
+    is the reply that carries a status/telemetry/neighbours response whenever the
+    ACL holds no out_path for the client.
+    """
+
+    def _req_handler(self, server: LocalIdentity, client_info):
+        handler = ProtocolRequestHandler(
+            local_identity=server,
+            contacts=None,
+            get_clients_fn=lambda src_hash: [client_info],
+            request_handlers={REQ_TYPE_GET_STATUS: lambda c, ts, data: b"\x01\x02\x03\x04"},
+            log_fn=lambda *_: None,
+        )
+        return handler
+
+    def _client_info(self, client: LocalIdentity, *, out_path_len: int = -1, out_path=b""):
+        class _Client:
+            def __init__(self):
+                self.id = Identity(client.get_public_key())
+                self.public_key = client.get_public_key()
+                self.out_path = bytearray(out_path)
+                self.out_path_len = out_path_len
+                self.last_timestamp = 0
+
+        return _Client()
+
+    def _build_req(
+        self,
+        server: LocalIdentity,
+        client: LocalIdentity,
+        *,
+        route_type: int,
+        region_key: bytes = None,
+    ) -> Packet:
+        server_pub = server.get_public_key()
+        client_pub = client.get_public_key()
+        shared = Identity(server_pub).calc_shared_secret(client.get_private_key())
+        plaintext = struct.pack("<I", int(time.time())) + bytes([REQ_TYPE_GET_STATUS])
+        enc = CryptoUtils.encrypt_then_mac(shared[:16], shared, plaintext)
+        payload = bytes([server_pub[0], client_pub[0]]) + enc
+
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_REQ << 2) | route_type
+        pkt.payload = bytearray(payload)
+        pkt.payload_len = len(payload)
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        if region_key is not None:
+            scope_packet(pkt, region_key)
+        return pkt
+
+    @pytest.mark.asyncio
+    async def test_direct_req_without_out_path_replies_plain_flood(self):
+        """Branch (b): the node default must not reach this reply.
+
+        A DIRECT request captures no region (firmware ``recv_pkt_region`` is
+        NULL), so the flood RESPONSE stays plain and is marked applied.
+        """
+        region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
+        server, client = LocalIdentity(), LocalIdentity()
+        handler = self._req_handler(server, self._client_info(client))  # no out_path
+
+        req = self._build_req(server, client, route_type=ROUTE_TYPE_DIRECT)
+        capture_recv_region(region_map, req)
+        assert req._recv_region_captured is True
+        assert req._recv_region_key is None
+
+        result = await handler(req)
+        assert result.authenticated is True
+        reply = result.response
+        assert reply is not None
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply._flood_scope_applied is True
+
+        # The gate has to actually hold at TX time against a configured default.
+        dispatcher = Dispatcher(MockRadio())
+        dispatcher.default_flood_transport_key = get_auto_key_for("#region-a")
+        dispatcher._apply_flood_scope(reply)
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+
+    @pytest.mark.asyncio
+    async def test_flood_req_path_return_carries_request_region(self):
+        """Branch (a) keeps carrying the region the REQ arrived under."""
+        a_key = get_auto_key_for("#region-a")
+        region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
+        server, client = LocalIdentity(), LocalIdentity()
+        handler = self._req_handler(server, self._client_info(client))
+
+        req = self._build_req(
+            server, client, route_type=ROUTE_TYPE_TRANSPORT_FLOOD, region_key=a_key
+        )
+        capture_recv_region(region_map, req)
+        assert req._recv_region_key == a_key
+
+        result = await handler(req)
+        reply = result.response
+        assert reply is not None
+        assert reply.get_payload_type() == PAYLOAD_TYPE_PATH
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(a_key, reply)
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_direct_req_with_out_path_replies_direct_unscoped(self):
+        """A known out_path is a sendDirect: no flood scope decision at all."""
+        region_map = RegionMap([RegionEntry(id=1, name="#region-a")])
+        server, client = LocalIdentity(), LocalIdentity()
+        client_info = self._client_info(client, out_path_len=1, out_path=b"\x5a")
+        handler = self._req_handler(server, client_info)
+
+        req = self._build_req(server, client, route_type=ROUTE_TYPE_DIRECT)
+        capture_recv_region(region_map, req)
+
+        result = await handler(req)
+        reply = result.response
+        assert reply is not None
+        assert reply.get_route_type() == ROUTE_TYPE_DIRECT
+        assert reply.transport_codes == [0, 0]
+
+    @pytest.mark.asyncio
+    async def test_standalone_node_flood_reply_still_takes_the_default(self):
+        """Without a RegionMap the reply falls through to the node default.
+
+        Companion parity: ``BaseChatMesh::onPeerDataRecv`` answers this branch
+        with ``sendFloodScoped(from, ...)``, which does fall back to
+        ``prefs.default_scope_key``. The mark must not be applied when nothing
+        was captured, or that fallback would be suppressed.
+        """
+        server, client = LocalIdentity(), LocalIdentity()
+        handler = self._req_handler(server, self._client_info(client))
+
+        req = self._build_req(server, client, route_type=ROUTE_TYPE_DIRECT)
+        # No capture_recv_region(): region_map is None on a standalone node.
+        assert req._recv_region_captured is False
+
+        result = await handler(req)
+        reply = result.response
+        assert reply is not None
+        assert reply._flood_scope_applied is False
+
+        default_key = get_auto_key_for("#default-region")
+        dispatcher = Dispatcher(MockRadio())
+        dispatcher.default_flood_transport_key = default_key
+        dispatcher._apply_flood_scope(reply)
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(default_key, reply)
 
 
 class TestRegionCaptureBothEntrypoints:

--- a/tests/test_flood_scope_fix.py
+++ b/tests/test_flood_scope_fix.py
@@ -1,0 +1,566 @@
+"""Regression tests for the OH-022 + OH-026 flood-scope fix.
+
+OH-022: mirror the persisted default flood scope (and the explicit-unscoped
+        flag) to the dispatcher, so sends that build a packet and rely on the
+        dispatcher to scope it at TX time carry the default too.
+OH-026: capture the region a request arrived under on the Packet, and scope a
+        freshly-built flood reply to that region (or plain), never the node
+        default.
+
+Both parts share one ``scope_packet`` primitive and the ``_flood_scope_applied``
+double-scope gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import struct
+import time
+
+import pytest
+
+from openhop_core.companion import CompanionBridge, CompanionRadio
+from openhop_core.companion.models import Contact
+from openhop_core.node.dispatcher import Dispatcher
+from openhop_core.node.handlers.login_server import LoginServerHandler
+from openhop_core.protocol import (
+    CryptoUtils,
+    Identity,
+    LocalIdentity,
+    Packet,
+    PacketBuilder,
+)
+from openhop_core.protocol.constants import (
+    PAYLOAD_TYPE_ANON_REQ,
+    PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_TXT_MSG,
+    ROUTE_TYPE_FLOOD,
+    ROUTE_TYPE_TRANSPORT_FLOOD,
+    TXT_TYPE_PLAIN,
+)
+from openhop_core.protocol.region_map import (
+    RegionEntry,
+    RegionMap,
+    capture_recv_region,
+)
+from openhop_core.protocol.transport_keys import (
+    calc_transport_code,
+    get_auto_key_for,
+    scope_packet,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockRadio:
+    """Minimal mock radio that records transmitted frames."""
+
+    def __init__(self):
+        self.rx_callback = None
+        self.sent: list[bytes] = []
+
+    def set_rx_callback(self, callback):
+        self.rx_callback = callback
+
+    async def send(self, data: bytes) -> bool:
+        self.sent.append(bytes(data))
+        return True
+
+    def get_last_rssi(self) -> int:
+        return -50
+
+    def get_last_snr(self) -> float:
+        return 5.0
+
+
+def _make_companion(node_name: str = "test") -> CompanionRadio:
+    return CompanionRadio(radio=MockRadio(), identity=LocalIdentity(), node_name=node_name)
+
+
+def _make_flood_packet() -> Packet:
+    """A minimal flood-routed advert packet (for dispatcher-level unit tests)."""
+    return PacketBuilder.create_advert(
+        local_identity=LocalIdentity(), name="x", route_type="flood"
+    )
+
+
+def _build_login_req(
+    server: LocalIdentity,
+    client: LocalIdentity,
+    password: str = "pw",
+    region_key: bytes = None,
+    route_type: int = ROUTE_TYPE_FLOOD,
+) -> Packet:
+    """Build an ANON_REQ login packet from ``client`` to ``server``.
+
+    When ``region_key`` is given the packet is scoped (TRANSPORT_FLOOD) with
+    that key, exactly as a firmware repeater would have re-broadcast it.
+    """
+    server_pub = server.get_public_key()
+    client_pub = client.get_public_key()
+    shared = Identity(server_pub).calc_shared_secret(client.get_private_key())
+    aes = shared[:16]
+    plaintext = struct.pack("<I", int(time.time())) + password.encode("utf-8") + b"\x00"
+    enc = CryptoUtils.encrypt_then_mac(aes, shared, plaintext)
+    payload = bytes([server_pub[0]]) + client_pub + enc
+
+    pkt = Packet()
+    pkt.header = (PAYLOAD_TYPE_ANON_REQ << 2) | route_type
+    pkt.payload = bytearray(payload)
+    pkt.payload_len = len(payload)
+    pkt.path = bytearray()
+    pkt.path_len = 0
+    if region_key is not None:
+        scope_packet(pkt, region_key)  # -> TRANSPORT_FLOOD with region code
+    return pkt
+
+
+def _login_handler(server: LocalIdentity):
+    """A LoginServerHandler that always authenticates, capturing sent replies."""
+    sent: list = []
+    handler = LoginServerHandler(
+        local_identity=server,
+        log_fn=lambda *_: None,
+        authenticate_callback=lambda *a, **k: (True, 0x03),
+        is_room_server=False,
+    )
+    handler.set_send_packet_callback(lambda pkt, delay_ms: sent.append(pkt))
+    return handler, sent
+
+
+def _build_flood_dm(sender: LocalIdentity, receiver: LocalIdentity, text: str = "hi") -> Packet:
+    """Build a real encrypted FLOOD DM from ``sender`` to ``receiver``."""
+
+    class _SendContact:
+        def __init__(self, pubkey_hex):
+            self.public_key = pubkey_hex
+            self.out_path = []
+            self.out_path_len = -1
+
+    pkt, _ = PacketBuilder.create_text_message(
+        _SendContact(receiver.get_public_key().hex()),
+        sender,
+        text,
+        attempt=0,
+        message_type="flood",
+        txt_type=TXT_TYPE_PLAIN,
+    )
+    return pkt
+
+
+async def _drain_first_tx(companion: CompanionRadio, radio: MockRadio, coro) -> Packet:
+    """Run ``coro`` until the first packet is transmitted, return it, then cancel.
+
+    Several public send methods block on a response (login/status/telemetry/CLI).
+    Only their first transmitted packet matters here, so poll ``radio.sent``,
+    capture that packet, then cancel the call and any retry/waiter background
+    tasks so they stop re-sending.
+    """
+    n0 = len(radio.sent)
+    task = asyncio.ensure_future(coro)
+    try:
+        for _ in range(400):
+            if len(radio.sent) > n0:
+                break
+            await asyncio.sleep(0.005)
+    finally:
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+        for bt in list(getattr(companion, "_background_tasks", ())):
+            bt.cancel()
+        for bt in list(getattr(companion, "_background_tasks", ())):
+            with contextlib.suppress(BaseException):
+                await bt
+    assert len(radio.sent) > n0, "expected a transmitted packet"
+    pkt = Packet()
+    pkt.read_from(radio.sent[n0])
+    return pkt
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — OH-022: default / unscoped mirror on the dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMirrorToDispatcher:
+    def test_set_default_flood_scope_reaches_dispatcher(self):
+        """(1) set_default_flood_scope mirrors the resolved key to the dispatcher."""
+        companion = _make_companion()
+        key = get_auto_key_for("#usa")
+        companion.set_default_flood_scope("usa", key)
+        assert companion.node.dispatcher.default_flood_transport_key == key
+
+    def test_null_and_short_default_clear_dispatcher_mirror(self):
+        """(1) A null (all-zero) or too-short default resolves to None on the mirror."""
+        companion = _make_companion()
+        companion.set_default_flood_scope("usa", get_auto_key_for("#usa"))
+        assert companion.node.dispatcher.default_flood_transport_key is not None
+
+        # All-zero key: firmware persists the name but treats the key as null at send.
+        companion.set_default_flood_scope("usa", b"\x00" * 16)
+        assert companion.node.dispatcher.default_flood_transport_key is None
+
+        companion.set_default_flood_scope("usa", get_auto_key_for("#usa"))
+        # Short key => base clears the default entirely.
+        companion.set_default_flood_scope("usa", b"\x01" * 8)
+        assert companion.node.dispatcher.default_flood_transport_key is None
+
+        companion.set_default_flood_scope("usa", get_auto_key_for("#usa"))
+        companion.set_default_flood_scope(None, None)
+        assert companion.node.dispatcher.default_flood_transport_key is None
+
+    @pytest.mark.asyncio
+    async def test_start_seeds_all_three_mirrors_from_prefs(self):
+        """(2) start() seeds default + override + unscoped flag from persisted prefs."""
+        companion = _make_companion()
+        default_key = get_auto_key_for("#usa")
+        override_key = b"\x02" * 16
+        # Simulate persisted prefs restored at boot, bypassing the live setters.
+        companion.prefs.default_scope_name = "usa"
+        companion.prefs.default_scope_key = default_key
+        companion._flood_transport_key = override_key
+        companion._flood_unscoped = True
+
+        # Not yet started: mirrors are still at their __init__ defaults.
+        assert companion.node.dispatcher.default_flood_transport_key is None
+        assert companion.node.dispatcher.flood_transport_key is None
+        assert companion.node.dispatcher.flood_unscoped is False
+
+        await companion.start()
+        try:
+            assert companion.node.dispatcher.default_flood_transport_key == default_key
+            assert companion.node.dispatcher.flood_transport_key == override_key
+            assert companion.node.dispatcher.flood_unscoped is True
+        finally:
+            await companion.stop()
+
+
+class TestSetASendsCarryDefault:
+    """(3) With only a default set, sends that rely on the dispatcher carry it."""
+
+    async def _companion_with_default(self):
+        radio = MockRadio()
+        companion = CompanionRadio(radio=radio, identity=LocalIdentity(), node_name="setA")
+        peer = LocalIdentity()
+        contact_key = peer.get_public_key()
+        companion.contacts.add(Contact(public_key=contact_key, name="rpt"))  # out_path_len=-1
+        default_key = get_auto_key_for("#usa")
+        await companion.start()
+        companion.set_default_flood_scope("usa", default_key)
+        # Ensure NO transient override / unscoped is in play.
+        assert companion.node.dispatcher.flood_transport_key is None
+        assert companion.node.dispatcher.flood_unscoped is False
+        return companion, radio, contact_key, default_key
+
+    def _assert_scoped_with_default(self, pkt: Packet, default_key: bytes, label: str):
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD, f"{label} not TRANSPORT_FLOOD"
+        assert pkt.transport_codes[0] == calc_transport_code(default_key, pkt), (
+            f"{label} transport code does not match the default key"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flood_sends_carry_default(self):
+        companion, radio, key, default_key = await self._companion_with_default()
+        try:
+            pkt = await _drain_first_tx(companion, radio, companion.send_login(key, "pw"))
+            self._assert_scoped_with_default(pkt, default_key, "login")
+
+            pkt = await _drain_first_tx(companion, radio, companion.send_status_request(key))
+            self._assert_scoped_with_default(pkt, default_key, "status")
+
+            pkt = await _drain_first_tx(companion, radio, companion.send_telemetry_request(key))
+            self._assert_scoped_with_default(pkt, default_key, "telemetry")
+
+            pkt = await _drain_first_tx(
+                companion, radio, companion.send_repeater_command(key, "reboot")
+            )
+            self._assert_scoped_with_default(pkt, default_key, "cli/repeater_command")
+
+            pkt = await _drain_first_tx(
+                companion, radio, companion.send_raw_data(key, b"\x01\x02\x03\x04")
+            )
+            self._assert_scoped_with_default(pkt, default_key, "raw_data")
+        finally:
+            await companion.stop()
+
+
+class TestUnscopedSuppressesDefault:
+    def test_unscoped_suppresses_default_then_resumes(self):
+        """(4) Unscoped suppresses (not nulls) the default; a later scope resumes."""
+        companion = _make_companion()
+        dispatcher = companion.node.dispatcher
+        default_key = get_auto_key_for("#usa")
+        companion.set_default_flood_scope("usa", default_key)
+
+        companion.set_flood_unscoped()
+        # The default mirror is preserved, only suppressed by the flag.
+        assert dispatcher.default_flood_transport_key == default_key
+        assert dispatcher.flood_unscoped is True
+
+        pkt = _make_flood_packet()
+        dispatcher._apply_flood_scope(pkt)
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD  # stayed plain
+        assert pkt.transport_codes == [0, 0]
+
+        # A transient override clears the flag and resumes scoping.
+        override_key = get_auto_key_for("#europe")
+        companion.set_flood_scope(override_key)
+        assert dispatcher.flood_unscoped is False
+        pkt2 = _make_flood_packet()
+        dispatcher._apply_flood_scope(pkt2)
+        assert pkt2.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt2.transport_codes[0] == calc_transport_code(override_key, pkt2)
+
+        # Clearing the override falls back to the (still-present) default.
+        companion.set_flood_scope(None)
+        assert dispatcher.flood_unscoped is False
+        pkt3 = _make_flood_packet()
+        dispatcher._apply_flood_scope(pkt3)
+        assert pkt3.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt3.transport_codes[0] == calc_transport_code(default_key, pkt3)
+
+
+class TestOverrideBeatsDefault:
+    def test_transient_override_beats_default(self):
+        """(5) The transient override wins over the persisted default."""
+        companion = _make_companion()
+        dispatcher = companion.node.dispatcher
+        default_key = get_auto_key_for("#usa")
+        override_key = get_auto_key_for("#europe")
+        companion.set_default_flood_scope("usa", default_key)
+        companion.set_flood_region("europe")
+
+        assert dispatcher.flood_transport_key == override_key
+        assert dispatcher.default_flood_transport_key == default_key
+
+        pkt = _make_flood_packet()
+        dispatcher._apply_flood_scope(pkt)
+        assert pkt.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert pkt.transport_codes[0] == calc_transport_code(override_key, pkt)
+        assert pkt.transport_codes[0] != calc_transport_code(default_key, pkt)
+
+
+class TestPreScopedPacketUntouched:
+    def test_dispatcher_skips_marked_packet_even_with_default(self):
+        """(6) A packet already marked _flood_scope_applied is never re-scoped,
+        even when the dispatcher holds a default."""
+        companion = _make_companion()
+        dispatcher = companion.node.dispatcher
+        dispatcher.default_flood_transport_key = get_auto_key_for("#usa")
+        dispatcher.flood_transport_key = get_auto_key_for("#europe")
+
+        pkt = _make_flood_packet()
+        pkt._flood_scope_applied = True
+        dispatcher._apply_flood_scope(pkt)
+
+        assert pkt.get_route_type() == ROUTE_TYPE_FLOOD
+        assert pkt.transport_codes == [0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — OH-026: reply-region capture + scoping
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneCompanionReplyCarriesDefault:
+    @pytest.mark.asyncio
+    async def test_standalone_txt_ack_carries_default(self):
+        """(7) A standalone companion (region_map None) does not capture, so its
+        flood TXT ACK falls through to the dispatcher default (OH-022)."""
+        radio = MockRadio()
+        server = LocalIdentity()
+        companion = CompanionRadio(radio=radio, identity=server, node_name="standalone")
+        sender = LocalIdentity()
+        companion.contacts.add(Contact(public_key=sender.get_public_key(), name="peer"))
+        default_key = get_auto_key_for("#usa")
+
+        await companion.start()
+        try:
+            companion.set_default_flood_scope("usa", default_key)
+            assert companion.node.dispatcher.region_map is None
+
+            dm = _build_flood_dm(sender, server, "hello")
+            await companion.node.dispatcher._process_received_packet(dm.write_to(), -50, 5.0)
+            # The flood PATH-return ACK is scheduled after TXT_ACK_DELAY (~200ms).
+            for _ in range(200):
+                if radio.sent:
+                    break
+                await asyncio.sleep(0.005)
+
+            assert radio.sent, "expected a flood ACK to be transmitted"
+            ack = Packet()
+            ack.read_from(radio.sent[-1])
+            assert ack.get_payload_type() == PAYLOAD_TYPE_PATH
+            assert ack.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+            assert ack.transport_codes[0] == calc_transport_code(default_key, ack)
+        finally:
+            await companion.stop()
+
+
+class TestRepeaterReplyCarriesRegion:
+    def _region_map(self):
+        rm = RegionMap([RegionEntry(id=1, name="#region-a"), RegionEntry(id=2, name="#region-b")])
+        return rm, get_auto_key_for("#region-a"), get_auto_key_for("#region-b")
+
+    @pytest.mark.asyncio
+    async def test_reply_carries_incoming_region(self):
+        """(8) A request scoped to region B yields a reply scoped to region B,
+        with the code re-hashed over the reply payload, marked applied."""
+        region_map, _a_key, b_key = self._region_map()
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req = _build_login_req(server, client, region_key=b_key)
+        capture_recv_region(region_map, req)  # what the RX path does
+        assert req._recv_region_captured is True
+        assert req._recv_region_key == b_key
+
+        result = await handler(req)
+        assert result.authenticated is True
+        assert len(sent) == 1
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+        assert reply.transport_codes[0] == calc_transport_code(b_key, reply)
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_plain_flood_request_reply_stays_plain(self):
+        """(9) A plain-flood request => plain reply (not over-scoped, not
+        default-scoped): marked applied so the dispatcher default cannot touch it."""
+        region_map, _a_key, _b_key = self._region_map()
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req = _build_login_req(server, client, region_key=None)  # plain FLOOD
+        capture_recv_region(region_map, req)
+        assert req._recv_region_captured is True
+        assert req._recv_region_key is None
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_region_reply_stays_plain(self):
+        """(10) A request scoped to a region absent from the map => plain reply."""
+        region_map, _a_key, _b_key = self._region_map()
+        server, client = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        unknown_key = get_auto_key_for("#not-in-map")
+        req = _build_login_req(server, client, region_key=unknown_key)
+        capture_recv_region(region_map, req)
+        assert req._recv_region_captured is True
+        assert req._recv_region_key is None  # no region matched
+
+        await handler(req)
+        reply = sent[0]
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert reply.transport_codes == [0, 0]
+        assert reply._flood_scope_applied is True
+
+    @pytest.mark.asyncio
+    async def test_interleaved_requests_each_reply_scoped_correctly(self):
+        """(11) Region lives on each Packet, not a shared member: two interleaved
+        requests (regions A, B) each yield a correctly-scoped reply."""
+        region_map, a_key, b_key = self._region_map()
+        server = LocalIdentity()
+        client_a, client_b = LocalIdentity(), LocalIdentity()
+        handler, sent = _login_handler(server)
+
+        req_a = _build_login_req(server, client_a, region_key=a_key)
+        req_b = _build_login_req(server, client_b, region_key=b_key)
+
+        # Capture both BEFORE either reply is built (a shared member would be
+        # overwritten by the second capture).
+        capture_recv_region(region_map, req_a)
+        capture_recv_region(region_map, req_b)
+        assert req_a._recv_region_key == a_key
+        assert req_b._recv_region_key == b_key
+
+        await handler(req_a)
+        await handler(req_b)
+        assert len(sent) == 2
+        reply_a, reply_b = sent
+        assert reply_a.transport_codes[0] == calc_transport_code(a_key, reply_a)
+        assert reply_b.transport_codes[0] == calc_transport_code(b_key, reply_b)
+        # Cross-check: each reply matches only its own region.
+        assert reply_a.transport_codes[0] != calc_transport_code(b_key, reply_a)
+        assert reply_b.transport_codes[0] != calc_transport_code(a_key, reply_b)
+
+
+class TestRegionCaptureBothEntrypoints:
+    def _region_map(self):
+        return RegionMap([RegionEntry(id=2, name="#region-b")]), get_auto_key_for("#region-b")
+
+    def _scoped_transport_flood_packet(self, key: bytes) -> Packet:
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_TRANSPORT_FLOOD
+        pkt.payload = bytearray(b"\x11\x22hello-region-payload")
+        pkt.payload_len = len(pkt.payload)
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        pkt.transport_codes[0] = calc_transport_code(key, pkt)
+        pkt.transport_codes[1] = 0
+        return pkt
+
+    @pytest.mark.asyncio
+    async def test_capture_via_dispatcher_entrypoint(self):
+        """(12a) Dispatcher._process_received_packet captures the region."""
+        region_map, b_key = self._region_map()
+        dispatcher = Dispatcher(MockRadio())
+        dispatcher.region_map = region_map
+
+        seen: list[Packet] = []
+
+        async def _record(pkt: Packet):
+            seen.append(pkt)
+
+        dispatcher.register_handler(PAYLOAD_TYPE_TXT_MSG, _record)
+
+        raw = self._scoped_transport_flood_packet(b_key).write_to()
+        await dispatcher._process_received_packet(raw, -50, 5.0)
+
+        assert len(seen) == 1
+        assert seen[0]._recv_region_captured is True
+        assert seen[0]._recv_region_key == b_key
+
+    @pytest.mark.asyncio
+    async def test_capture_via_bridge_entrypoint(self):
+        """(12b) CompanionBridge.process_received_packet captures the region."""
+        region_map, b_key = self._region_map()
+
+        async def _injector(pkt, wait_for_ack=False, expected_crc=None):
+            return True
+
+        bridge = CompanionBridge(LocalIdentity(), _injector, node_name="bridge")
+        bridge.region_map = region_map
+
+        pkt = self._scoped_transport_flood_packet(b_key)
+        await bridge.process_received_packet(pkt)
+
+        assert pkt._recv_region_captured is True
+        assert pkt._recv_region_key == b_key
+
+    @pytest.mark.asyncio
+    async def test_bridge_without_region_map_does_not_capture(self):
+        """A standalone bridge (region_map None) captures nothing."""
+
+        async def _injector(pkt, wait_for_ack=False, expected_crc=None):
+            return True
+
+        bridge = CompanionBridge(LocalIdentity(), _injector, node_name="bridge")
+        assert bridge.region_map is None
+
+        _rm, b_key = self._region_map()
+        pkt = self._scoped_transport_flood_packet(b_key)
+        await bridge.process_received_packet(pkt)
+
+        assert pkt._recv_region_captured is False
+        assert pkt._recv_region_key is None

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -233,6 +233,33 @@ async def test_node_discovered_pushes_short_advert_for_stored_contact():
     assert len(data) == 1 + PUB_KEY_SIZE
 
 
+@pytest.mark.asyncio
+async def test_self_advert_pushes_no_frame_to_client():
+    """Our own advert, heard back off a repeater, is dropped like Mesh::onRecvPacket
+    does (Mesh.cpp:263): the client sees neither ADVERT nor NEW_ADVERT."""
+    from unittest.mock import AsyncMock
+
+    from openhop_core.companion.companion_bridge import CompanionBridge
+    from openhop_core.protocol import LocalIdentity, PacketBuilder
+
+    injector = AsyncMock(return_value=True)
+    identity = LocalIdentity()
+    bridge = CompanionBridge(identity, injector)
+
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    server._write_queue = asyncio.Queue(maxsize=256)
+    server._setup_push_callbacks()
+
+    await bridge.process_received_packet(PacketBuilder.create_advert(identity, "Me"))
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    push_codes = [server._write_queue.get_nowait()[3] for _ in range(server._write_queue.qsize())]
+    assert PUSH_CODE_ADVERT not in push_codes
+    assert PUSH_CODE_NEW_ADVERT not in push_codes
+    assert bridge.contacts.get_count() == 0
+
+
 def test_build_advert_push_frames_name_truncated_to_32_bytes():
     """Long name is truncated to 32 bytes in full frame."""
     pubkey = bytes(range(32))

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1484,6 +1484,7 @@ class TestProtocolResponseHandler:
             path=[0xA1],
             extra_type=PAYLOAD_TYPE_RESPONSE,
             extra=bytes(reply),
+            path_len_encoded=PathUtils.encode_path_len(1, 1),
         )
         packet.set_path(b"\xb2", PathUtils.encode_path_len(1, 1))
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -977,6 +977,130 @@ class TestGroupTextHandler:
         assert parsed["content"] == "Bob: hey"
 
 
+class TestPendingLoginDoesNotSwallowOtherReplies:
+    """A pending login must not claim an unrelated reply from the same contact.
+
+    Observed live: three login attempts to a repeater timed out at the client,
+    leaving a login waiter alive (openHop keeps one for
+    ``FRAME_LOGIN_PENDING_TTL_S`` so a late flood login reply can still
+    complete). A neighbours fetch to that repeater then answered normally — and
+    the 148-byte reply was consumed here and logged as ``Login failed to
+    'Hillcrest' (code: 0x2F)``. 0x2F is 47, the low byte of that response's
+    ``neighbours_count``: the login parser had read a neighbour count as a
+    response code, and the fetch reported failure with the data discarded.
+
+    Firmware has the same contact-based ambiguity but a one-response window
+    (``MyMesh::onContactResponse`` clears ``pending_login`` on the first reply),
+    so at most one packet can be misread. The discriminator is the reflected
+    request tag, which firmware's own source points at:
+    ``// FUTURE: tag == pending_status``.
+    """
+
+    def setup_method(self):
+        self.contacts = MockContactBook()
+        self.local_identity = LocalIdentity()
+        self.server = LocalIdentity()
+        self.server_key = self.server.get_public_key()
+        # LoginResponseHandler iterates ``contacts.contacts`` looking for a
+        # pubkey whose first byte matches the responding hash.
+        server_contact = type("_C", (), {"public_key": self.server_key, "name": "FarRepeater"})()
+        self.contacts.contacts.append(server_contact)
+        self.handler = LoginResponseHandler(self.local_identity, self.contacts, MagicMock())
+        self.forwarded = []
+
+        class _Proto:
+            _response_waiters: dict = {}
+
+            async def __call__(_self, pkt):
+                self.forwarded.append(pkt)
+                return HandlerResult.consumed()
+
+        self.proto = _Proto()
+        self.handler.set_protocol_response_handler(self.proto)
+
+    def _reply(self, plaintext: bytes) -> Packet:
+        """A RESPONSE datagram from the server to us carrying ``plaintext``."""
+        shared = Identity(self.server_key).calc_shared_secret(self.local_identity.get_private_key())
+        enc = CryptoUtils.encrypt_then_mac(shared[:16], shared, plaintext)
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | ROUTE_TYPE_DIRECT
+        pkt.payload = bytearray(
+            [self.local_identity.get_public_key()[0], self.server_key[0]]
+        ) + bytearray(enc)
+        pkt.payload_len = len(pkt.payload)
+        pkt.path = bytearray()
+        pkt.path_len = 0
+        return pkt
+
+    def _neighbours_reply(self, tag: int) -> Packet:
+        """tag(4) + neighbours_count(2)=47 + results_count(2) + entries."""
+        body = struct.pack("<IHH", tag, 47, 2) + bytes(range(18))
+        return self._reply(body)
+
+    def _login_reply(self, tag: int) -> Packet:
+        """tag(4) + code(1)=OK + keep_alive(1) + is_admin(1) + perms(1) + rand(4) + ver(1)."""
+        return self._reply(struct.pack("<IBBBB", tag, 0, 0, 1, 0x03) + b"\x00\x00\x00\x00\x07")
+
+    @pytest.mark.asyncio
+    async def test_neighbours_reply_is_forwarded_not_read_as_a_login(self):
+        tag = 0x11223344
+        login_cb = MagicMock()
+        self.handler.register_login_callback(self.server_key, login_cb)
+        self.handler.set_foreign_request_probe(lambda t, key: t == tag and key == self.server_key)
+
+        result = await self.handler(self._neighbours_reply(tag))
+
+        assert self.forwarded, "the neighbours reply must reach the protocol handler"
+        assert result.authenticated is True
+        login_cb.assert_not_called()  # and must NOT be reported as a login result
+
+    @pytest.mark.asyncio
+    async def test_a_real_login_reply_still_completes_while_a_request_is_pending(self):
+        """The probe must not divert the login reply it was meant to protect."""
+        login_cb = MagicMock()
+        self.handler.register_login_callback(self.server_key, login_cb)
+        # Some *other* tag is pending; this reply reflects the login's own tag.
+        self.handler.set_foreign_request_probe(lambda t, key: t == 0xAAAAAAAA)
+
+        await self.handler(self._login_reply(0x55667788))
+
+        assert self.forwarded == []
+        login_cb.assert_called_once()
+        assert login_cb.call_args[0][0] is True
+
+    @pytest.mark.asyncio
+    async def test_without_a_probe_behaviour_is_unchanged(self):
+        """A standalone handler (no companion wiring) keeps its old behaviour."""
+        login_cb = MagicMock()
+        self.handler.register_login_callback(self.server_key, login_cb)
+
+        await self.handler(self._neighbours_reply(0x11223344))
+
+        assert self.forwarded == []
+        login_cb.assert_called_once()  # the pre-fix misread, still reachable
+
+    @pytest.mark.asyncio
+    async def test_probe_covers_pending_binary_requests_via_the_companion(self):
+        """End-to-end wiring: CompanionBase.has_pending_request_tag is the probe."""
+        from openhop_core.companion.companion_bridge import CompanionBridge
+
+        async def _injector(pkt, wait_for_ack=False, expected_crc=None):
+            return True
+
+        bridge = CompanionBridge(LocalIdentity(), _injector, node_name="b")
+        tag = 0x0BADF00D
+        assert bridge.has_pending_request_tag(tag, self.server_key) is False
+        bridge.register_binary_request(
+            tag.to_bytes(4, "little").hex(), request_type=0x06, timeout_seconds=30
+        )
+        assert bridge.has_pending_request_tag(tag, self.server_key) is True
+        # An expired registration must stop diverting replies.
+        bridge.register_binary_request(
+            tag.to_bytes(4, "little").hex(), request_type=0x06, timeout_seconds=-1
+        )
+        assert bridge.has_pending_request_tag(tag, self.server_key) is False
+
+
 # Login Response Handler Tests
 class TestLoginResponseHandler:
     def setup_method(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1378,13 +1378,8 @@ class TestProtocolResponseHandler:
             "len": PathUtils.encode_path_len(1, 1),
             "path": b"\xa1",
         }
+        # The reciprocal is genuinely in flight (queued, not awaited inline).
         await asyncio.wait_for(injector_started.wait(), timeout=0.1)
-        assert (
-            await protocol_handler.return_path_teacher.maybe_teach_reverse_of_out_path(
-                server_pubkey, reason="login retry"
-            )
-            is False
-        )
         release_injector.set()
         await protocol_handler.wait_for_pending_reciprocals()
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -463,6 +463,58 @@ class TestTextMessageHandler:
         assert len(res) == 1
         assert res[0][1] == TXT_ACK_DELAY_MS / 1000.0
 
+    def _flood_ack_inner(self, pkt, sender, shared):
+        """Decrypt the inner payload of the PATH-return ACK built for ``pkt``."""
+        res = self.handler._build_ack_responses(
+            packet=pkt,
+            matched_contact=MockContact(public_key=sender.get_public_key().hex()),
+            shared_secret=shared,
+            pubkey=sender.get_public_key(),
+            ack_hash=bytes(range(6)),
+            is_flood=True,
+        )
+        return CryptoUtils.mac_then_decrypt(shared[:16], shared, bytes(res[0][0].payload[2:]))
+
+    def test_flood_ack_path_return_preserves_multibyte_hash_width(self):
+        """The taught path keeps the DM's declared width and is trimmed to it.
+
+        The path bytes and the path_len declaring their width are one decision:
+        taking the whole buffer while declaring only the first two hops makes
+        create_path_return reject the pair.
+        """
+        sender = LocalIdentity()
+        shared = Identity(sender.get_public_key()).calc_shared_secret(
+            self.local_identity.get_private_key()
+        )
+        pkt = Packet()
+        # 2 hops of 2-byte hashes, plus slack the declared length excludes.
+        pkt.path = bytearray([0xA1, 0xA2, 0xB1, 0xB2, 0xFF, 0xFF])
+        pkt.path_len = PathUtils.encode_path_len(2, 2)
+
+        plaintext = self._flood_ack_inner(pkt, sender, shared)
+        assert plaintext[0] == PathUtils.encode_path_len(2, 2)
+        assert plaintext[1:5] == bytes([0xA1, 0xA2, 0xB1, 0xB2])
+        assert plaintext[5] == PAYLOAD_TYPE_ACK  # extra_type
+
+    def test_flood_ack_path_return_drops_a_path_of_undecodable_width(self):
+        """An undecodable path_len teaches no path rather than guessing a width.
+
+        Unreachable from the wire — Packet.from_bytes rejects an invalid
+        path_len — but the two halves must stay consistent regardless of how the
+        packet was constructed.
+        """
+        sender = LocalIdentity()
+        shared = Identity(sender.get_public_key()).calc_shared_secret(
+            self.local_identity.get_private_key()
+        )
+        pkt = Packet()
+        pkt.path = bytearray([0x01, 0x02, 0x03, 0x04])
+        pkt.path_len = 0xFF  # hash_size 4 is reserved: no decodable width
+
+        plaintext = self._flood_ack_inner(pkt, sender, shared)
+        assert plaintext[0] == 0  # zero hops, nothing taught
+        assert plaintext[1] == PAYLOAD_TYPE_ACK
+
     @pytest.mark.asyncio
     async def test_received_text_stops_at_first_nul(self):
         """The delivered message text ends at the first NUL: AES zero padding and the
@@ -1659,6 +1711,48 @@ class TestProtocolRequestHandler:
         assert r.response is not None
         assert client.last_timestamp == 500
 
+    @pytest.mark.asyncio
+    async def test_direct_req_flood_fallback_accumulates_at_request_hash_width(self):
+        """With no out_path the RESPONSE floods at the REQ's hash width.
+
+        Firmware: sendFloodReply(reply, SERVER_RESPONSE_DELAY,
+        packet->getPathHashSize()) (simple_repeater onPeerDataRecv, the
+        OUT_PATH_UNKNOWN branch). A DIRECT request that reached us has had its
+        hops consumed, but removeSelfFromPath only decrements the count, so
+        path_len bits 6-7 still carry the width it was routed at.
+        """
+        handler, client, build_req = self._req_handler_with_client()
+        assert client.out_path_len == -1  # no known route: forces the flood fallback
+
+        pkt = build_req(1000)
+        pkt.path_len = PathUtils.encode_path_len(3, 0)  # 3-byte hashes, hops consumed
+
+        reply = (await handler(pkt)).response
+        assert reply.get_route_type() == ROUTE_TYPE_FLOOD
+        assert PathUtils.get_path_hash_size(reply.path_len) == 3
+        assert PathUtils.get_path_hash_count(reply.path_len) == 0
+        # Marked so the dispatcher's node default cannot stamp over the mirror
+        # (see test_dispatcher.py: applied marker is not overwritten).
+        assert getattr(reply, "_path_hash_mode_applied", False) is True
+
+    @pytest.mark.asyncio
+    async def test_direct_req_reply_keeps_the_out_path_hash_width(self):
+        """A routed reply keeps its out_path's width; the mirror is flood-only.
+
+        The out_path here is zero-hop, so nothing but the branch guard stops the
+        mirror from rewriting a path_len that belongs to the stored route.
+        """
+        handler, client, build_req = self._req_handler_with_client()
+        client.out_path = b""
+        client.out_path_len = PathUtils.encode_path_len(2, 0)  # zero-hop, 2-byte hashes
+
+        pkt = build_req(1000)
+        pkt.path_len = PathUtils.encode_path_len(3, 0)  # request used a different width
+
+        reply = (await handler(pkt)).response
+        assert reply.get_route_type() == ROUTE_TYPE_DIRECT
+        assert reply.path_len == PathUtils.encode_path_len(2, 0)
+
     def test_advance_client_watermark_is_monotonic(self):
         """The watermark never moves backwards: if another accepted request
         advanced it between the replay check and the write, an older (but
@@ -2188,6 +2282,60 @@ class TestLoginServerHandler:
         assert plaintext[1] == 0xAA
         assert plaintext[2] == 0xBB
         assert plaintext[3] == PAYLOAD_TYPE_RESPONSE  # extra_type
+
+    @pytest.mark.asyncio
+    async def test_flood_login_reply_accumulates_at_request_hash_width(self):
+        """The PATH-return accumulates hops at the *request's* hash width.
+
+        Firmware: sendFloodReply(path, SERVER_RESPONSE_DELAY,
+        packet->getPathHashSize()) (simple_repeater onAnonDataRecv). The reply's
+        own path_len declares the width repeaters use on the way back, which is
+        separate from the width declared for the path carried inside it.
+        """
+        pkt = self._build_login_packet(
+            password="admin123", route_type="flood", path=[0xAA, 0xBB, 0xCC, 0xDD]
+        )
+        pkt.path_len = PathUtils.encode_path_len(2, 2)  # 2 hops of 2-byte hashes
+
+        await self.handler(pkt)
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.get_payload_type() == PAYLOAD_TYPE_PATH
+        # Outer: reply starts at zero hops but declares the inbound width.
+        assert PathUtils.get_path_hash_size(response_pkt.path_len) == 2
+        assert PathUtils.get_path_hash_count(response_pkt.path_len) == 0
+        # Marked so the dispatcher's node default cannot stamp over the mirror
+        # (see test_dispatcher.py: applied marker is not overwritten).
+        assert getattr(response_pkt, "_path_hash_mode_applied", False) is True
+
+        # Inner: the taught path keeps its own 2-byte declaration and bytes.
+        client_id = Identity(self.client_identity_local.get_public_key())
+        shared_secret = client_id.calc_shared_secret(self.server_identity.get_private_key())
+        plaintext = CryptoUtils.mac_then_decrypt(
+            shared_secret[:16], shared_secret, bytes(response_pkt.payload[2:])
+        )
+        assert plaintext[0] == PathUtils.encode_path_len(2, 2)
+        assert plaintext[1:5] == bytes([0xAA, 0xBB, 0xCC, 0xDD])
+
+    @pytest.mark.asyncio
+    async def test_direct_login_flood_reply_accumulates_at_request_hash_width(self):
+        """The direct-login flood RESPONSE mirrors the width too.
+
+        Firmware runs this branch through the same sendFloodReply(...,
+        packet->getPathHashSize()) call (simple_repeater onAnonDataRecv, the
+        ``reply_path_len < 0`` case). A direct request that reached us has had
+        its hops consumed but still carries the width in path_len bits 6-7.
+        """
+        pkt = self._build_login_packet(password="admin123", route_type="direct")
+        pkt.path_len = PathUtils.encode_path_len(3, 0)  # 3-byte hashes, hops consumed
+
+        await self.handler(pkt)
+
+        response_pkt, _ = self.sent_packets[0]
+        assert response_pkt.get_payload_type() == PAYLOAD_TYPE_RESPONSE
+        assert PathUtils.get_path_hash_size(response_pkt.path_len) == 3
+        assert PathUtils.get_path_hash_count(response_pkt.path_len) == 0
+        assert getattr(response_pkt, "_path_hash_mode_applied", False) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -867,7 +867,9 @@ class TestAdvertHandler:
 
     @pytest.mark.asyncio
     async def test_advert_handler_ignores_self_advert(self):
-        """Test that handler processes self-advert (dispatcher handles filtering)."""
+        """Without a local identity the handler cannot know an advert is its own,
+        so it parses normally (the registry always supplies one — see
+        test_advert_handler_drops_self_advert_when_identity_known)."""
         local_identity = LocalIdentity()
         packet = PacketBuilder.create_advert(local_identity, "SelfNode")
 
@@ -876,6 +878,57 @@ class TestAdvertHandler:
         # Handler should still return parsed data; dispatcher filters self-adverts
         assert result is not None
         assert result["name"] == "SelfNode"
+
+    @pytest.mark.asyncio
+    async def test_advert_handler_drops_self_advert_when_identity_known(self):
+        """Mesh::onRecvPacket (Mesh.cpp:263) never reads our own advert back in."""
+        local_identity = LocalIdentity()
+        event_service = MockEventService()
+        handler = AdvertHandler(
+            self.log_fn, event_service=event_service, local_identity=local_identity
+        )
+        packet = PacketBuilder.create_advert(local_identity, "SelfNode")
+
+        result = await handler(packet)
+
+        assert result is None
+        event_service.publish_sync.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_advert_is_still_retransmittable(self):
+        """The self-advert guard is read-side only: it never marks the packet, so
+        the forwarding decision stays what it is for a freshly parsed copy."""
+        local_identity = LocalIdentity()
+        handler = AdvertHandler(self.log_fn, local_identity=local_identity)
+        packet = PacketBuilder.create_advert(local_identity, "SelfNode")
+        fresh = Packet()
+        assert fresh.read_from(packet.write_to())
+
+        assert await handler(packet) is None
+
+        assert packet.is_marked_do_not_retransmit() == fresh.is_marked_do_not_retransmit()
+        assert packet.is_marked_do_not_retransmit() is False
+
+    def test_registry_wires_local_identity_into_the_advert_handler(self):
+        """The factory is the only place production code supplies the identity, so
+        if this kwarg is ever dropped the self-advert guard goes inert everywhere
+        (Dispatcher, CompanionBridge, CompanionRadio) with the suite still green."""
+        from openhop_core.companion.contact_store import ContactStore
+        from openhop_core.node.handlers.registry import create_core_handlers
+
+        identity = LocalIdentity()
+
+        handlers = create_core_handlers(
+            identity=identity,
+            contacts=ContactStore(5),
+            channels=None,
+            event_service=None,
+            send_packet_fn=lambda *a, **k: None,
+            log_fn=self.log_fn,
+            node_name="test",
+        )
+
+        assert handlers.advert_handler.local_identity is identity
 
     def test_decode_appdata_rejects_truncated_optional_fields(self):
         with pytest.raises(ValueError, match="truncated"):

--- a/tests/test_kiss_modem_wrapper.py
+++ b/tests/test_kiss_modem_wrapper.py
@@ -715,7 +715,7 @@ class TestCommandResponses:
             RESP_VERSION,
             RESP_STATS,
         ]
-        assert [entry[1] for entry in modem._response_queue] == [b"\xAA", b"\x01", b"\x02"]
+        assert [entry[1] for entry in modem._response_queue] == [b"\xaa", b"\x01", b"\x02"]
 
     def test_tx_done_response(self):
         """Test SetHardware TxDone (0xF8) response sets event"""
@@ -1151,7 +1151,7 @@ class TestSerialWriteSerialization:
         modem.serial_conn = serial_conn
 
         stop_event = threading.Event()
-        data_frame = modem._encode_kiss_frame(CMD_DATA, b"\xAA\xBB\xCC")
+        data_frame = modem._encode_kiss_frame(CMD_DATA, b"\xaa\xbb\xcc")
 
         def data_tx_worker() -> None:
             for _ in range(200):
@@ -1282,7 +1282,7 @@ class TestSerialWriteSerialization:
         modem.serial_conn = serial_conn
         modem._start_reconnect_worker = MagicMock()
 
-        frame = modem._encode_kiss_frame(CMD_DATA, b"\xAA\xBB")
+        frame = modem._encode_kiss_frame(CMD_DATA, b"\xaa\xbb")
         assert modem._write_frame(frame) is False
         assert modem._degraded is True
         assert modem.is_connected is False
@@ -2414,6 +2414,203 @@ class TestBulkDecodeEquivalence:
                 chunks.append(size)
                 remaining -= size
             self._assert_equiv(stream, chunks)
+
+
+class TestWorkerFailureDuringReconnectWindow:
+    """A worker failure must never be silent just because a reconnect is underway.
+
+    ``_reconnect_loop`` starts the RX/TX workers with ``is_connected`` still
+    False and only sets it True after readiness plus the SetHardware handshake.
+    Gating the workers' error handler on ``is_connected`` therefore silenced
+    exactly the window in which a freshly reopened USB device is most likely to
+    fail: the thread died with no log and no failure marked, nothing re-armed a
+    reconnect, and the node went permanently deaf while the log read "KISS modem
+    serial reconnect successful". Seen in the field after two processes briefly
+    contended for the port, and reproduced here.
+    """
+
+    class _FailingSerial:
+        """An open port whose first read raises, as a just-reopened device can."""
+
+        def __init__(self):
+            self.is_open = True
+            self._failed = False
+            self.raised = threading.Event()
+
+        def read(self, n=1):
+            if not self._failed:
+                self._failed = True
+                self.raised.set()
+                raise OSError("device reports readiness to read but returned no data")
+            time.sleep(0.01)
+            return b""
+
+        @property
+        def in_waiting(self):
+            return 0
+
+        def close(self):
+            self.is_open = False
+
+    def _run_worker_until_failure(self, is_connected: bool):
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        fake = self._FailingSerial()
+        modem.serial_conn = fake
+        modem.is_connected = is_connected
+        failures = []
+        modem._mark_serial_failure = lambda reason: failures.append(reason)
+
+        worker = threading.Thread(target=modem._rx_worker, daemon=True)
+        worker.start()
+        assert fake.raised.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        return failures
+
+    def test_rx_failure_is_marked_inside_the_reconnect_window(self):
+        """is_connected is False there; the failure must still arm a reconnect."""
+        failures = self._run_worker_until_failure(is_connected=False)
+        assert failures, "RX died silently: nothing will ever reconnect"
+
+    def test_rx_failure_is_marked_in_steady_state_too(self):
+        failures = self._run_worker_until_failure(is_connected=True)
+        assert failures
+
+    def test_rx_failure_is_silent_only_while_deliberately_stopping(self):
+        """Teardown must stay quiet — that is what the old gate was protecting."""
+        for attr, value in (("_shutting_down", True), ("stop_event", None)):
+            modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+            fake = self._FailingSerial()
+            modem.serial_conn = fake
+            modem.is_connected = True
+            failures = []
+            modem._mark_serial_failure = lambda reason: failures.append(reason)
+            if attr == "stop_event":
+                modem.stop_event.set()
+            else:
+                setattr(modem, attr, value)
+
+            worker = threading.Thread(target=modem._rx_worker, daemon=True)
+            worker.start()
+            worker.join(timeout=2.0)
+            assert not worker.is_alive()
+            assert failures == [], f"teardown via {attr} should not report a failure"
+
+
+class TestReconnectRequiresLiveReader:
+    """A (re)connect must not be reported as successful with a dead reader.
+
+    The workers are started before readiness and the SetHardware handshake run,
+    so an RX failure inside that window used to leave a dead reader behind while
+    the caller logged "reconnect successful" — is_connected True, no error, no
+    retry, and no further packet ever delivered.
+    """
+
+    class _ReadFailsSerial:
+        def __init__(self):
+            self.is_open = True
+            self.raised = threading.Event()
+
+        def read(self, n=1):
+            self.raised.set()
+            raise OSError("device reports readiness to read but returned no data")
+
+        @property
+        def in_waiting(self):
+            return 0
+
+        def close(self):
+            self.is_open = False
+
+    def test_open_reports_failure_when_the_reader_dies_during_startup(self):
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        fake = self._ReadFailsSerial()
+        modem._mark_serial_failure = lambda reason: None
+
+        def _ready():
+            assert fake.raised.wait(timeout=2.0)  # let the reader die first
+            modem.rx_thread.join(timeout=2.0)
+            return True
+
+        with patch(
+            "openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake
+        ), patch.object(modem, "_wait_for_modem_ready", side_effect=_ready):
+            assert modem._open_serial_and_start_threads() is False
+
+    def test_open_reports_success_when_the_reader_survives(self):
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+
+        class QuietSerial:
+            is_open = True
+
+            def read(self, n=1):
+                time.sleep(0.01)
+                return b""
+
+            @property
+            def in_waiting(self):
+                return 0
+
+            def close(self):
+                type(self).is_open = False
+
+        fake = QuietSerial()
+        try:
+            with patch(
+                "openhop_core.hardware.kiss_modem_wrapper.serial.Serial", return_value=fake
+            ), patch.object(modem, "_wait_for_modem_ready", return_value=True):
+                assert modem._open_serial_and_start_threads() is True
+                assert modem.rx_thread.is_alive()
+        finally:
+            modem.stop_event.set()
+            fake.close()
+            if modem.rx_thread:
+                modem.rx_thread.join(timeout=2)
+
+
+class TestStopIoThreadsEndsThePreviousGeneration:
+    def test_stop_io_threads_closes_the_port_so_a_blocked_reader_exits(self):
+        """Joining alone let a reader blocked in read() outlive the join.
+
+        _mark_serial_failure defers closing the port when the connection lock is
+        busy, so the reconnect path could reach _stop_io_threads with the old
+        port still open and a worker parked in read(). It survived the 0.5s join
+        and kept decoding into the same KISS buffer as the new generation.
+        """
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+
+        class BlockingSerial:
+            def __init__(self):
+                self.is_open = True
+                self.entered = threading.Event()
+
+            def read(self, n=1):
+                self.entered.set()
+                while self.is_open:
+                    time.sleep(0.005)
+                raise OSError("port closed")
+
+            @property
+            def in_waiting(self):
+                return 0
+
+            def close(self):
+                self.is_open = False
+
+        fake = BlockingSerial()
+        modem.serial_conn = fake
+        modem.is_connected = True
+        modem._mark_serial_failure = lambda reason: None
+
+        reader = threading.Thread(target=modem._rx_worker, daemon=True)
+        modem.rx_thread = reader
+        reader.start()
+        assert fake.entered.wait(timeout=2.0)
+
+        modem._stop_io_threads(join_timeout=2.0)
+
+        assert fake.is_open is False, "the port was left open, so the reader kept running"
+        assert not reader.is_alive(), "the previous generation reader outlived the stop"
 
 
 class TestRxCallbackDisarmRace:

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -22,6 +22,18 @@ def test_packet_creation():
     assert packet.get_payload() == test_payload
 
 
+def test_packet_carries_an_injected_origin_hash_slot():
+    """A downstream router tags a locally injected packet with the companion that
+    originated it, so the fan-out can withhold it from that bridge.  Packet defines
+    __slots__ and has no __dict__, so the attribute must be declared here or the
+    assignment raises AttributeError in the consumer at run time."""
+    packet = Packet()
+    assert packet._injected_origin_hash is None
+
+    packet._injected_origin_hash = "0x1a"
+    assert packet._injected_origin_hash == "0x1a"
+
+
 def test_packet_validation():
     """Test packet validation."""
     packet = Packet()

--- a/tests/test_packet_builder.py
+++ b/tests/test_packet_builder.py
@@ -203,9 +203,28 @@ def test_packet_builder_create_path_return_encoded_path_len():
     assert decrypted[5] == 0xFF  # extra_type
 
 
-def test_packet_builder_create_path_return_no_encoded_uses_len_path():
-    """When path_len_encoded is None, first byte is len(path) (1-byte hash semantics)."""
-    path = [0x11, 0x22, 0x33]  # 3 bytes
+def test_packet_builder_create_path_return_requires_encoded_len_for_nonempty_path():
+    """A non-empty path without path_len_encoded is ambiguous, so it must raise.
+
+    3 bytes is either three 1-byte hashes or one 3-byte hash, and guessing
+    wrong teaches the peer a route that resolves to nobody until a flood login
+    resets it (firmware onPeerPathRecv stores the taught path verbatim).
+    """
+    with pytest.raises(ValueError, match="path_len_encoded is required"):
+        PacketBuilder.create_path_return(
+            dest_hash=0x01,
+            src_hash=0x02,
+            secret=bytes(32),
+            path=[0x11, 0x22, 0x33],
+            extra_type=0xFF,
+            extra=b"",
+            path_len_encoded=None,
+        )
+
+
+def test_packet_builder_create_path_return_one_byte_hashes_declared_explicitly():
+    """1-byte hashes still work; the caller just has to say so."""
+    path = [0x11, 0x22, 0x33]  # three 1-byte hashes
     secret = bytes(32)
     pkt = PacketBuilder.create_path_return(
         dest_hash=0x01,
@@ -214,15 +233,45 @@ def test_packet_builder_create_path_return_no_encoded_uses_len_path():
         path=path,
         extra_type=0xFF,
         extra=b"",
-        path_len_encoded=None,
+        path_len_encoded=PathUtils.encode_path_len(1, 3),
     )
     aes_key = secret[:16]
     decrypted = CryptoUtils.mac_then_decrypt(aes_key, secret, bytes(pkt.payload[2:]))
-    assert decrypted[0] == 3
+    assert PathUtils.get_path_hash_size(decrypted[0]) == 1
+    assert PathUtils.get_path_hash_count(decrypted[0]) == 3
     assert decrypted[1:4] == bytes(path)
     # No extra payload: 0xFF dummy type followed by 4 random uniqueness bytes.
     assert decrypted[4] == 0xFF
     assert len(decrypted) >= 4 + 1 + 4
+
+
+def test_packet_builder_create_path_return_empty_path_needs_no_encoded_len():
+    """An empty path is unambiguous, so path_len_encoded stays optional."""
+    secret = bytes(32)
+    pkt = PacketBuilder.create_path_return(
+        dest_hash=0x01,
+        src_hash=0x02,
+        secret=secret,
+        path=[],
+        extra_type=0xFF,
+        extra=b"",
+    )
+    decrypted = CryptoUtils.mac_then_decrypt(secret[:16], secret, bytes(pkt.payload[2:]))
+    assert decrypted[0] == 0
+
+
+def test_packet_builder_create_path_return_rejects_invalid_encoded_len():
+    """An invalid encoded path_len must raise, not fall back to a byte count."""
+    with pytest.raises(ValueError, match="invalid path_len_encoded"):
+        PacketBuilder.create_path_return(
+            dest_hash=0x01,
+            src_hash=0x02,
+            secret=bytes(32),
+            path=[0x11] * 4,
+            extra_type=0xFF,
+            extra=b"",
+            path_len_encoded=0xFF,  # hash_size 4 is reserved
+        )
 
 
 def test_packet_builder_create_path_return_empty_extra_is_unique():
@@ -230,7 +279,14 @@ def test_packet_builder_create_path_return_empty_extra_is_unique():
     matching MeshCore Mesh::createPathReturn."""
     path = [0x11, 0x22, 0x33]
     secret = bytes(32)
-    kwargs = dict(dest_hash=0x01, src_hash=0x02, secret=secret, path=path, extra=b"")
+    kwargs = dict(
+        dest_hash=0x01,
+        src_hash=0x02,
+        secret=secret,
+        path=path,
+        extra=b"",
+        path_len_encoded=PathUtils.encode_path_len(1, 3),
+    )
     a = PacketBuilder.create_path_return(**kwargs)
     b = PacketBuilder.create_path_return(**kwargs)
     assert bytes(a.payload) != bytes(b.payload)

--- a/tests/test_path_ack_handler.py
+++ b/tests/test_path_ack_handler.py
@@ -119,6 +119,7 @@ async def test_path_ack_accepts_return_paths_larger_than_one_cipher_block():
         path=list(range(11)),
         extra_type=PAYLOAD_TYPE_ACK,
         extra=ack_crc.to_bytes(4, "little"),
+        path_len_encoded=PathUtils.encode_path_len(1, 11),
     )
     assert len(packet.payload) == 36
 
@@ -140,6 +141,7 @@ async def test_path_response_does_not_complete_ack_from_matching_path_bytes():
         path=ack_crc.to_bytes(4, "little"),
         extra_type=PAYLOAD_TYPE_RESPONSE,
         extra=b"data",
+        path_len_encoded=PathUtils.encode_path_len(1, 4),
     )
     assert len(packet.payload) == 20
 

--- a/tests/test_protocol_utils.py
+++ b/tests/test_protocol_utils.py
@@ -1,0 +1,24 @@
+"""Tests for shared protocol helpers in openhop_core.protocol.utils."""
+
+from openhop_core.protocol import LocalIdentity
+from openhop_core.protocol.constants import PUB_KEY_SIZE
+from openhop_core.protocol.utils import is_self_advert
+
+
+def test_is_self_advert_matches_only_the_full_public_key():
+    """Mesh::onRecvPacket compares the whole key (Mesh.cpp:263), not a prefix."""
+    identity = LocalIdentity()
+    self_key = identity.get_public_key()
+    payload = self_key + b"\x78\x56\x34\x12" + b"\x00" * 64 + b"\x81SelfNode"
+
+    assert is_self_advert(payload, self_key) is True
+
+    other_key = bytearray(self_key)
+    other_key[-1] ^= 0x01
+    assert is_self_advert(bytes(other_key) + payload[PUB_KEY_SIZE:], self_key) is False
+
+    # A payload too short to hold a full public key can never be ours.
+    assert is_self_advert(self_key[:-1], self_key) is False
+
+    # No identity to compare against: never claim the advert.
+    assert is_self_advert(payload, b"") is False

--- a/tests/test_return_path_teacher.py
+++ b/tests/test_return_path_teacher.py
@@ -18,7 +18,7 @@ from openhop_core.companion.models import Contact
 from openhop_core.node.handlers.login_response import LoginResponseHandler
 from openhop_core.node.handlers.protocol_response import ProtocolResponseHandler
 from openhop_core.node.handlers.registry import create_core_handlers
-from openhop_core.node.handlers.return_path import ReturnPathTeacher, reverse_path
+from openhop_core.node.handlers.return_path import ReturnPathTeacher
 from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_PATH,
@@ -155,40 +155,6 @@ async def _teach_flood(teacher, **kwargs):
     )
     await teacher.wait_for_pending()
     return sent
-
-
-# --------------------------------------------------------------------------- #
-# reverse_path
-# --------------------------------------------------------------------------- #
-
-
-def test_reverse_path_reverses_whole_hashes_not_bytes():
-    """A 2-byte-hash path must reverse hop order, keeping each hash intact."""
-    path = bytes([0x11, 0x22, 0x33, 0x44])
-    assert reverse_path(path, PathUtils.encode_path_len(2, 2)) == bytes([0x33, 0x44, 0x11, 0x22])
-    # Byte-wise reversal would give 44332211 and corrupt every hop.
-
-
-def test_reverse_path_three_byte_hashes():
-    path = bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
-    assert reverse_path(path, PathUtils.encode_path_len(3, 2)) == bytes(
-        [0x04, 0x05, 0x06, 0x01, 0x02, 0x03]
-    )
-
-
-def test_reverse_path_single_byte_hashes():
-    assert reverse_path(bytes([0xA1, 0xB2, 0xC3]), PathUtils.encode_path_len(1, 3)) == bytes(
-        [0xC3, 0xB2, 0xA1]
-    )
-
-
-def test_reverse_path_zero_hop_is_empty_not_none():
-    """A zero-hop path is valid (direct neighbour), distinct from malformed."""
-    assert reverse_path(b"", 0) == b""
-
-
-def test_reverse_path_rejects_length_mismatch():
-    assert reverse_path(bytes([0xAA]), PathUtils.encode_path_len(1, 3)) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -409,7 +375,12 @@ def test_recorded_copies_are_pruned_by_ttl():
 
 
 # --------------------------------------------------------------------------- #
-# Hop-penalized selection (a strong nearby repeater must not add a needless hop)
+# Copy selection by decodability margin, then hop count
+#
+# LoRa decodes on SNR margin over the demodulator limit, not on absolute RSSI:
+# measured here, four copies of one reply spanned 86 dB of RSSI while all
+# reported ~+11.5 dB SNR, i.e. all equally decodable. So dB only decide inside
+# the waterfall; above it, hop count does.
 # --------------------------------------------------------------------------- #
 
 
@@ -501,21 +472,87 @@ async def test_materially_stronger_one_hop_copy_beats_tenuous_zero_hop_copy():
 
 
 @pytest.mark.asyncio
-async def test_longer_route_wins_when_it_is_materially_stronger():
-    """When the shorter route's final hop is genuinely weak, the extra hop is
-    earned: a 3-hop copy at -13 beats a 2-hop copy at -60."""
+async def test_longer_route_wins_only_when_the_shorter_one_is_marginal():
+    """A hop is bought when the short route is inside the waterfall, not merely
+    when the long route reads stronger.
+
+    -60 dBm is ~55 dB above this mesh's decode threshold, so under the threshold
+    model the 2-hop copy is reliable and hop count decides. Only when the shorter
+    copy drops into the steep region does the extra hop earn its place.
+    """
     teacher = _teacher(injector=_Injector())
+    # Both reliable: fewest hops wins even though the 3-hop copy is 47 dB stronger.
     embedded = await _teach_choosing_between(teacher, short_rssi=-60, long_rssi=-13)
+    assert embedded == SHORT_2HOP
+
+    # Now the 2-hop copy is marginal (-114 dBm is ~1.5 dB of margin against the
+    # assumed -108 floor at SF7), so the reliable 3-hop copy takes over.
+    teacher2 = _teacher(injector=_Injector())
+    embedded = await _teach_choosing_between(teacher2, short_rssi=-114, long_rssi=-13)
     assert embedded == LONG_3HOP
 
 
 @pytest.mark.asyncio
-async def test_zero_penalty_restores_pure_best_rssi():
-    """With the penalty disabled, selection is pure last-hop RSSI again, so the
-    stronger 3-hop copy wins even for a 2 dB edge."""
-    teacher = _teacher(injector=_Injector(), hop_penalty_db=0.0)
-    embedded = await _teach_choosing_between(teacher, short_rssi=-15, long_rssi=-13)
-    assert embedded == LONG_3HOP
+async def test_extra_db_above_the_waterfall_never_buys_a_hop():
+    """Two reliable copies: no RSSI gap, however large, promotes the longer one."""
+    for long_rssi in (-13, -5, 0):
+        teacher = _teacher(injector=_Injector())
+        embedded = await _teach_choosing_between(teacher, short_rssi=-70, long_rssi=long_rssi)
+        assert embedded == SHORT_2HOP, f"a {long_rssi} dBm 3-hop copy displaced a healthy 2-hop"
+
+
+def test_copy_below_the_demod_floor_is_not_recorded_at_all():
+    """Below the waterfall a copy is not a route, so it is not a candidate.
+
+    At SF7 the demodulator limit is -7.5 dB SNR; against the assumed -108 dBm
+    floor that puts the decode threshold near -115.5 dBm.
+    """
+    teacher = _teacher()
+    base = _response_packet(flood=True)
+    teacher.note_flood_copy(_copy_of(base, in_path=SHORT_2HOP, rssi=-120, len_byte=SHORT_2HOP_LEN))
+    assert teacher._recent_copies == {}
+
+    teacher.note_flood_copy(_copy_of(base, in_path=SHORT_2HOP, rssi=-100, len_byte=SHORT_2HOP_LEN))
+    assert len(teacher._recent_copies) == 1
+
+
+def test_margin_uses_snr_when_it_is_the_pessimistic_estimate():
+    """SNR is the real decodability measure; RSSI is the fallback.
+
+    A copy can look strong in RSSI while its SNR says it is barely decodable
+    (a loud interferer raises both). The pessimistic estimate must win, so such a
+    copy is not treated as reliable.
+    """
+    teacher = _teacher()
+    limit = teacher._demod_limit_db()  # -7.5 at SF7
+
+    strong_rssi_bad_snr = teacher._copy_margin_db(rssi=-20, snr=limit + 1.0)
+    assert strong_rssi_bad_snr == pytest.approx(1.0)  # SNR binds, not the -20 dBm
+
+    weak_rssi_good_snr = teacher._copy_margin_db(rssi=-120, snr=limit + 20.0)
+    assert weak_rssi_good_snr < 0  # RSSI binds
+
+
+def test_margin_tracks_the_spreading_factor():
+    """The same signal is more decodable at a higher SF, so the limit must follow
+    the radio rather than being baked in."""
+    sf = {"v": 7}
+    teacher = _teacher(sf_getter=lambda: sf["v"])
+    assert teacher._demod_limit_db() == pytest.approx(-7.5)
+
+    at_sf7 = teacher._copy_margin_db(rssi=-40, snr=-6.0)
+    sf["v"] = 12
+    at_sf12 = teacher._copy_margin_db(rssi=-40, snr=-6.0)
+    assert at_sf7 == pytest.approx(1.5)  # marginal at SF7
+    assert at_sf12 == pytest.approx(14.0)  # comfortable at SF12
+    assert at_sf12 > teacher._reliable_margin_db > at_sf7
+
+
+def test_unknown_spreading_factor_falls_back_to_sf7():
+    teacher = _teacher(sf_getter=lambda: 99)
+    assert teacher._demod_limit_db() == pytest.approx(-7.5)
+    broken = _teacher(sf_getter=lambda: (_ for _ in ()).throw(RuntimeError("no radio")))
+    assert broken._demod_limit_db() == pytest.approx(-7.5)
 
 
 # --------------------------------------------------------------------------- #
@@ -593,69 +630,41 @@ async def test_failed_inject_releases_cooldown_for_the_next_trigger():
 
 
 # --------------------------------------------------------------------------- #
-# Reverse-of-out_path hardening (no firmware equivalent)
+# No guessing: only observed paths are ever taught
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.asyncio
-async def test_reverse_teach_embeds_reversed_out_path():
-    """With nothing inbound to learn from, assume a symmetric route. Uses 2-byte
-    hashes so a byte-wise reversal would not pass."""
-    out_path = bytes([0x11, 0x22, 0x33, 0x44])
-    out_len = PathUtils.encode_path_len(2, 2)
-    injector = _Injector()
-    teacher = _teacher(contacts=_contacts(out_path, out_len), injector=injector)
+def test_teacher_exposes_no_way_to_teach_an_unobserved_path():
+    """The symmetry guess is gone, not merely unused.
 
-    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is True
-    await teacher.wait_for_pending()
-
-    teach = injector.packets[0]
-    assert teach.get_route_type() == ROUTE_TYPE_DIRECT
-    assert bytes(teach.path) == out_path  # still routed outward along out_path
-    _, embedded_path = _decode_teach(teach)
-    assert embedded_path == bytes([0x33, 0x44, 0x11, 0x22])
+    An earlier revision taught the reverse of our own out_path on a request
+    timeout. Real routes are frequently asymmetric, and onPeerPathRecv overwrites
+    client->out_path unconditionally, so a wrong guess replaced a working route
+    with a dead one and the peer then answered DIRECT into a void — with no flood
+    reply left to correct it. The timeout case is handled by flooding the retry
+    (_SendOpsMixin._build_retry_packet) so a real inbound path can be observed.
+    """
+    teacher = _teacher()
+    assert not hasattr(teacher, "maybe_teach_reverse_of_out_path")
+    # The only public teach trigger takes a received packet to learn from.
+    assert hasattr(teacher, "maybe_teach_from_flood_reply")
 
 
 @pytest.mark.asyncio
-async def test_reverse_teach_skipped_without_known_out_path():
-    injector = _Injector()
-    teacher = _teacher(contacts=_contacts(out_path=b"", out_path_len=-1), injector=injector)
-    assert not await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout")
-    assert injector.packets == []
-
-
-@pytest.mark.asyncio
-async def test_reverse_teach_never_overwrites_an_evidence_derived_teach():
-    """THE regression guard. The peer applies whichever path it received last
-    (MyMesh::onPeerPathRecv overwrites unconditionally). If a merely slow first
-    attempt let the symmetry guess replace the route we learned from a real
-    inbound path, and the guess is wrong, the peer would reply into a void — no
-    flood reply would ever arrive again, so nothing could re-teach it. That is
-    strictly worse than never having guessed."""
-    clock = {"t": 0.0}
+async def test_note_evidence_teach_claims_the_cooldown():
+    """Another handler's teach suppresses an immediate duplicate from this one."""
+    clock = {"t": 1000.0}
     injector = _Injector()
     teacher = _teacher(injector=injector, cooldown_s=5.0, time_fn=lambda: clock["t"])
 
-    assert await _teach_flood(teacher) is True
-    _, embedded = _decode_teach(injector.packets[0])
-    assert embedded == IN_PATH
-
-    # Well past the cooldown: only the evidence guard can stop this.
-    clock["t"] += 3600.0
-    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is False
-    await teacher.wait_for_pending()
-    assert len(injector.packets) == 1, "the symmetry guess clobbered a known-good route"
-
-
-@pytest.mark.asyncio
-async def test_note_evidence_teach_blocks_the_reverse_guess():
-    injector = _Injector()
-    teacher = _teacher(injector=injector)
-
     teacher.note_evidence_teach(PEER_KEY)
-
-    assert await teacher.maybe_teach_reverse_of_out_path(PEER_KEY, reason="timeout") is False
+    clock["t"] += 1.0
+    assert await _teach_flood(teacher) is False
     assert injector.packets == []
+
+    clock["t"] += 5.0
+    assert await _teach_flood(teacher) is True
+    assert len(injector.packets) == 1
 
 
 def _flood_path_packet(inner_path=OUT_PATH, inner_len=OUT_PATH_LEN):
@@ -679,29 +688,178 @@ def _flood_path_packet(inner_path=OUT_PATH, inner_len=OUT_PATH_LEN):
 
 
 @pytest.mark.asyncio
-async def test_flood_path_reciprocal_reports_itself_and_blocks_the_reverse_guess():
-    """End-to-end: the pre-existing flood-PATH reciprocal teaches from a real
-    inbound path. If ProtocolResponseHandler did not report it, a normal flood
-    login would leave the symmetry guess free to overwrite a correct route on
-    the very first retry — with no cooldown involved."""
+async def test_flood_path_reciprocal_reports_itself_to_the_teacher():
+    """End-to-end: the flood-PATH reciprocal teaches from a real inbound path and
+    reports itself, so the teacher does not immediately send a second teach for
+    the same contact and route."""
     injector = _Injector()
     handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
     handler.set_packet_injector(injector)
+    # No settle: the corrective re-teach has its own tests below.
+    handler.return_path_teacher._settle_s = 0.0
 
     await handler(_flood_path_packet())
     await handler.wait_for_pending_reciprocals()
     await handler.return_path_teacher.wait_for_pending()
 
     # Exactly one packet: the reciprocal. The RESPONSE-branch teach must not
-    # also fire for a PATH packet.
+    # also fire for a PATH packet, and with no better copy recorded the
+    # corrective re-teach must transmit nothing.
+    assert len(injector.packets) == 1
+    assert PEER_KEY in handler.return_path_teacher._last_taught
+
+    # A flood RESPONSE arriving inside the cooldown is not re-taught.
+    assert await _teach_flood(handler.return_path_teacher) is False
     assert len(injector.packets) == 1
 
-    blocked = await handler.return_path_teacher.maybe_teach_reverse_of_out_path(
-        PEER_KEY, reason="timeout"
+
+# --------------------------------------------------------------------------- #
+# Correcting a teach sent from the first-arrived copy
+# --------------------------------------------------------------------------- #
+
+
+def _reteach_kwargs(pkt, *, taught_path, taught_len_byte, hash_key=None):
+    return dict(
+        contact_pubkey=PEER_KEY,
+        dest_hash=PEER_HASH,
+        taught_path=taught_path,
+        taught_len_byte=taught_len_byte,
+        out_path=OUT_PATH,
+        out_path_len=OUT_PATH_LEN,
+        shared_secret=_shared_secret(),
+        hash_key=hash_key if hash_key is not None else bytes(pkt.calculate_packet_hash()),
+        reason="test",
     )
-    await handler.return_path_teacher.wait_for_pending()
-    assert blocked is False
+
+
+@pytest.mark.asyncio
+async def test_note_flood_copy_now_records_flood_path_copies():
+    """A flood login is answered with a PATH, so PATH copies must be collected.
+
+    Before this, only RESPONSE copies were recorded, so the single most
+    consequential teach — the reciprocal after a flood login, which decides the
+    route the peer uses for every later direct reply — had no copies to choose
+    from and always embedded the first-arrived route.
+    """
+    teacher = _teacher()
+    first = _flood_path_packet()
+    first._rssi = -100
+    better = _copy_of(first, in_path=SHORT_2HOP, rssi=-40, len_byte=SHORT_2HOP_LEN)
+
+    teacher.note_flood_copy(first)
+    teacher.note_flood_copy(better)
+
+    assert len(teacher._recent_copies) == 1
+    kept = next(iter(teacher._recent_copies.values()))
+    assert kept.path == SHORT_2HOP
+    assert kept.rssi == -40
+
+
+@pytest.mark.asyncio
+async def test_reteach_sends_the_better_copy_and_keeps_routing_via_out_path():
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+    pkt = _flood_path_packet()
+    pkt._rssi = -100
+    teacher.note_flood_copy(pkt)
+    teacher.note_flood_copy(_copy_of(pkt, in_path=SHORT_2HOP, rssi=-40, len_byte=SHORT_2HOP_LEN))
+
+    sent = await teacher.maybe_reteach_better_copy(
+        **_reteach_kwargs(pkt, taught_path=IN_PATH, taught_len_byte=IN_PATH_LEN)
+    )
+
+    assert sent is True
     assert len(injector.packets) == 1
+    teach = injector.packets[0]
+    assert teach.get_payload_type() == PAYLOAD_TYPE_PATH
+    assert teach.get_route_type() == ROUTE_TYPE_DIRECT
+    # Still routed along OUR out_path; only the embedded route changed.
+    assert bytes(teach.path) == OUT_PATH
+    len_byte, embedded = _decode_teach(teach)
+    assert embedded == SHORT_2HOP
+    assert len_byte == SHORT_2HOP_LEN
+
+
+@pytest.mark.asyncio
+async def test_reteach_is_silent_when_the_first_copy_was_already_best():
+    """The common case must cost no airtime at all."""
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+    pkt = _flood_path_packet()
+    pkt._rssi = -40
+    teacher.note_flood_copy(pkt)
+    teacher.note_flood_copy(_copy_of(pkt, in_path=LONG_3HOP, rssi=-95, len_byte=LONG_3HOP_LEN))
+
+    sent = await teacher.maybe_reteach_better_copy(
+        **_reteach_kwargs(pkt, taught_path=IN_PATH, taught_len_byte=IN_PATH_LEN)
+    )
+
+    assert sent is False
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_reteach_is_silent_when_no_copies_were_collected():
+    injector = _Injector()
+    teacher = _teacher(injector=injector)
+    pkt = _flood_path_packet()
+
+    sent = await teacher.maybe_reteach_better_copy(
+        **_reteach_kwargs(pkt, taught_path=IN_PATH, taught_len_byte=IN_PATH_LEN)
+    )
+
+    assert sent is False
+    assert injector.packets == []
+
+
+@pytest.mark.asyncio
+async def test_reteach_ignores_the_cooldown_claimed_by_the_teach_it_corrects():
+    """It corrects a teach that just claimed the cooldown, so it must not be
+    throttled by it — otherwise the peer keeps the marginal first route."""
+    clock = {"t": 1000.0}
+    injector = _Injector()
+    teacher = _teacher(injector=injector, cooldown_s=5.0, time_fn=lambda: clock["t"])
+    pkt = _flood_path_packet()
+    pkt._rssi = -100
+    teacher.note_flood_copy(pkt)
+    teacher.note_flood_copy(_copy_of(pkt, in_path=SHORT_2HOP, rssi=-40, len_byte=SHORT_2HOP_LEN))
+
+    teacher.note_evidence_teach(PEER_KEY)  # the immediate reciprocal claims it
+    clock["t"] += 0.5
+
+    sent = await teacher.maybe_reteach_better_copy(
+        **_reteach_kwargs(pkt, taught_path=IN_PATH, taught_len_byte=IN_PATH_LEN)
+    )
+
+    assert sent is True
+    assert len(injector.packets) == 1
+
+
+@pytest.mark.asyncio
+async def test_reciprocal_end_to_end_corrects_itself_to_the_best_copy():
+    """The whole path: flood-PATH login reply -> immediate teach from the copy in
+    hand -> corrective teach from the best copy collected pre-dedup."""
+    injector = _Injector()
+    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
+    handler.set_packet_injector(injector)
+    teacher = handler.return_path_teacher
+    teacher._settle_s = 0.0
+
+    first = _flood_path_packet()
+    first._rssi = -100
+    # A stronger, shorter copy of the same reply lands pre-dedup (raw subscriber).
+    teacher.note_flood_copy(first)
+    teacher.note_flood_copy(_copy_of(first, in_path=SHORT_2HOP, rssi=-40, len_byte=SHORT_2HOP_LEN))
+
+    await handler(first)
+    await handler.wait_for_pending_reciprocals()
+    await teacher.wait_for_pending()
+
+    assert len(injector.packets) == 2, "expected the immediate teach plus one correction"
+    _, first_taught = _decode_teach(injector.packets[0])
+    _, corrected = _decode_teach(injector.packets[1])
+    assert first_taught == bytes(first.path)  # the copy in hand
+    assert corrected == SHORT_2HOP  # the best copy collected
 
 
 # --------------------------------------------------------------------------- #
@@ -823,66 +981,143 @@ def test_login_handler_can_wire_its_own_injector_standalone():
 
 
 # --------------------------------------------------------------------------- #
-# base_send retry hook
+# base_send retry: flood instead of guessing a return path
 # --------------------------------------------------------------------------- #
 
 
-class _StubSender(_SendOpsMixin):
-    """Minimal carrier for the retry hook; only the handler accessor is used."""
+class _Proxy:
+    """Stand-in for ContactProxy: only the route fields matter here."""
 
-    def __init__(self, handler):
-        self._handler = handler
-
-    def _get_protocol_response_handler(self):
-        return self._handler
+    def __init__(self, out_path=OUT_PATH, out_path_len=OUT_PATH_LEN):
+        self.out_path = out_path
+        self.out_path_len = out_path_len
 
 
-@pytest.mark.asyncio
-async def test_retry_hook_asks_the_teacher_to_reverse_the_out_path():
-    injector = _Injector()
-    handler = ProtocolResponseHandler(lambda _m: None, LOCAL_IDENTITY, _contacts())
-    handler.set_packet_injector(injector)
+class _RetrySender(_SendOpsMixin):
+    """Carrier for the retry loops with radio/timing stubbed out."""
 
-    await _StubSender(handler)._teach_return_path_before_retry(PEER_KEY, "REQ 0x01")
-    await handler.return_path_teacher.wait_for_pending()
+    def __init__(self):
+        self.sent = []
 
-    assert len(injector.packets) == 1
-    _, embedded_path = _decode_teach(injector.packets[0])
-    assert embedded_path == bytes(reversed(OUT_PATH))
+    def _apply_path_hash_mode(self, pkt):
+        return None
 
+    def _response_timeout_s(self, pkt, proxy):
+        return 0.001
 
-@pytest.mark.asyncio
-async def test_retry_hook_is_best_effort_and_never_raises():
-    """A failing teach must not abort the retry it precedes."""
-
-    class _Boom:
-        @property
-        def return_path_teacher(self):
-            raise RuntimeError("handler exploded")
-
-    await _StubSender(_Boom())._teach_return_path_before_retry(PEER_KEY, "REQ")
-    # No handler at all (companion subclasses may return None).
-    await _StubSender(None)._teach_return_path_before_retry(PEER_KEY, "REQ")
+    async def _send_packet(self, pkt, wait_for_ack=False, expected_crc=None):
+        self.sent.append(pkt)
+        return True
 
 
-@pytest.mark.asyncio
-async def test_request_retry_loop_invokes_the_teach_hook():
-    """Covers the wiring in _request_with_retries itself: without this, deleting
-    the call would leave every other test in this file green."""
-    calls = []
+def _req_builder(proxy):
+    """Build a REQ the way PacketBuilder does: route chosen from out_path_len."""
 
-    class _Sender(_SendOpsMixin):
-        async def _teach_return_path_before_retry(self, contact_pubkey, log_label):
-            calls.append(bytes(contact_pubkey))
+    def _build():
+        pkt = Packet()
+        route = ROUTE_TYPE_DIRECT if proxy.out_path_len >= 0 else ROUTE_TYPE_FLOOD
+        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | route
+        pkt.payload = bytearray(b"\x00" * 8)
+        pkt.payload_len = 8
+        if route == ROUTE_TYPE_DIRECT and proxy.out_path_len > 0:
+            pkt.path = bytearray(proxy.out_path)
+            pkt.path_len = proxy.out_path_len
+        else:
+            pkt.path = bytearray()
+            pkt.path_len = 0
+        return pkt, None
 
-        def _apply_path_hash_mode(self, pkt):
-            return None
+    return _build
 
-        def _response_timeout_s(self, pkt, proxy):
-            return 0.001
 
-        async def _send_packet(self, pkt, wait_for_ack=False, expected_crc=None):
-            return True
+async def _always_timeout(_timeout):
+    return {"timeout": True}
+
+
+def test_retry_packet_floods_a_contact_that_has_a_direct_path():
+    """Mirrors firmware's own way of forcing one request to flood: mask
+    out_path_len to OUT_PATH_UNKNOWN around the build, then restore it."""
+    proxy = _Proxy()
+    sender = _RetrySender()
+
+    pkt, _tag = sender._build_retry_packet(_req_builder(proxy), proxy, "REQ")
+
+    assert pkt.is_route_flood()
+    assert bytes(pkt.path) == b""
+    assert pkt.path_len == 0
+    # The stored route is masked, never cleared: every other caller still sees it.
+    assert proxy.out_path_len == OUT_PATH_LEN
+    assert proxy.out_path == OUT_PATH
+
+
+def test_forced_flood_retry_is_unscoped_and_survives_a_configured_scope():
+    """A region-scoped retry dies at the first region-less repeater.
+
+    Most repeaters on a mixed mesh have no regions configured, so they cannot
+    match a transport code and refuse to forward a TRANSPORT_FLOOD packet
+    (``allowPacketForward``: ``recv_pkt_region == NULL``). Scoping the retry would
+    make it strictly worse than the direct attempt it replaces, so the forced
+    flood is marked as a deliberate plain-flood decision that the dispatcher's
+    override/default resolver must not override.
+    """
+    from openhop_core.node.dispatcher import Dispatcher
+    from openhop_core.protocol.constants import ROUTE_TYPE_TRANSPORT_FLOOD
+    from openhop_core.protocol.transport_keys import get_auto_key_for
+
+    proxy = _Proxy()
+    sender = _RetrySender()
+
+    pkt, _tag = sender._build_retry_packet(_req_builder(proxy), proxy, "REQ")
+    assert pkt.is_route_flood()
+    assert pkt._flood_scope_applied is True
+
+    class _Radio:
+        def set_rx_callback(self, cb):
+            pass
+
+    dispatcher = Dispatcher(_Radio())
+    dispatcher.flood_transport_key = get_auto_key_for("#region-a")
+    dispatcher.default_flood_transport_key = get_auto_key_for("#region-b")
+    dispatcher._apply_flood_scope(pkt)
+
+    assert pkt.get_route_type() != ROUTE_TYPE_TRANSPORT_FLOOD
+    assert pkt.transport_codes == [0, 0]
+
+
+def test_retry_packet_restores_the_stored_path_when_the_builder_raises():
+    proxy = _Proxy()
+    sender = _RetrySender()
+
+    def _boom():
+        raise RuntimeError("builder exploded")
+
+    with pytest.raises(RuntimeError):
+        sender._build_retry_packet(_boom, proxy, "REQ")
+    assert proxy.out_path_len == OUT_PATH_LEN
+
+
+def test_retry_packet_leaves_an_already_flooding_contact_alone():
+    proxy = _Proxy(out_path=b"", out_path_len=-1)
+    sender = _RetrySender()
+
+    pkt, _tag = sender._build_retry_packet(_req_builder(proxy), proxy, "REQ")
+
+    assert pkt.is_route_flood()
+    assert proxy.out_path_len == -1
+
+
+def test_retry_packet_tolerates_a_proxy_that_cannot_be_masked():
+    """A non-settable contact object must not break the retry."""
+
+    class _Frozen:
+        __slots__ = ("out_path", "out_path_len")
+
+        def __init__(self):
+            self.out_path = OUT_PATH
+            self.out_path_len = OUT_PATH_LEN
+
+    proxy = _Frozen()
+    sender = _RetrySender()
 
     def _build():
         pkt = Packet()
@@ -893,59 +1128,47 @@ async def test_request_retry_loop_invokes_the_teach_hook():
         pkt.path_len = 0
         return pkt, None
 
-    async def _always_timeout(_timeout):
-        return {"timeout": True}
+    pkt, _tag = sender._build_retry_packet(_build, proxy, "REQ")
+    assert pkt is not None
+    assert proxy.out_path_len == OUT_PATH_LEN
 
-    result = await _Sender()._request_with_retries(
-        _build, _always_timeout, object(), log_label="REQ", contact_pubkey=PEER_KEY
+
+@pytest.mark.asyncio
+async def test_request_retry_loop_floods_every_attempt_after_the_first():
+    """Covers the wiring in _request_with_retries: the first attempt keeps the
+    contact's route, every retry floods so a reply can be observed."""
+    proxy = _Proxy()
+    sender = _RetrySender()
+
+    result = await sender._request_with_retries(
+        _req_builder(proxy), _always_timeout, proxy, log_label="REQ"
     )
 
     assert result["timeout"] is True
-    # One teach before every attempt after the first.
-    assert calls and all(c == PEER_KEY for c in calls)
+    assert len(sender.sent) >= 2
+    assert not sender.sent[0].is_route_flood(), "first attempt keeps the stored route"
+    assert all(p.is_route_flood() for p in sender.sent[1:]), "every retry floods"
+    assert proxy.out_path_len == OUT_PATH_LEN
 
 
 @pytest.mark.asyncio
-async def test_started_request_retry_loop_invokes_the_teach_hook():
+async def test_started_request_retry_loop_floods_every_retry():
     """Same coverage for the background continuation used by the frame-server
-    API path (_finish_started_request)."""
-    calls = []
+    API path (_finish_started_request), whose first attempt is already sent."""
+    proxy = _Proxy()
+    sender = _RetrySender()
 
-    class _Sender(_SendOpsMixin):
-        async def _teach_return_path_before_retry(self, contact_pubkey, log_label):
-            calls.append(bytes(contact_pubkey))
-
-        def _apply_path_hash_mode(self, pkt):
-            return None
-
-        def _response_timeout_s(self, pkt, proxy):
-            return 0.001
-
-        async def _send_packet(self, pkt, wait_for_ack=False, expected_crc=None):
-            return True
-
-    def _build():
-        pkt = Packet()
-        pkt.header = (PAYLOAD_TYPE_RESPONSE << 2) | ROUTE_TYPE_DIRECT
-        pkt.payload = bytearray(b"\x00" * 8)
-        pkt.payload_len = 8
-        pkt.path = bytearray()
-        pkt.path_len = 0
-        return pkt, None
-
-    async def _always_timeout(_timeout):
-        return {"timeout": True}
-
-    await _Sender()._finish_started_request(
-        _build,
+    await sender._finish_started_request(
+        _req_builder(proxy),
         _always_timeout,
-        object(),
+        proxy,
         first_timeout_s=0.001,
         deadline=None,
         log_label="REQ",
         cleanup=None,
         response_tag_registered=None,
-        contact_pubkey=PEER_KEY,
     )
 
-    assert calls and all(c == PEER_KEY for c in calls)
+    assert sender.sent, "the continuation must retry"
+    assert all(p.is_route_flood() for p in sender.sent), "every retry floods"
+    assert proxy.out_path_len == OUT_PATH_LEN

--- a/tests/test_transit_direct_delivery.py
+++ b/tests/test_transit_direct_delivery.py
@@ -1,0 +1,352 @@
+"""Local delivery of routed-direct packets still carrying hops.
+
+MeshCore ``Mesh::onRecvPacket`` never runs payload processing for a direct
+packet whose path is not yet exhausted::
+
+    if (pkt->isRouteDirect() && pkt->getPathHashCount() > 0) {
+      if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) { ... onAckRecv(...); }   // early-ACK peek
+      if (self_id.isHashMatch(pkt->path, ...) && allowPacketForward(pkt)) {
+        ... markSeen(pkt); removeSelfFromPath(pkt); ACTION_RETRANSMIT_DELAYED ...
+      }
+      return ACTION_RELEASE;   // NOT the next hop (or already forwarded)
+    }
+
+So a direct packet is delivered to payload processing only once its hop count
+reaches 0, and the un-stripped copy is never delivered — not even by the node
+that is its next hop, which forwards instead.
+
+openHop diverged: ``_dispatch`` had no such gate, and the dedup table was the
+only thing hiding it. Once dedup stopped tracking routed-direct packets this
+node is not the next hop for (correct firmware parity — otherwise an overheard
+route variant suppresses a copy this node *does* own), a node in direct range of
+a sender that routes through a relay delivered the same DM twice: once from the
+overheard pre-relay copy and again from the relayed copy, which share a
+path-independent packet hash.
+
+The gate applies only to handlers registered ``local_delivery=True``, because
+``_dispatch`` is also how applications route: openhop_repeater installs its
+router as the fallback handler (and its own RAW_CUSTOM handler) and must keep
+seeing exactly these transit packets.
+"""
+
+import asyncio
+
+import pytest
+
+from openhop_core.node.dispatcher import Dispatcher
+from openhop_core.protocol import Packet
+from openhop_core.protocol.constants import (
+    PAYLOAD_TYPE_ACK,
+    PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_RESPONSE,
+    PAYLOAD_TYPE_TRACE,
+    PAYLOAD_TYPE_TXT_MSG,
+    ROUTE_TYPE_DIRECT,
+    ROUTE_TYPE_FLOOD,
+)
+from openhop_core.protocol.packet_utils import PathUtils
+
+SELF_KEY = b"0123456789abcdef0123456789abcdef"
+SELF_HASH = SELF_KEY[0]  # 0x30
+OTHER_HASH = 0xEE
+
+
+class CountingRadio:
+    def __init__(self):
+        self.rx_callback = None
+        self.send_count = 0
+
+    def set_rx_callback(self, callback):
+        self.rx_callback = callback
+
+    async def send(self, data: bytes):
+        self.send_count += 1
+        return {"ok": True}
+
+    def get_last_rssi(self):
+        return -70
+
+    def get_last_snr(self):
+        return 8.0
+
+
+class MockIdentity:
+    def get_public_key(self):
+        return SELF_KEY
+
+
+def _make_dispatcher():
+    radio = CountingRadio()
+    d = Dispatcher(radio, dedupe_enabled=True)
+    d.local_identity = MockIdentity()
+    return d, radio
+
+
+def _direct_pkt(payload_type, path, hops, payload=None):
+    """A routed-direct packet with a path-independent payload.
+
+    Every route variant of the same payload hashes alike, which is what makes
+    the overheard copy and the relayed copy collide in the dedup table.
+    """
+    p = Packet()
+    p.header = (payload_type << 2) | ROUTE_TYPE_DIRECT
+    body = (
+        payload if payload is not None else bytearray([SELF_HASH, 0x99]) + bytearray(b"\xaa" * 12)
+    )
+    p.payload = bytearray(body)
+    p.payload_len = len(p.payload)
+    p.path = bytearray(path)
+    p.path_len = PathUtils.encode_path_len(1, hops)
+    return p
+
+
+def _flood_pkt(payload_type):
+    p = Packet()
+    p.header = (payload_type << 2) | ROUTE_TYPE_FLOOD
+    # Distinct payload: the packet hash is path-independent, so reusing the
+    # direct payload here would collide with it in the dedup table.
+    p.payload = bytearray([SELF_HASH, 0x99]) + bytearray(b"\xbb" * 12)
+    p.payload_len = len(p.payload)
+    p.path = bytearray()
+    p.path_len = 0
+    return p
+
+
+def _recording_handler(seen):
+    async def _handler(pkt):
+        seen.append(bytes(pkt.path))
+        return None
+
+    return _handler
+
+
+async def _feed(dispatcher, pkt):
+    await dispatcher._process_received_packet(pkt.write_to(), -70, 8.0)
+    await asyncio.sleep(0)
+
+
+# --------------------------------------------------------------------------- #
+# The regression: one DM, two received copies, one local delivery
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_overheard_transit_copy_is_not_delivered_locally():
+    """The pre-relay copy is released; only the exhausted-path copy is delivered.
+
+    Before the fix both copies reached the handler, because dedup (correctly) no
+    longer tracks a routed-direct packet this node is not the next hop for.
+    """
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen), local_delivery=True)
+
+    # Overheard while still addressed via a relay: first hash is not ours.
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH, 0xBB]), hops=2))
+    assert seen == [], "a direct packet with hops left must not be delivered locally"
+
+    # The relay strips itself; the path is now exhausted and this copy is ours.
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, b"", hops=0))
+    assert seen == [b""], "the exhausted-path copy must be delivered exactly once"
+
+
+@pytest.mark.asyncio
+async def test_transit_copy_addressed_via_us_is_not_delivered_either():
+    """Being the next hop means forward, not deliver (firmware strips then relays)."""
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen), local_delivery=True)
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([SELF_HASH, 0xBB]), hops=2))
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_every_core_local_delivery_type_is_gated():
+    """RESPONSE / PATH / TXT all carry replies; none may be delivered in transit."""
+    for payload_type in (PAYLOAD_TYPE_TXT_MSG, PAYLOAD_TYPE_RESPONSE, PAYLOAD_TYPE_PATH):
+        d, _radio = _make_dispatcher()
+        seen = []
+        d.register_handler(payload_type, _recording_handler(seen), local_delivery=True)
+        await _feed(d, _direct_pkt(payload_type, bytes([OTHER_HASH]), hops=1))
+        assert seen == [], f"payload type {payload_type} delivered while in transit"
+
+
+# --------------------------------------------------------------------------- #
+# The gate must not over-reach
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_routing_handler_still_sees_transit_packets():
+    """An application router (registered without ``local_delivery``) is un-gated.
+
+    openhop_repeater routes through the dispatcher's handler chain; gating it
+    would silently stop the repeater relaying routed-direct traffic.
+    """
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen))
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH, 0xBB]), hops=2))
+    assert seen == [bytes([OTHER_HASH, 0xBB])]
+
+
+@pytest.mark.asyncio
+async def test_fallback_handler_still_sees_transit_packets():
+    """The repeater installs its router via register_fallback_handler."""
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_fallback_handler(_recording_handler(seen))
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH]), hops=1))
+    assert seen == [bytes([OTHER_HASH])]
+
+
+def test_default_handler_wiring_marks_exactly_the_local_delivery_types():
+    """Pin which core payload types are gated, so a new handler cannot slip through.
+
+    Everything ``register_default_handlers`` installs consumes the payload for
+    this node except: ACK / MULTIPART (firmware peeks a transit direct ACK, and
+    CRC correlation is idempotent) and TRACE (its own firmware branch; its path
+    bytes are per-hop SNR, not routing hashes). Adding a handler here means
+    deciding which side of that line it falls on.
+    """
+    d, _radio = _make_dispatcher()
+    d.register_default_handlers(contacts=None, local_identity=d.local_identity)
+
+    from openhop_core.protocol.constants import (
+        PAYLOAD_TYPE_ADVERT,
+        PAYLOAD_TYPE_ANON_REQ,
+        PAYLOAD_TYPE_CONTROL,
+        PAYLOAD_TYPE_GRP_TXT,
+        PAYLOAD_TYPE_MULTIPART,
+        PAYLOAD_TYPE_RAW_CUSTOM,
+    )
+
+    assert d._local_delivery_types == {
+        PAYLOAD_TYPE_ADVERT,
+        PAYLOAD_TYPE_TXT_MSG,
+        PAYLOAD_TYPE_GRP_TXT,
+        PAYLOAD_TYPE_PATH,
+        PAYLOAD_TYPE_RESPONSE,
+        PAYLOAD_TYPE_ANON_REQ,
+        PAYLOAD_TYPE_CONTROL,
+        PAYLOAD_TYPE_RAW_CUSTOM,
+    }
+    # The deliberate exemptions, spelled out.
+    assert d._local_delivery_types.isdisjoint(
+        {PAYLOAD_TYPE_ACK, PAYLOAD_TYPE_MULTIPART, PAYLOAD_TYPE_TRACE}
+    )
+    # Every gated type must actually have a handler installed.
+    assert d._local_delivery_types <= set(d._handlers)
+
+
+@pytest.mark.asyncio
+async def test_application_override_of_a_core_type_clears_the_gate():
+    """Re-registering a core payload type hands the decision to the application."""
+    d, _radio = _make_dispatcher()
+    d.register_default_handlers(contacts=None, local_identity=d.local_identity)
+    assert PAYLOAD_TYPE_TXT_MSG in d._local_delivery_types
+
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen))
+    assert PAYLOAD_TYPE_TXT_MSG not in d._local_delivery_types
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH]), hops=1))
+    assert seen == [bytes([OTHER_HASH])]
+
+
+@pytest.mark.asyncio
+async def test_direct_ack_is_still_peeked_in_transit():
+    """Firmware's "early received ACK": onAckRecv runs before the next-hop check."""
+    d, _radio = _make_dispatcher()
+    d.register_default_handlers(contacts=None, local_identity=d.local_identity)
+    assert PAYLOAD_TYPE_ACK not in d._local_delivery_types
+
+    crc = 0x12345678
+    evt = asyncio.Event()
+    d._waiting_acks[crc] = evt
+
+    ack = _direct_pkt(
+        PAYLOAD_TYPE_ACK, bytes([OTHER_HASH, 0xBB]), hops=2, payload=crc.to_bytes(4, "little")
+    )
+    await _feed(d, ack)
+
+    assert evt.is_set(), "a transit direct ACK must still be correlated"
+
+
+@pytest.mark.asyncio
+async def test_direct_trace_is_not_gated():
+    """Direct TRACE has its own firmware branch, and its path bytes are SNR data."""
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TRACE, _recording_handler(seen))
+    assert PAYLOAD_TYPE_TRACE not in d._local_delivery_types
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TRACE, bytes([OTHER_HASH]), hops=1))
+    assert seen == [bytes([OTHER_HASH])]
+
+
+@pytest.mark.asyncio
+async def test_zero_hop_direct_and_flood_are_delivered():
+    """The gate is scoped to routed-direct packets: nothing else changes."""
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen), local_delivery=True)
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, b"", hops=0))
+    await _feed(d, _flood_pkt(PAYLOAD_TYPE_TXT_MSG))
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_packet_received_callback_still_fires_for_a_transit_packet():
+    """Only payload delivery is suppressed; observers (RX stats) are untouched."""
+    d, _radio = _make_dispatcher()
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen), local_delivery=True)
+
+    observed = []
+
+    async def _on_received(pkt):
+        observed.append(pkt.get_payload_type())
+
+    d.set_packet_received_callback(_on_received)
+
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH]), hops=1))
+    assert seen == []
+    assert observed == [PAYLOAD_TYPE_TXT_MSG]
+
+
+# --------------------------------------------------------------------------- #
+# Interaction with the dedup rule the gate exists to complement
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_dedup_skip_and_delivery_gate_hold_together():
+    """The two halves of firmware parity must both hold at once.
+
+    Dedup must not track a routed-direct packet this node is not the next hop
+    for (or an overheard variant suppresses the copy it later owns), *and* that
+    untracked copy must not be delivered locally. Asserting them together is
+    what pins the regression: satisfying either one alone reintroduces a bug.
+    """
+    d, radio = _make_dispatcher()
+    d.set_client_repeat_enabled(True)
+    d._client_repeat_delay_ms = lambda pkt: 0.0
+    seen = []
+    d.register_handler(PAYLOAD_TYPE_TXT_MSG, _recording_handler(seen), local_delivery=True)
+
+    # Overheard longer variant: not ours to relay, not delivered, not tracked.
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([OTHER_HASH, SELF_HASH, 0xBB]), hops=3))
+    await asyncio.sleep(0.01)
+    assert radio.send_count == 0
+    assert seen == []
+
+    # Upstream strips itself: we are the next hop now. Relay it (not delivered).
+    await _feed(d, _direct_pkt(PAYLOAD_TYPE_TXT_MSG, bytes([SELF_HASH, 0xBB]), hops=2))
+    await asyncio.sleep(0.01)
+    assert radio.send_count == 1, "an overheard variant must not suppress a relay we own"
+    assert seen == []


### PR DESCRIPTION
Summary

Twelve MeshCore-parity fixes, most of them reproduced on a live mesh. No API breaks; every new behavior is inert unless the host wires it up.

Flood scoping

- The persisted default scope key never reached the dispatcher, so every send that relies on TX-time scoping (login, status, telemetry, CLI, raw data, node-generated flood ACKs) went out as plain flood. The dispatcher now mirrors the default key and an explicit unscoped flag, resolving override → default with unscoped winning first — matching sendFloodScoped(recipient).
- Flood replies now carry the request's region (captured at both RX entrypoints, re-hashed over the reply payload) instead of the node default, matching sendFloodReply. Previously a reply to a region-B request was scoped A and dropped by B-only repeaters. Gated on an optional RegionMap, so standalone companions are unchanged.
- The no-out_path flood RESPONSE — the one that carries status/telemetry/neighbours when the ACL holds no route — now marks its own scope decision, so the dispatcher stops stamping a region firmware would never apply.

Path hash width

- Server flood replies answer at the request's width (sendFloodReply(..., packet->getPathHashSize())), not the node preference, across login_server, protocol_request, and anon_request. The one site that already mirrored didn't mark_applied, so the dispatcher's node default reliably stamped over it.
- create_path_return no longer infers hash size from path length: a 3-byte path was declared as three 1-byte hops, teaching a peer a route that resolves to nobody until a flood login resets it (observed in the field). path_len_encoded is now required for a non-empty path, and an invalid one is rejected rather than reinterpreted.
- The text ACK derived its path bytes and its declared width from two different guards; a multi-byte DM with slack in the path buffer raised out of _build_ack_responses. Now one decision: trim to the declared length, or teach no path.

Delivery correctness

- Direct packets that still have hops left are no longer delivered locally — firmware only delivers at hop count 0. Without this, a node in direct range of a sender that routes through a relay delivered the same DM twice. Gated to local_delivery=True handlers so application routing (the repeater) still sees transit packets; ACK/MULTIPART/TRACE stay un-gated.
- A pending login no longer swallows unrelated authenticated RESPONSEs. LoginResponseHandler now discriminates on the reflected request tag before the login branch, so a neighbours reply is no longer misparsed — observed live as Login failed (code: 0x2F), where 0x2F was the low byte of neighbours_count.
- ADVERTs carrying our own public key are ignored, so a node can't add itself as a contact.
- Identity generation re-rolls keys whose public key starts 0x00/0xFF; firmware refuses to import them because the first byte doubles as the routing hash.

Return-path teaching

- Dropped the reverse-of-out_path guess on request timeout — real routes are often asymmetric, and onPeerPathRecv overwrites unconditionally, so a wrong guess replaced a working route with a dead one. Timeouts now re-send the request as an unscoped flood, and the peer answers with a real observed path.
- Best flood copy is now chosen by decodability (fewest hops when reliable, SNR margin when marginal, hard floor below which nothing is recorded), replacing a dB-per-hop trade calibrated ~60 dB above where decodability actually changes.
- The reciprocal teach fires immediately from the copy in hand, then re-teaches once if a better copy lands inside the settle window — and only transmits when the route differs.

KISS reliability

- A serial reconnect could report success with an already-dead reader, leaving the node silently deaf. Worker error handlers now gate on deliberate shutdown instead of is_connected (which silenced exactly the reconnect window), _open_serial_and_start_threads verifies the reader survived startup, and _stop_io_threads closes the port before joining so a reader blocked in read() can't decode into the next generation's buffer.

Testing

New and expanded suites for flood scoping, transit-direct delivery, return-path teaching, path-hash width, and KISS reconnect — including one test that drives a real handler reply through send_packet to pin the width all the way to the serialized path_len byte. Also verified against the downstream repeater's suite (1295 tests).