### PR TITLE
Stop pyserial resetting the board when the KISS port opens, add a USB modem udev rule

### DIFF
--- a/99-openhop-modem.rules
+++ b/99-openhop-modem.rules
@@ -1,0 +1,35 @@
+# openHop / MeshCore USB modem - stable, colon-free device symlink
+#
+# ESP32-S3 boards that talk over the chip's native USB-Serial-JTAG peripheral
+# report their factory MAC address *with colons* as the USB serial number, so
+# udev builds a /dev/serial/by-id/ name that looks like:
+#
+#   usb-Espressif_USB_JTAG_serial_debug_unit_60:55:F9:C0:27:18-if00
+#
+# Docker parses `devices:` entries as host:container[:permissions] and offers no
+# way to escape a colon inside the path, so that name cannot be handed to a
+# container at all. /dev/serial/by-path/ is no better - those contain PCI
+# addresses, which also have colons.
+#
+# This rule creates /dev/openhop-modem, which is colon-free, stable across
+# re-plugs, and safe to use in a compose file:
+#
+#   devices:
+#     - /dev/openhop-modem:/dev/openhop-modem
+#
+# Install on the HOST (udev does not run inside a container):
+#
+#   sudo cp 99-openhop-modem.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules
+#   sudo udevadm trigger --subsystem-match=tty --action=change
+#
+SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", GROUP="dialout", MODE="0660", TAG+="uaccess", SYMLINK+="openhop-modem"
+
+# 303a:1001 is Espressif's native-USB identifier and is shared by every
+# ESP32-S3/C3 board that uses it. With more than one attached, the symlink
+# lands on whichever enumerates first - pin it to a single board instead by
+# commenting out the rule above and using this one, with the serial number from:
+#
+#   udevadm info -a -n /dev/ttyACM0 | grep -E 'idVendor|idProduct|ATTRS\{serial\}'
+#
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", ATTRS{serial}=="60:55:F9:C0:27:18", GROUP="dialout", MODE="0660", TAG+="uaccess", SYMLINK+="openhop-modem"

--- a/src/openhop_core/hardware/kiss_modem_wrapper.py
+++ b/src/openhop_core/hardware/kiss_modem_wrapper.py
@@ -526,6 +526,15 @@ class KissModemWrapper(LoRaRadio):
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
+                # dsrdtr=True tells pyserial to leave DTR alone on open rather than
+                # asserting it, the same guard usb_radio.py already applies. On a
+                # CP2102 board DTR pulls EN low and reboots the ESP32; on an
+                # ESP32-S3 using the native USB-Serial-JTAG peripheral the host's
+                # DTR/RTS state feeds the on-chip reset logic directly. Either way
+                # the modem restarts every time we (re-)open the port. rtscts stays
+                # off because the firmware has no hardware flow control.
+                dsrdtr=True,
+                rtscts=False,
             )
             self.is_connected = False
 

--- a/src/openhop_core/hardware/kiss_serial_wrapper.py
+++ b/src/openhop_core/hardware/kiss_serial_wrapper.py
@@ -148,6 +148,10 @@ class KissSerialWrapper(LoRaRadio):
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
+                # See kiss_modem_wrapper.connect(): dsrdtr=True keeps pyserial from
+                # asserting DTR on open, which reboots the attached ESP32 board.
+                dsrdtr=True,
+                rtscts=False,
             )
 
             self.is_connected = True

--- a/tests/test_kiss_modem_wrapper.py
+++ b/tests/test_kiss_modem_wrapper.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from openhop_core.hardware import kiss_modem_wrapper
 from openhop_core.hardware.kiss_modem_wrapper import (
     CMD_DATA,
     CMD_GET_BATTERY,
@@ -2653,3 +2654,34 @@ class TestRxCallbackDisarmRace:
         modem._dispatch_rx_callback(b"payload", -50, 7.5)  # must not raise
 
         fake_loop.call_soon_threadsafe.assert_not_called()
+
+
+class TestSerialPortOpen:
+    """Opening the port must not let pyserial drive the modem's control lines."""
+
+    def _connect_with_fake_serial(self):
+        """Run connect() against a fake pyserial, return the Serial() kwargs."""
+        modem = KissModemWrapper(port="/dev/null", auto_configure=False)
+        modem._post_connect_settle_s = 0
+        with patch(
+            "openhop_core.hardware.kiss_modem_wrapper.serial"
+        ) as fake_serial, patch.object(
+            kiss_modem_wrapper.threading, "Thread"
+        ), patch.object(
+            KissModemWrapper, "_wait_for_modem_ready", return_value=True
+        ), patch.object(
+            KissModemWrapper, "_query_modem_info"
+        ), patch.object(
+            KissModemWrapper, "_set_kiss_tx_delay"
+        ):
+            modem.connect()
+        assert fake_serial.Serial.call_count == 1
+        return fake_serial.Serial.call_args.kwargs
+
+    def test_connect_leaves_dtr_alone(self):
+        """dsrdtr=True stops pyserial asserting DTR on open, which resets the modem."""
+        assert self._connect_with_fake_serial().get("dsrdtr") is True
+
+    def test_connect_does_not_enable_hardware_flow_control(self):
+        """The firmware implements no RTS/CTS flow control on the RX pipe."""
+        assert self._connect_with_fake_serial().get("rtscts") is False


### PR DESCRIPTION
Two USB modem fixes, found while working out why a MeshCore KISS modem stopped behaving after MeshCore switched its ESP32-S3 KISS builds to the chip's native USB-Serial-JTAG peripheral.

## pyserial resets the board when the KISS port opens

`usb_radio.py` opens its port with `dsrdtr=True` and a comment explaining why: otherwise pyserial asserts DTR on open, which on a CP2102 board pulls EN low and reboots the ESP32. Both KISS wrappers open the same class of device through the plain `serial.Serial(port=...)` constructor, so they get the default instead.

The guard has to be passed explicitly. pyserial only skips the DTR write when `dsrdtr` is set, in `serialposix.py`, `_reconfigure_port`:

```python
if not self._dsrdtr:
    self._update_dtr_state()
```

So this adds `dsrdtr=True, rtscts=False` to `kiss_modem_wrapper.connect()` and `kiss_serial_wrapper.connect()`, matching `usb_radio.py`. Two tests cover the kwargs on the modem wrapper.

## 99-openhop-modem.rules

ESP32-S3 boards on native USB report their MAC as the USB serial number, colons and all, so udev builds names like:

```
usb-Espressif_USB_JTAG_serial_debug_unit_60:55:F9:C0:27:18-if00
```

Docker reads `devices:` entries as host:container and has no escape for a colon inside the path, so anyone running the repeater in a container cannot map that device. by-path is no better, those carry PCI addresses.

The rule creates `/dev/openhop-modem`, stable across replugs and usable in a compose file. It sits next to `99-ch341.rules`. Checked with `udevadm verify`. The VID/PID matches any ESP32-S3 on native USB, so the file also carries a commented variant pinned to one serial number, for hosts with several boards attached.

`openhop_repeater` installs the rule and documents it in a companion PR.
