### PR TITLE
Add barometric pressure encoder

### DIFF
--- a/src/openhop_core/protocol/cayenne_lpp.py
+++ b/src/openhop_core/protocol/cayenne_lpp.py
@@ -14,6 +14,7 @@ import struct
 # LPP type codes, byte sizes and multipliers (CayenneLPP.h).
 LPP_TEMPERATURE = 0x67  # 103: 2 bytes, 0.1 C/LSB, signed
 LPP_RELATIVE_HUMIDITY = 0x68  # 104: 1 byte, 0.5 %/LSB, unsigned
+LPP_BAROMETRIC_PRESSURE = 0x73  # 115: 2 bytes, 0.1 hPa/LSB, unsigned
 LPP_VOLTAGE = 0x74  # 116: 2 bytes, 0.01 V/LSB, unsigned
 LPP_CURRENT = 0x75  # 115: 2 bytes, 0.001 A/LSB, signed
 LPP_POWER = 0x80  # 128: 2 bytes, 1 W/LSB, unsigned
@@ -28,6 +29,7 @@ LPP_VOLTAGE_MULT = 100
 _LPP_TYPES = {
     LPP_TEMPERATURE: (2, 10, True),
     LPP_RELATIVE_HUMIDITY: (1, 2, False),
+    LPP_BAROMETRIC_PRESSURE: (2, 10, False),
     LPP_VOLTAGE: (2, 100, False),
     LPP_CURRENT: (2, 1000, True),
     LPP_POWER: (2, 1, False), 
@@ -80,3 +82,8 @@ def encode_temperature(channel: int, celsius: float) -> bytes:
 def encode_relative_humidity(channel: int, percent: float) -> bytes:
     """Encode a relative-humidity entry (LPP_RELATIVE_HUMIDITY, 0.5 %/LSB)."""
     return _add_field(channel, LPP_RELATIVE_HUMIDITY, percent)
+
+
+def encode_barometric_pressure(channel: int, hpa: float) -> bytes:
+    """Encode a barometric-pressure entry (LPP_BAROMETRIC_PRESSURE, 0.1 hPa/LSB)."""
+    return _add_field(channel, LPP_BAROMETRIC_PRESSURE, hpa)

--- a/tests/test_cayenne_lpp.py
+++ b/tests/test_cayenne_lpp.py
@@ -6,10 +6,12 @@ zero, then stores the result MSB-first (signed types as two's complement).
 """
 
 from openhop_core.protocol.cayenne_lpp import (
+    LPP_BAROMETRIC_PRESSURE,
     LPP_RELATIVE_HUMIDITY,
     LPP_TEMPERATURE,
     LPP_VOLTAGE,
     TELEM_CHANNEL_SELF,
+    encode_barometric_pressure,
     encode_relative_humidity,
     encode_temperature,
     encode_voltage,
@@ -20,6 +22,7 @@ def test_type_codes_match_firmware():
     assert LPP_VOLTAGE == 0x74
     assert LPP_TEMPERATURE == 0x67
     assert LPP_RELATIVE_HUMIDITY == 0x68
+    assert LPP_BAROMETRIC_PRESSURE == 0x73
     assert TELEM_CHANNEL_SELF == 1
 
 
@@ -53,3 +56,12 @@ def test_relative_humidity_single_byte():
     assert encode_relative_humidity(2, 48.5) == bytes([0x02, 0x68, 0x61])
     # 100 % -> 200 (0xC8), the unsigned byte max region.
     assert encode_relative_humidity(4, 100.0) == bytes([0x04, 0x68, 0xC8])
+
+
+def test_barometric_pressure_unsigned_two_bytes():
+    # 1013.25 hPa -> 10132 (0x2794); 0.1 hPa/LSB, unsigned 2 bytes.
+    assert encode_barometric_pressure(2, 1013.25) == bytes([0x02, 0x73, 0x27, 0x94])
+    # 1021.46 hPa: 1021.46f * 10f truncates to 10214 (0x27E6), not 10215.
+    assert encode_barometric_pressure(2, 1021.46) == bytes([0x02, 0x73, 0x27, 0xE6])
+    # 1025.94 hPa -> 10259 (0x2813).
+    assert encode_barometric_pressure(1, 1025.94) == bytes([0x01, 0x73, 0x28, 0x13])


### PR DESCRIPTION
Adds `encode_barometric_pressure` / `LPP_BAROMETRIC_PRESSURE`. 

Needed by `openhop_repeater` for BME280 pressure (https://github.com/openhop-dev/openhop_repeater/pull/387).