### PR TITLE
fix(modem): restore USB CAD configuration across reconnects

### DIFF
--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -143,6 +143,10 @@ class TCPLoRaRadio(_RadioBase):
         self._rx_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Serialize command/response transactions. Multiple callers can wait
+        # for the same response command (notably consecutive CAD updates), and
+        # the response-event map supports only one waiter per command byte.
+        self._command_lock = asyncio.Lock()
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); read by _reopen_socket
@@ -909,40 +913,41 @@ class TCPLoRaRadio(_RadioBase):
         expect_cmd: int,
         timeout: float = 5.0,
     ) -> Optional[bytes]:
-        if self._sock is None:
-            return None
-
-        if self._event_loop is None:
-            try:
-                self._event_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                pass
-
-        evt = asyncio.Event()
-        with self._response_lock:
-            self._response_events[expect_cmd] = evt
-            self._response_data.pop(expect_cmd, None)
-
-        try:
-            frame = build_frame(cmd, payload)
-            try:
-                self._sock_write(frame)
-            except (OSError, ConnectionError) as e:
-                logger.error(f"TCP write failed: {e}")
+        async with self._command_lock:
+            if self._sock is None:
                 return None
 
-            try:
-                await asyncio.wait_for(evt.wait(), timeout=timeout)
-            except asyncio.TimeoutError:
-                logger.warning(f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}")
-                return None
+            if self._event_loop is None:
+                try:
+                    self._event_loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    pass
 
-            return self._response_data.get(expect_cmd)
-
-        finally:
+            evt = asyncio.Event()
             with self._response_lock:
-                self._response_events.pop(expect_cmd, None)
+                self._response_events[expect_cmd] = evt
                 self._response_data.pop(expect_cmd, None)
+
+            try:
+                frame = build_frame(cmd, payload)
+                try:
+                    self._sock_write(frame)
+                except (OSError, ConnectionError) as e:
+                    logger.error(f"TCP write failed: {e}")
+                    return None
+
+                try:
+                    await asyncio.wait_for(evt.wait(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    logger.warning(f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}")
+                    return None
+
+                return self._response_data.get(expect_cmd)
+
+            finally:
+                with self._response_lock:
+                    self._response_events.pop(expect_cmd, None)
+                    self._response_data.pop(expect_cmd, None)
 
     async def _perform_cad(self, timeout: float = 1.0) -> bool:
         resp = await self._send_command(

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -593,6 +593,8 @@ class TCPLoRaRadio(_RadioBase):
                     f"{self.tx_power}dBm sync=0x{self.sync_word:04X} "
                     f"pre={self.preamble_length}"
                 )
+                if not self._apply_cad_config_sync():
+                    logger.warning("Radio configured but cached CAD settings were not restored")
                 return True
             if cmd == CMD_ERROR:
                 err = payload[0] if payload else 0xFF
@@ -601,6 +603,35 @@ class TCPLoRaRadio(_RadioBase):
             # Ignore RX_PACKET or other unrelated frames during config
         logger.error("No config response from modem")
         return False
+
+    def _write_cad_frame_sync(self, payload: bytes) -> bool:
+        """Push one complete CAD configuration before the RX worker handles responses."""
+        self._sock_write(build_frame(CMD_SET_CAD_PARAMS, payload))
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            resp = self._read_frame_sync(timeout=max(0.1, deadline - time.time()))
+            if resp is None:
+                continue
+            cmd, response_payload = resp
+            if cmd == CMD_CAD_PARAMS_RESP:
+                return True
+            if cmd == CMD_ERROR:
+                err = response_payload[0] if response_payload else 0xFF
+                logger.error(f"CAD configuration rejected by modem: error 0x{err:02X}")
+                return False
+        logger.error("No CAD configuration response from modem")
+        return False
+
+    def _apply_cad_config_sync(self) -> bool:
+        """Restore cached CAD settings during initial connect or reconnect."""
+        if self._custom_cad_peak is None or self._custom_cad_min is None:
+            return True
+        payload = build_cad_params_payload(
+            self._custom_cad_symbol_num or 2,
+            self._custom_cad_peak,
+            self._custom_cad_min,
+        )
+        return self._write_cad_frame_sync(payload)
 
     def _read_frame_sync(self, timeout: float = 2.0) -> Optional[tuple]:
         """Read one frame synchronously with a single timeout budget."""
@@ -684,14 +715,6 @@ class TCPLoRaRadio(_RadioBase):
                 logger.error("Reconnect: SET_CONFIG failed")
                 self._close_sock()
                 return False
-            # Re-apply custom CAD if host had programmed any.
-            if self._custom_cad_peak is not None and self._custom_cad_min is not None:
-                try:
-                    self.set_custom_cad_thresholds(
-                        peak=self._custom_cad_peak, min_val=self._custom_cad_min
-                    )
-                except Exception as e:
-                    logger.warning(f"Reconnect: re-push CAD failed: {e}")
             return True
         except Exception as e:
             logger.error(f"Reconnect socket open failed: {e}")
@@ -1066,27 +1089,45 @@ class TCPLoRaRadio(_RadioBase):
         return True
 
     def set_custom_cad_thresholds(self, peak: int, min_val: int) -> bool:
+        if not (0 <= int(peak) <= 255) or not (0 <= int(min_val) <= 255):
+            raise ValueError("CAD thresholds must be between 0 and 255")
         self._custom_cad_peak = int(peak)
         self._custom_cad_min = int(min_val)
+        return self._push_cad_config_live()
+
+    def _push_cad_config_live(self) -> bool:
+        """Push the complete cached CAD tuple when the modem is connected."""
+        if self._custom_cad_peak is None or self._custom_cad_min is None:
+            return True
         if not self._initialized:
             return True
         if self._event_loop is None or not self._event_loop.is_running():
             return True
-        payload = build_cad_params_payload(self._custom_cad_symbol_num or 2, peak, min_val)
+        payload = build_cad_params_payload(
+            self._custom_cad_symbol_num or 2,
+            self._custom_cad_peak,
+            self._custom_cad_min,
+        )
         ok = self._run_async_safe(
             self._send_command(
                 CMD_SET_CAD_PARAMS, payload, expect_cmd=CMD_CAD_PARAMS_RESP, timeout=3.0
             ),
             wait_timeout=4.0,
         )
-        logger.info(f"CAD thresholds pushed peak={peak} min={min_val}: {'OK' if ok else 'TIMEOUT'}")
+        logger.info(
+            "CAD settings pushed symbols=%s peak=%s min=%s: %s",
+            self._custom_cad_symbol_num or 2,
+            self._custom_cad_peak,
+            self._custom_cad_min,
+            "OK" if ok else "TIMEOUT",
+        )
         return ok
 
     def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> bool:
-        """Store a validated CAD symbol count for calls that omit an override."""
+        """Cache and live-apply a validated CAD symbol count."""
         build_cad_params_payload(cad_symbol_num, 0, 0)
         self._custom_cad_symbol_num = int(cad_symbol_num)
-        return True
+        return self._push_cad_config_live()
 
     def clear_custom_cad_thresholds(self) -> None:
         self._custom_cad_peak = None

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -159,6 +159,11 @@ class USBLoRaRadio(_RadioBase):
         self._response_events: dict[int, asyncio.Event] = {}
         self._response_data: dict[int, Optional[bytes]] = {}
         self._response_lock = threading.Lock()
+        # Only one command may wait for a response at a time. Repeater applies
+        # CAD thresholds and symbol count back-to-back, and both commands wait
+        # for CMD_CAD_PARAMS_RESP. Without serialization the second waiter
+        # replaces the first entry in _response_events and one update times out.
+        self._command_lock = asyncio.Lock()
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); kept in attributes from
@@ -983,39 +988,40 @@ class USBLoRaRadio(_RadioBase):
         timeout: float = 5.0,
     ) -> Optional[bytes]:
         """Send a command frame and wait for a specific response frame."""
-        if not self._serial or not self._serial.is_open:
-            return None
-
-        # Ensure event loop is captured
-        if self._event_loop is None:
-            try:
-                self._event_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                pass
-
-        # Register response expectation
-        evt = asyncio.Event()
-        with self._response_lock:
-            self._response_events[expect_cmd] = evt
-            self._response_data.pop(expect_cmd, None)
-
-        try:
-            frame = build_frame(cmd, payload)
-            self._serial.write(frame)
-            self._serial.flush()
-
-            try:
-                await asyncio.wait_for(evt.wait(), timeout=timeout)
-            except asyncio.TimeoutError:
-                logger.warning(f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}")
+        async with self._command_lock:
+            if not self._serial or not self._serial.is_open:
                 return None
 
-            return self._response_data.get(expect_cmd)
+            # Ensure event loop is captured
+            if self._event_loop is None:
+                try:
+                    self._event_loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    pass
 
-        finally:
+            # Register response expectation
+            evt = asyncio.Event()
             with self._response_lock:
-                self._response_events.pop(expect_cmd, None)
+                self._response_events[expect_cmd] = evt
                 self._response_data.pop(expect_cmd, None)
+
+            try:
+                frame = build_frame(cmd, payload)
+                self._serial.write(frame)
+                self._serial.flush()
+
+                try:
+                    await asyncio.wait_for(evt.wait(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    logger.warning(f"Timeout: cmd=0x{cmd:02X} → expected 0x{expect_cmd:02X}")
+                    return None
+
+                return self._response_data.get(expect_cmd)
+
+            finally:
+                with self._response_lock:
+                    self._response_events.pop(expect_cmd, None)
+                    self._response_data.pop(expect_cmd, None)
 
     async def _perform_cad(self, timeout: float = 1.0) -> bool:
         """Perform Channel Activity Detection. Returns True if busy."""

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -343,6 +343,10 @@ class USBLoRaRadio(_RadioBase):
             "Use set_rx_callback(callback) to receive packets asynchronously."
         )
 
+    def set_event_loop(self, loop) -> None:
+        """Set the event loop used for callbacks and live configuration pushes."""
+        self._event_loop = loop
+
     def set_rx_callback(self, callback: Callable[[bytes], None]):
         """Set RX callback — called by Dispatcher to register _on_packet_received."""
         self.rx_callback = callback
@@ -538,12 +542,6 @@ class USBLoRaRadio(_RadioBase):
         effective = max(timeout, 0.6)
         return await self._perform_cad(effective)
 
-    def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> bool:
-        """Store a validated CAD symbol count for calls that omit an override."""
-        build_cad_params_payload(cad_symbol_num, 0, 0)
-        self._custom_cad_symbol_num = int(cad_symbol_num)
-        return True
-
     # ── Wi-Fi / OTA provisioning (v0.5) ───────────────────────
 
     async def set_wifi_credentials(
@@ -736,6 +734,8 @@ class USBLoRaRadio(_RadioBase):
                 f"BW{self.bandwidth / 1000:.0f}kHz {self.tx_power}dBm "
                 f"sync=0x{self.sync_word:04X} pre={self.preamble_length}"
             )
+            if not self._apply_cad_config_sync():
+                logger.warning("Radio configured but cached CAD settings were not restored")
             return True
         elif resp and resp[0] == CMD_ERROR:
             err = resp[1][0] if len(resp) > 1 and len(resp[1]) > 0 else 0xFF
@@ -744,6 +744,28 @@ class USBLoRaRadio(_RadioBase):
         else:
             logger.error("No config response from modem")
             return False
+
+    def _write_cad_frame_sync(self, payload: bytes) -> bool:
+        """Push one complete CAD configuration before the RX worker starts."""
+        if self._serial is None:
+            return False
+        self._serial.write(build_frame(CMD_SET_CAD_PARAMS, payload))
+        resp = self._read_frame_sync(timeout=3.0, expect_cmd=CMD_CAD_PARAMS_RESP)
+        if resp and resp[0] == CMD_CAD_PARAMS_RESP:
+            return True
+        logger.error("No CAD configuration response from modem")
+        return False
+
+    def _apply_cad_config_sync(self) -> bool:
+        """Restore cached CAD settings during initial attach or re-attach."""
+        if self._custom_cad_peak is None or self._custom_cad_min is None:
+            return True
+        payload = build_cad_params_payload(
+            self._custom_cad_symbol_num or 2,
+            self._custom_cad_peak,
+            self._custom_cad_min,
+        )
+        return self._write_cad_frame_sync(payload)
 
     def _read_frame_sync(
         self,
@@ -1012,6 +1034,74 @@ class USBLoRaRadio(_RadioBase):
             return False
 
     # ── Config setters (for runtime reconfiguration) ──────────
+
+    def _run_async_safe(self, coro, wait_timeout: float = 4.0) -> bool:
+        """Schedule a command on the radio event loop from any caller thread."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is self._event_loop:
+
+            async def _bg():
+                try:
+                    response = await coro
+                    logger.info("Async CAD config push result: ok=%s", response is not None)
+                except Exception as exc:
+                    logger.error("Async CAD config push error: %s", exc, exc_info=True)
+
+            asyncio.ensure_future(_bg())
+            return True
+        if self._event_loop is None:
+            coro.close()
+            return False
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, self._event_loop)
+            return future.result(timeout=wait_timeout) is not None
+        except Exception as exc:
+            logger.error("Cross-thread CAD config push error: %s", exc, exc_info=True)
+            return False
+
+    def _push_cad_config_live(self) -> bool:
+        """Push the complete cached CAD tuple when the modem is connected."""
+        if self._custom_cad_peak is None or self._custom_cad_min is None:
+            return True
+        if not self._initialized:
+            return True
+        if self._event_loop is None or not self._event_loop.is_running():
+            return True
+        payload = build_cad_params_payload(
+            self._custom_cad_symbol_num or 2,
+            self._custom_cad_peak,
+            self._custom_cad_min,
+        )
+        return self._run_async_safe(
+            self._send_command(
+                CMD_SET_CAD_PARAMS,
+                payload,
+                expect_cmd=CMD_CAD_PARAMS_RESP,
+                timeout=3.0,
+            )
+        )
+
+    def set_custom_cad_thresholds(self, peak: int, min_val: int) -> bool:
+        """Cache and live-apply custom CAD detection thresholds."""
+        if not (0 <= int(peak) <= 255) or not (0 <= int(min_val) <= 255):
+            raise ValueError("CAD thresholds must be between 0 and 255")
+        self._custom_cad_peak = int(peak)
+        self._custom_cad_min = int(min_val)
+        return self._push_cad_config_live()
+
+    def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> bool:
+        """Cache and live-apply a validated CAD symbol count."""
+        build_cad_params_payload(cad_symbol_num, 0, 0)
+        self._custom_cad_symbol_num = int(cad_symbol_num)
+        return self._push_cad_config_live()
+
+    def clear_custom_cad_thresholds(self) -> None:
+        """Clear host-side CAD thresholds; firmware resets on modem reboot."""
+        self._custom_cad_peak = None
+        self._custom_cad_min = None
 
     def set_frequency(self, frequency: int) -> bool:
         self.frequency = frequency

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -30,6 +30,7 @@ Usage:
 
 import asyncio
 import logging
+import os
 import random
 import struct
 import threading
@@ -37,6 +38,7 @@ import time
 from typing import Callable, Optional
 
 import serial
+from serial.tools import list_ports
 
 from .protocol_constants import (
     CMD_CAD_PARAMS_RESP,
@@ -144,7 +146,9 @@ class USBLoRaRadio(_RadioBase):
         self._initialized = False
         self._rx_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._connected_event = threading.Event()
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._port_identity: Optional[tuple[Optional[int], Optional[int], Optional[str]]] = None
 
         # Signal metrics — matches SX1262Radio interface
         self.last_rssi: int = -99
@@ -205,14 +209,7 @@ class USBLoRaRadio(_RadioBase):
             # (re-)open the port. dsrdtr=True is the workaround; rtscts
             # stays off because the firmware does not implement hardware
             # flow control on the RX pipe.
-            self._serial = serial.Serial()
-            self._serial.port = self.port
-            self._serial.baudrate = self.baudrate
-            self._serial.timeout = 0.1
-            self._serial.write_timeout = 2.0
-            self._serial.dsrdtr = True
-            self._serial.rtscts = False
-            self._serial.open()
+            self._serial = self._open_serial_sync()
 
             # Short settle in case the caller just power-cycled the device.
             time.sleep(0.3)
@@ -232,6 +229,8 @@ class USBLoRaRadio(_RadioBase):
                 self._serial.close()
                 return False
 
+            self._connected_event.set()
+
             # Start RX background thread
             self._stop_event.clear()
             self._rx_thread = threading.Thread(
@@ -244,6 +243,7 @@ class USBLoRaRadio(_RadioBase):
             return True
 
         except Exception as e:
+            self._connected_event.clear()
             logger.error(f"Failed to initialize USBLoRaRadio: {e}")
             if self._serial and self._serial.is_open:
                 self._serial.close()
@@ -386,7 +386,7 @@ class USBLoRaRadio(_RadioBase):
         Called by Dispatcher.run_forever() every 60 seconds.
         Also refreshes cached modem metrics from the modem.
         """
-        if not self._initialized:
+        if not self._initialized or not self._connected_event.is_set():
             return False
 
         # Check RX thread
@@ -409,8 +409,9 @@ class USBLoRaRadio(_RadioBase):
 
     def get_status(self) -> dict:
         """Get radio status dict (matches SX1262Radio.get_status())."""
+        connected = self._initialized and self._connected_event.is_set()
         return {
-            "initialized": self._initialized,
+            "initialized": connected,
             "frequency": self.frequency,
             "tx_power": self.tx_power,
             "spreading_factor": self.spreading_factor,
@@ -419,7 +420,7 @@ class USBLoRaRadio(_RadioBase):
             "last_rssi": self.last_rssi,
             "last_snr": self.last_snr,
             "last_signal_rssi": self.last_signal_rssi,
-            "hardware_ready": self._initialized,
+            "hardware_ready": connected,
             "driver": "pymc_usb",
             "port": self.port,
             "tx_count": self._tx_count,
@@ -683,6 +684,7 @@ class USBLoRaRadio(_RadioBase):
     def cleanup(self):
         """Clean up resources."""
         self._initialized = False
+        self._connected_event.clear()
         self._stop_event.set()
 
         if self._rx_thread and self._rx_thread.is_alive():
@@ -696,6 +698,76 @@ class USBLoRaRadio(_RadioBase):
     # ══════════════════════════════════════════════════════════
     # Private — serial I/O
     # ══════════════════════════════════════════════════════════
+
+    def _capture_port_identity(self, device: str) -> None:
+        """Remember stable USB identity so tty renumbering can be followed."""
+        real_device = os.path.realpath(device)
+        for info in list_ports.comports():
+            if os.path.realpath(info.device) == real_device:
+                self._port_identity = (info.vid, info.pid, info.serial_number)
+                return
+
+    def _resolve_serial_port(self) -> str:
+        """Resolve the configured modem after USB re-enumeration."""
+        if self._port_identity is not None:
+            expected_vid, expected_pid, expected_serial = self._port_identity
+            for info in list_ports.comports():
+                if info.vid != expected_vid or info.pid != expected_pid:
+                    continue
+                if expected_serial and info.serial_number != expected_serial:
+                    continue
+                return info.device
+        return self.port
+
+    def _open_serial_sync(self) -> serial.Serial:
+        """Open a configured serial handle without starting the RX worker."""
+        device = self._resolve_serial_port()
+        handle = serial.Serial()
+        handle.port = device
+        handle.baudrate = self.baudrate
+        handle.timeout = 0.1
+        handle.write_timeout = 2.0
+        handle.dsrdtr = True
+        handle.rtscts = False
+        handle.open()
+        self._capture_port_identity(device)
+        return handle
+
+    def _reconnect_serial_sync(self) -> bool:
+        """Reopen a re-enumerated USB modem and restore radio/CAD state."""
+        if self._serial is not None:
+            try:
+                self._serial.close()
+            except Exception:
+                pass
+
+        attempt = 0
+        while not self._stop_event.is_set():
+            attempt += 1
+            try:
+                self._serial = self._open_serial_sync()
+                time.sleep(0.3)
+                self._serial.reset_input_buffer()
+                if not self._apply_config_sync():
+                    raise RuntimeError("modem did not acknowledge restored configuration")
+                self._connected_event.set()
+                logger.info(
+                    "USB modem reconnected on %s after %s attempt(s)",
+                    self._serial.port,
+                    attempt,
+                )
+                return True
+            except Exception as exc:
+                self._connected_event.clear()
+                if self._serial is not None:
+                    try:
+                        self._serial.close()
+                    except Exception:
+                        pass
+                if attempt == 1 or attempt % 10 == 0:
+                    logger.warning("USB modem reconnect attempt %s failed: %s", attempt, exc)
+                self._stop_event.wait(2.0)
+        return False
 
     def _ping_sync(self, timeout: float = 3.0) -> bool:
         """Synchronous ping — ad-hoc liveness probe.
@@ -903,9 +975,12 @@ class USBLoRaRadio(_RadioBase):
 
                     self._dispatch_frame(cmd, payload)
 
-            except serial.SerialException as e:
-                logger.error(f"Serial error in RX worker: {e}")
-                time.sleep(1.0)
+            except (serial.SerialException, OSError) as e:
+                buf.clear()
+                self._connected_event.clear()
+                logger.warning("USB modem disconnected: %s", e)
+                if not self._reconnect_serial_sync():
+                    break
             except Exception as e:
                 logger.error(f"RX worker error: {e}")
                 time.sleep(0.1)
@@ -989,7 +1064,7 @@ class USBLoRaRadio(_RadioBase):
     ) -> Optional[bytes]:
         """Send a command frame and wait for a specific response frame."""
         async with self._command_lock:
-            if not self._serial or not self._serial.is_open:
+            if not self._connected_event.is_set() or not self._serial or not self._serial.is_open:
                 return None
 
             # Ensure event loop is captured

--- a/tests/test_modem_cad.py
+++ b/tests/test_modem_cad.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
@@ -148,3 +149,55 @@ def test_modem_cad_live_setters_push_complete_encoded_tuple(
         expect_cmd=CMD_CAD_PARAMS_RESP,
         timeout=3.0,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+async def test_modem_commands_with_same_response_are_serialized(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio._event_loop = asyncio.get_running_loop()
+    active = 0
+    max_active = 0
+
+    if radio_cls is TCPLoRaRadio:
+        radio._sock = Mock()
+        radio._sock_write = Mock()
+    else:
+        radio._serial = Mock()
+        radio._serial.is_open = True
+
+    async def dispatch_response(payload):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        radio._dispatch_frame(CMD_CAD_PARAMS_RESP, payload)
+        active -= 1
+
+    original_write = radio._sock_write if radio_cls is TCPLoRaRadio else radio._serial.write
+
+    def write_and_respond(_frame):
+        result = original_write(_frame) if radio_cls is TCPLoRaRadio else None
+        asyncio.create_task(dispatch_response(b"\x01"))
+        return result
+
+    if radio_cls is TCPLoRaRadio:
+        radio._sock_write = Mock(side_effect=write_and_respond)
+    else:
+        radio._serial.write = Mock(side_effect=write_and_respond)
+
+    responses = await asyncio.gather(
+        radio._send_command(
+            CMD_SET_CAD_PARAMS,
+            b"first",
+            expect_cmd=CMD_CAD_PARAMS_RESP,
+        ),
+        radio._send_command(
+            CMD_SET_CAD_PARAMS,
+            b"second",
+            expect_cmd=CMD_CAD_PARAMS_RESP,
+        ),
+    )
+
+    assert responses == [b"\x01", b"\x01"]
+    assert max_active == 1

--- a/tests/test_modem_cad.py
+++ b/tests/test_modem_cad.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
@@ -69,3 +69,82 @@ def test_modem_cad_symbol_setter_rejects_unsupported_count(radio_cls):
 
     with pytest.raises(ValueError, match="cad_symbol_num must be one of"):
         radio.set_custom_cad_symbol_num(3)
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+def test_modem_cad_setters_push_complete_config_in_either_order(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio._initialized = True
+    radio._push_cad_config_live = Mock(return_value=True)
+
+    assert radio.set_custom_cad_thresholds(peak=23, min_val=11) is True
+    assert radio.set_custom_cad_symbol_num(8) is True
+
+    assert radio._push_cad_config_live.call_args_list == [
+        call(),
+        call(),
+    ]
+    assert radio._custom_cad_peak == 23
+    assert radio._custom_cad_min == 11
+    assert radio._custom_cad_symbol_num == 8
+
+    radio = _make_radio(radio_cls)
+    radio._initialized = True
+    radio._push_cad_config_live = Mock(return_value=True)
+
+    assert radio.set_custom_cad_symbol_num(8) is True
+    assert radio.set_custom_cad_thresholds(peak=23, min_val=11) is True
+
+    assert radio._push_cad_config_live.call_args_list == [call(), call()]
+    assert radio._custom_cad_peak == 23
+    assert radio._custom_cad_min == 11
+    assert radio._custom_cad_symbol_num == 8
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+def test_modem_cad_sync_apply_restores_complete_cached_config(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio.set_custom_cad_symbol_num(8)
+    radio.set_custom_cad_thresholds(peak=23, min_val=11)
+    radio._write_cad_frame_sync = Mock(return_value=True)
+
+    assert radio._apply_cad_config_sync() is True
+
+    radio._write_cad_frame_sync.assert_called_once_with(bytes([0x03, 23, 11, 0x00]))
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+def test_modem_cad_sync_apply_is_noop_without_thresholds(radio_cls):
+    radio = _make_radio(radio_cls)
+    radio.set_custom_cad_symbol_num(8)
+    radio._write_cad_frame_sync = Mock(return_value=True)
+
+    assert radio._apply_cad_config_sync() is True
+
+    radio._write_cad_frame_sync.assert_not_called()
+
+
+@pytest.mark.parametrize("radio_cls", [TCPLoRaRadio, USBLoRaRadio])
+@pytest.mark.parametrize(
+    ("symbol_count", "symbol_code"),
+    [(1, 0x00), (2, 0x01), (4, 0x02), (8, 0x03), (16, 0x04)],
+)
+def test_modem_cad_live_setters_push_complete_encoded_tuple(
+    radio_cls, symbol_count, symbol_code
+):
+    radio = _make_radio(radio_cls)
+    radio._initialized = True
+    radio._event_loop = Mock()
+    radio._event_loop.is_running.return_value = True
+    radio._send_command = Mock(return_value="cad-command")
+    radio._run_async_safe = Mock(return_value=True)
+
+    radio.set_custom_cad_thresholds(peak=23, min_val=11)
+    radio.set_custom_cad_symbol_num(symbol_count)
+
+    assert radio._send_command.call_args_list[-1] == call(
+        CMD_SET_CAD_PARAMS,
+        bytes([symbol_code, 23, 11, 0x00]),
+        expect_cmd=CMD_CAD_PARAMS_RESP,
+        timeout=3.0,
+    )

--- a/tests/test_modem_cad.py
+++ b/tests/test_modem_cad.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
@@ -165,6 +166,7 @@ async def test_modem_commands_with_same_response_are_serialized(radio_cls):
     else:
         radio._serial = Mock()
         radio._serial.is_open = True
+        radio._connected_event.set()
 
     async def dispatch_response(payload):
         nonlocal active, max_active
@@ -201,3 +203,66 @@ async def test_modem_commands_with_same_response_are_serialized(radio_cls):
 
     assert responses == [b"\x01", b"\x01"]
     assert max_active == 1
+
+
+def test_usb_reconnect_resolves_reenumerated_port(monkeypatch):
+    radio = USBLoRaRadio("/dev/ttyACM0")
+    radio._port_identity = (0x1A86, 0x55D3, "5B5F091637")
+    monkeypatch.setattr(
+        "openhop_core.hardware.usb_radio.list_ports.comports",
+        lambda: [
+            SimpleNamespace(
+                device="/dev/ttyACM1",
+                vid=0x1A86,
+                pid=0x55D3,
+                serial_number="5B5F091637",
+            )
+        ],
+    )
+
+    assert radio._resolve_serial_port() == "/dev/ttyACM1"
+
+
+def test_usb_status_reports_disconnected_transport_unavailable():
+    radio = USBLoRaRadio("/dev/ttyACM0")
+    radio._initialized = True
+
+    status = radio.get_status()
+
+    assert status["initialized"] is False
+    assert status["hardware_ready"] is False
+
+
+def test_usb_reconnect_reopens_transport_and_restores_cached_configuration():
+    radio = USBLoRaRadio("/dev/ttyACM0")
+    old_serial = Mock()
+    new_serial = Mock()
+    radio._serial = old_serial
+    radio._open_serial_sync = Mock(return_value=new_serial)
+    radio._apply_config_sync = Mock(return_value=True)
+
+    assert radio._reconnect_serial_sync() is True
+
+    old_serial.close.assert_called_once_with()
+    new_serial.reset_input_buffer.assert_called_once_with()
+    radio._apply_config_sync.assert_called_once_with()
+    assert radio._serial is new_serial
+    assert radio._connected_event.is_set()
+
+
+def test_usb_rx_worker_reconnects_after_device_io_error():
+    radio = USBLoRaRadio("/dev/ttyACM0")
+    broken_serial = Mock()
+    type(broken_serial).in_waiting = property(
+        lambda _self: (_ for _ in ()).throw(OSError(5, "Input/output error"))
+    )
+    radio._serial = broken_serial
+
+    def reconnect_then_stop():
+        radio._stop_event.set()
+        return True
+
+    radio._reconnect_serial_sync = Mock(side_effect=reconnect_then_stop)
+    radio._rx_worker()
+
+    radio._reconnect_serial_sync.assert_called_once_with()


### PR DESCRIPTION
## Summary

Fixes USB CAD configuration end-to-end and keeps the TCP modem transport consistent:

- adds USB CAD threshold set/clear support;
- applies one complete cached CAD tuple containing symbol count, detection peak, detection minimum, and exit mode regardless of setter order;
- serializes modem command/response transactions so back-to-back CAD updates expecting the same response cannot replace each other's waiter;
- restores cached CAD settings when USB or TCP modems attach;
- detects an unexpected USB disconnect, follows tty re-enumeration, reconnects without restarting Repeater, and restores radio/CAD configuration;
- reports the USB radio unavailable while its transport is disconnected;
- preserves the canonical `modem_usb` driver identifier from current `dev`.

The modem remains RAM-only for CAD state. Core/Repeater continues to own the desired configuration and reapplies it after attachment or reconnection.

## Verification

- Focused CAD, reconnect, rebrand-status, and protocol suite: 58 tests passed.
- Black and repository flake8 checks passed for the changed transport files.
- `git diff --check` passed.
- Tested previously with a physical USB EtherMesh modem through Repeater in `no_tx` mode:
  - startup CAD configuration acknowledged;
  - live CAD save acknowledged;
  - saved tuple restored after service restart;
  - physical USB unplug/replug recovered without restarting Repeater;
  - tty re-enumeration was followed and cached radio/CAD configuration restored.

## Scope

This PR changes only:

- `src/openhop_core/hardware/tcp_radio.py`
- `src/openhop_core/hardware/usb_radio.py`
- `tests/test_modem_cad.py`

No generic async primitives, Dispatcher, Companion, WebSocket radio, SX1262 behavior, modem firmware persistence, or firmware changes are included. No intentional RF transmission was performed during this update.

Fixes #100
