### PR TITLE
Rename openHop Modem transport identifiers

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -31,7 +31,19 @@ from openhop_core import LocalIdentity
 from openhop_core.hardware.base import LoRaRadio
 from openhop_core.node.node import MeshNode
 
-RADIO_TYPES = ["waveshare", "uconsole", "meshadv-mini", "kiss-tnc", "kiss-modem", "ch341", "pinedio"]
+RADIO_TYPES = [
+    "waveshare",
+    "uconsole",
+    "meshadv-mini",
+    "kiss-tnc",
+    "kiss-modem",
+    "ch341",
+    "pinedio",
+    "modem_usb",
+    "modem_tcp",
+    "pymc_usb",  # Compatibility alias for modem_usb.
+    "pymc_tcp",  # Compatibility alias for modem_tcp.
+]
 
 
 def create_radio(
@@ -49,9 +61,11 @@ def create_radio(
             "kiss-modem"    — MeshCore KISS modem over serial
             "ch341"         — SX1262 via CH341 USB-to-SPI adapter
             "pinedio"       — Similar to CH341 but different pinout
-            "pymc_usb"      — pymc_usb firmware over USB-CDC
-            "pymc_tcp"      — pymc_usb firmware over Wi-Fi/TCP
-        serial_port: Serial port path. Used by "kiss-tnc", "kiss-modem", and "pymc_usb".
+            "modem_usb"     — openHop Modem over USB-CDC
+            "modem_tcp"     — openHop Modem over Wi-Fi/TCP
+            "pymc_usb"      — Compatibility alias for "modem_usb"
+            "pymc_tcp"      — Compatibility alias for "modem_tcp"
+        serial_port: Serial port path. Used by "kiss-tnc", "kiss-modem", and "modem_usb".
 
     Returns:
         Radio instance configured for the specified hardware
@@ -191,17 +205,26 @@ def create_radio(
             )
             return radio
 
-        # ── pymc_tcp (pymc_usb firmware over Wi-Fi/TCP) ─────────
-        if radio_type == "pymc_tcp":
+        # ── openHop Modem over Wi-Fi/TCP ────────────────────────
+        if radio_type in ("modem_tcp", "pymc_tcp"):
             from openhop_core.hardware.tcp_radio import TCPLoRaRadio
 
-            logger.debug("Using TCP LoRa Radio (pymc_usb firmware over Wi-Fi)")
+            logger.debug("Using openHop Modem TCP transport")
 
             tcp_config = {
-                "host": os.environ.get("PYMC_TCP_HOST", ""),
-                "port": int(os.environ.get("PYMC_TCP_PORT", 5055)),
-                "token": os.environ.get("PYMC_TCP_TOKEN", ""),
-                "connect_timeout": float(os.environ.get("PYMC_TCP_CONNECT_TIMEOUT", 5.0)),
+                "host": os.environ.get("MODEM_TCP_HOST", os.environ.get("PYMC_TCP_HOST", "")),
+                "port": int(
+                    os.environ.get("MODEM_TCP_PORT", os.environ.get("PYMC_TCP_PORT", 5055))
+                ),
+                "token": os.environ.get(
+                    "MODEM_TCP_TOKEN", os.environ.get("PYMC_TCP_TOKEN", "")
+                ),
+                "connect_timeout": float(
+                    os.environ.get(
+                        "MODEM_TCP_CONNECT_TIMEOUT",
+                        os.environ.get("PYMC_TCP_CONNECT_TIMEOUT", 5.0),
+                    )
+                ),
                 "frequency": int(os.environ.get("LORA_FREQ", 869618000)),
                 "bandwidth": int(os.environ.get("LORA_BW", 62500)),
                 "spreading_factor": int(os.environ.get("LORA_SF", 8)),
@@ -215,22 +238,23 @@ def create_radio(
 
             if not tcp_config["host"]:
                 raise ValueError(
-                    "pymc_tcp radio requires PYMC_TCP_HOST env var — " "modem hostname or LAN IP."
+                    "modem_tcp radio requires MODEM_TCP_HOST env var — modem hostname or LAN IP. "
+                    "PYMC_TCP_HOST remains available as a compatibility fallback."
                 )
 
             radio = TCPLoRaRadio(**tcp_config)
             logger.info(
-                f"pymc_tcp radio created at {tcp_config['host']}:{tcp_config['port']}: "
+                f"openHop Modem TCP radio created at {tcp_config['host']}:{tcp_config['port']}: "
                 f"{tcp_config['frequency']/1e6:.1f}MHz SF{tcp_config['spreading_factor']} "
                 f"BW{tcp_config['bandwidth']/1000:.0f}kHz {tcp_config['tx_power']}dBm"
             )
             return radio
 
-        # ── pymc_usb (pymc_usb firmware over USB-CDC) ───────────
-        if radio_type == "pymc_usb":
+        # ── openHop Modem over USB-CDC ──────────────────────────
+        if radio_type in ("modem_usb", "pymc_usb"):
             from openhop_core.hardware.usb_radio import USBLoRaRadio
 
-            logger.debug("Using USB LoRa Radio (pymc_usb firmware)")
+            logger.debug("Using openHop Modem USB transport")
 
             # Default: EU/UK (Narrow), Switzerland preset
             usb_config = {
@@ -249,7 +273,7 @@ def create_radio(
 
             radio = USBLoRaRadio(**usb_config)
             logger.info(
-                f"pymc_usb radio created on {serial_port}: "
+                f"openHop Modem USB radio created on {serial_port}: "
                 f"{usb_config['frequency']/1e6:.1f}MHz SF{usb_config['spreading_factor']} "
                 f"BW{usb_config['bandwidth']/1000:.0f}kHz {usb_config['tx_power']}dBm"
             )
@@ -317,7 +341,7 @@ def create_radio(
             raise ValueError(
                 f"Unknown radio type: {radio_type}. "
                 "Use 'waveshare', 'meshadv-mini', 'uconsole', 'kiss-tnc', "
-                "'kiss-modem', 'ch341', 'pymc_usb', or 'pymc_tcp'"
+                "'kiss-modem', 'ch341', 'pinedio', 'modem_usb', or 'modem_tcp'"
             )
 
         radio_kwargs = configs[radio_type]
@@ -349,9 +373,9 @@ def create_mesh_node(
     Args:
         node_name: Name for the mesh node
         radio_type: Type of radio hardware ("waveshare", "uconsole", "meshadv-mini",
-                    "kiss-tnc", "kiss-modem", "ch341", "pymc_usb", or "pymc_tcp")
-        serial_port: Serial port for KISS devices or pymc_usb
-                     (e.g. "/dev/ttyUSB0" for KISS, "/dev/ttyACM0" for pymc_usb)
+                    "kiss-tnc", "kiss-modem", "ch341", "modem_usb", or "modem_tcp")
+        serial_port: Serial port for KISS devices or an openHop Modem USB transport
+                     (e.g. "/dev/ttyUSB0" for KISS or "/dev/ttyACM0" for a modem)
         use_modem_identity: If True and radio_type is "kiss-modem", use the modem's
                            cryptographic identity instead of generating a local one.
                            This keeps the private key secure on the modem hardware.
@@ -401,7 +425,7 @@ def create_mesh_node(
             logger.info("CH341 radio initialized successfully")
             print("CH341 USB adapter radio initialized")
         else:
-            # waveshare/uconsole/meshadv-mini/pymc_usb/pymc_tcp all use begin()
+            # Direct radios and openHop Modem transports all use begin().
             logger.debug("Calling radio.begin()...")
             ok = radio.begin()
             if ok is False:

--- a/src/openhop_core/hardware/protocol_constants.py
+++ b/src/openhop_core/hardware/protocol_constants.py
@@ -2,7 +2,7 @@
 Wire-protocol constants and framing helpers shared by USBLoRaRadio and
 TCPLoRaRadio.
 
-Mirrors the on-the-wire format defined in the pymc_usb firmware
+Mirrors the on-the-wire format defined in the openHop Modem firmware
 (`firmware/include/protocol.h`). Keep this file and the firmware header
 in sync — every command code, struct layout, CRC vector and sync byte
 must match bit-for-bit, otherwise both drivers will silently lose frames.

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -1,8 +1,8 @@
 """
 TCP LoRa Radio Driver for openhop_core
 
-Implements the LoRaRadio interface using any board running the pymc_usb
-firmware in Wi-Fi/TCP mode. Same binary protocol as USBLoRaRadio — only
+Implements the LoRaRadio interface using an openHop Modem in Wi-Fi/TCP
+mode. Same binary protocol as USBLoRaRadio — only
 the transport differs.
 
 Drop-in replacement for SX1262Radio in openhop_core's hardware layer.
@@ -95,10 +95,10 @@ else:
 
 
 class TCPLoRaRadio(_RadioBase):
-    """TCP LoRa Radio — pymc_core LoRaRadio interface over Wi-Fi/TCP.
+    """TCP LoRa Radio — openhop_core LoRaRadio interface over Wi-Fi/TCP.
 
-    Communicates with any board running the pymc_usb firmware in Wi-Fi
-    STA mode. Provides the same interface as SX1262Radio and USBLoRaRadio
+    Communicates with an openHop Modem in Wi-Fi STA mode. Provides the
+    same interface as SX1262Radio and USBLoRaRadio
     for transparent integration with openhop_core.
     """
 
@@ -232,7 +232,7 @@ class TCPLoRaRadio(_RadioBase):
 
         # Always start the RX worker. When connected it processes traffic
         # immediately; otherwise _reconnect_with_backoff drives reconnection
-        # so the repeater UI can stay up while the user sets pymc_tcp.host
+        # so the repeater UI can stay up while the user sets modem_tcp.host
         # via /api/setup_wizard or /api/update_radio_config.
         self._stop_event.clear()
         self._rx_thread = threading.Thread(target=self._rx_worker, daemon=True, name="tcp-lora-rx")
@@ -391,7 +391,7 @@ class TCPLoRaRadio(_RadioBase):
             "last_snr": self.last_snr,
             "last_signal_rssi": self.last_signal_rssi,
             "hardware_ready": self._initialized,
-            "driver": "pymc_tcp",
+            "driver": "modem_tcp",
             "host": self.host,
             "port": self.port,
             "tx_count": self._tx_count,

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -1,7 +1,7 @@
 """
 USB LoRa Radio Driver for openhop_core
 
-Implements the LoRaRadio interface using a pymc_usb modem connected via
+Implements the LoRaRadio interface using an openHop Modem connected via
 USB-CDC. The modem acts as a "dumb" SX1262 transceiver — all MeshCore
 protocol logic runs on the host in openhop_core.
 
@@ -102,11 +102,11 @@ else:
 
 
 class USBLoRaRadio(_RadioBase):
-    """USB LoRa Radio — pymc_core LoRaRadio interface over USB-CDC serial.
+    """USB LoRa Radio — openhop_core LoRaRadio interface over USB-CDC serial.
 
-    Communicates with any board running the pymc_usb firmware over a
-    USB-CDC serial link. Provides the same interface as SX1262Radio for
-    transparent integration with pymc_core's Dispatcher and MeshNode.
+    Communicates with an openHop Modem over a USB-CDC serial link.
+    Provides the same interface as SX1262Radio for
+    transparent integration with openhop_core's Dispatcher and MeshNode.
     """
 
     def __init__(
@@ -411,7 +411,7 @@ class USBLoRaRadio(_RadioBase):
             "last_snr": self.last_snr,
             "last_signal_rssi": self.last_signal_rssi,
             "hardware_ready": self._initialized,
-            "driver": "pymc_usb",
+            "driver": "modem_usb",
             "port": self.port,
             "tx_count": self._tx_count,
             "rx_count": self._rx_count,

--- a/tests/hardware/test_protocol_constants.py
+++ b/tests/hardware/test_protocol_constants.py
@@ -1,5 +1,5 @@
 """
-Offline tests for the shared pymc_usb wire-protocol primitives.
+Offline tests for the shared openHop Modem wire-protocol primitives.
 
 Verifies CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, no reflect,
 no xor-out) and frame layout produced by `crc16_ccitt` / `build_frame`

--- a/tests/test_examples_common.py
+++ b/tests/test_examples_common.py
@@ -1,0 +1,133 @@
+import importlib
+from typing import Any
+from unittest.mock import patch
+
+from openhop_core.hardware import tcp_radio, usb_radio
+from openhop_core.hardware.tcp_radio import TCPLoRaRadio
+from openhop_core.hardware.usb_radio import USBLoRaRadio
+
+with patch("logging.basicConfig"):
+    common = importlib.import_module("examples.common")
+
+
+def _capture_constructor(monkeypatch, module, class_name):
+    calls = []
+
+    def constructor(**kwargs):
+        calls.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(module, class_name, constructor)
+    return calls
+
+
+def test_radio_types_expose_canonical_modem_names_and_compatibility_aliases():
+    assert "modem_tcp" in common.RADIO_TYPES
+    assert "modem_usb" in common.RADIO_TYPES
+    assert "pymc_tcp" in common.RADIO_TYPES
+    assert "pymc_usb" in common.RADIO_TYPES
+
+
+def test_modem_tcp_prefers_canonical_environment_variables(monkeypatch):
+    calls = _capture_constructor(monkeypatch, tcp_radio, "TCPLoRaRadio")
+    monkeypatch.setenv("MODEM_TCP_HOST", "canonical.example")
+    monkeypatch.setenv("MODEM_TCP_PORT", "6001")
+    monkeypatch.setenv("MODEM_TCP_TOKEN", "canonical-token")
+    monkeypatch.setenv("MODEM_TCP_CONNECT_TIMEOUT", "7.5")
+    monkeypatch.setenv("PYMC_TCP_HOST", "legacy.example")
+    monkeypatch.setenv("PYMC_TCP_PORT", "6002")
+    monkeypatch.setenv("PYMC_TCP_TOKEN", "legacy-token")
+    monkeypatch.setenv("PYMC_TCP_CONNECT_TIMEOUT", "8.5")
+
+    common.create_radio("modem_tcp")
+
+    assert calls == [
+        {
+            "host": "canonical.example",
+            "port": 6001,
+            "token": "canonical-token",
+            "connect_timeout": 7.5,
+            "frequency": 869618000,
+            "bandwidth": 62500,
+            "spreading_factor": 8,
+            "coding_rate": 8,
+            "tx_power": 22,
+            "sync_word": 0x12,
+            "preamble_length": 16,
+            "lbt_enabled": True,
+            "lbt_max_attempts": 5,
+        }
+    ]
+
+
+def test_modem_tcp_uses_legacy_environment_variables_as_fallback(monkeypatch):
+    calls = _capture_constructor(monkeypatch, tcp_radio, "TCPLoRaRadio")
+    monkeypatch.delenv("MODEM_TCP_HOST", raising=False)
+    monkeypatch.delenv("MODEM_TCP_PORT", raising=False)
+    monkeypatch.delenv("MODEM_TCP_TOKEN", raising=False)
+    monkeypatch.delenv("MODEM_TCP_CONNECT_TIMEOUT", raising=False)
+    monkeypatch.setenv("PYMC_TCP_HOST", "legacy.example")
+    monkeypatch.setenv("PYMC_TCP_PORT", "6002")
+    monkeypatch.setenv("PYMC_TCP_TOKEN", "legacy-token")
+    monkeypatch.setenv("PYMC_TCP_CONNECT_TIMEOUT", "8.5")
+
+    common.create_radio("modem_tcp")
+
+    assert calls[0]["host"] == "legacy.example"
+    assert calls[0]["port"] == 6002
+    assert calls[0]["token"] == "legacy-token"
+    assert calls[0]["connect_timeout"] == 8.5
+
+
+def test_legacy_tcp_radio_type_remains_a_compatibility_alias(monkeypatch):
+    calls = _capture_constructor(monkeypatch, tcp_radio, "TCPLoRaRadio")
+    monkeypatch.setenv("MODEM_TCP_HOST", "modem.example")
+
+    common.create_radio("pymc_tcp")
+
+    assert calls[0]["host"] == "modem.example"
+
+
+def test_canonical_and_legacy_usb_radio_types_use_usb_transport(monkeypatch):
+    calls = _capture_constructor(monkeypatch, usb_radio, "USBLoRaRadio")
+
+    common.create_radio("modem_usb", "/dev/canonical-modem")
+    common.create_radio("pymc_usb", "/dev/legacy-modem")
+
+    assert calls[0]["port"] == "/dev/canonical-modem"
+    assert calls[1]["port"] == "/dev/legacy-modem"
+
+
+def _status_radio(radio_class: type[Any], **transport_fields):
+    radio = object.__new__(radio_class)
+    fields = {
+        "_initialized": True,
+        "frequency": 869_618_000,
+        "tx_power": 22,
+        "spreading_factor": 8,
+        "bandwidth": 62_500,
+        "coding_rate": 8,
+        "last_rssi": -90,
+        "last_snr": 7.5,
+        "last_signal_rssi": -88,
+        "_tx_count": 3,
+        "_rx_count": 4,
+        "_crc_errors": 1,
+        "crc_error_count": 1,
+        **transport_fields,
+    }
+    for name, value in fields.items():
+        setattr(radio, name, value)
+    return radio
+
+
+def test_tcp_status_reports_canonical_modem_driver():
+    status = _status_radio(TCPLoRaRadio, host="modem.local", port=5055).get_status()
+
+    assert status["driver"] == "modem_tcp"
+
+
+def test_usb_status_reports_canonical_modem_driver():
+    status = _status_radio(USBLoRaRadio, port="/dev/ttyACM0").get_status()
+
+    assert status["driver"] == "modem_usb"


### PR DESCRIPTION
## Summary

Make `modem_tcp` and `modem_usb` the canonical openHop Core transport identifiers while preserving compatibility for existing examples and deployments.

- report canonical driver names from TCP and USB status responses;
- accept canonical radio types in shared examples;
- keep `pymc_tcp` and `pymc_usb` as explicit compatibility aliases;
- add canonical `MODEM_TCP_*` environment variables;
- retain `PYMC_TCP_*` as fallback environment variables;
- replace legacy product wording with openHop Modem terminology;
- leave transport classes, module paths, packet framing, command IDs, and RF behavior unchanged.

## Upgrade compatibility

Existing modem firmware does not need an update. The transport identifier is a host-side Core/Repeater configuration value and is not sent over the modem wire protocol.

Existing example invocations using `pymc_tcp` or `pymc_usb` continue to construct the same `TCPLoRaRadio` or `USBLoRaRadio` classes. Existing `PYMC_TCP_HOST`, `PYMC_TCP_PORT`, `PYMC_TCP_TOKEN`, and `PYMC_TCP_CONNECT_TIMEOUT` variables remain supported as fallbacks. Canonical `MODEM_TCP_*` values take precedence when both forms are set.

The observable Core status `driver` field now reports `modem_tcp` or `modem_usb`. Downstream consumers that compare this field should move to the canonical values.

USB descriptors, old modem hostnames such as `pymc-*.local`, device paths containing legacy branding, authentication, CAD, RX/TX, and the binary modem protocol remain unaffected.

## Verification

- Full Core pytest suite passed.
- Focused modem example/status/protocol tests passed.
- Pre-commit passed whitespace, EOF, YAML, large-file, Black, isort, and flake8 hooks.
- `git diff --check` passed.
- Real TCP modem operation was validated through the coordinated Repeater deployment, including authentication, PONG, radio configuration, and CAD threshold application.

## Coordinated PRs and merge order

1. RepeaterUI: https://github.com/openhop-dev/openHop_RepeaterUI/pull/97
2. openHop Core: this PR
3. openHop Repeater: https://github.com/openhop-dev/openhop_repeater/pull/397

Repeater merges last because its Docker build assembles the matching Core and RepeaterUI revisions.
