### PR TITLE
Return None for uninitialized/TX states in USB/TCP get_noise_floor

### DIFF
--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -437,9 +437,9 @@ class TCPLoRaRadio(_RadioBase):
 
     def get_noise_floor(self) -> Optional[float]:
         if not self._initialized:
-            return 0.0
+            return None
         if self._tx_lock.locked():
-            return 0.0
+            return None
         return self._noise_floor
 
     async def refresh_noise_floor(self) -> Optional[float]:

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -471,9 +471,9 @@ class USBLoRaRadio(_RadioBase):
         use await get_modem_status() which returns noise_floor.
         """
         if not self._initialized:
-            return 0.0
+            return None
         if self._tx_lock.locked():
-            return 0.0
+            return None
         return self._noise_floor
 
     async def refresh_noise_floor(self) -> Optional[float]:


### PR DESCRIPTION
Mirrors 41eec25

Applies the same fix from `SX1262Radio.get_noise_floor()` to the USB and TCP modem drivers.