### PR TITLE
fix(sx1262): time-bounded LBT and reception-aware TX path

### DIFF
--- a/src/openhop_core/hardware/lora/LoRaRF/SX126x.py
+++ b/src/openhop_core/hardware/lora/LoRaRF/SX126x.py
@@ -1123,9 +1123,14 @@ class SX126x(BaseLoRa):
         # # skip to enter RX mode when previous RX operation incomplete
         # if self.getMode() == self.STATUS_MODE_RX:
         #     return False
-        # clear previous interrupt and set RX done, RX timeout, header error, and CRC error as interrupt source
         self._irqSetup(
-            self.IRQ_RX_DONE | self.IRQ_TIMEOUT | self.IRQ_HEADER_ERR | self.IRQ_CRC_ERR
+            self.IRQ_RX_DONE
+            | self.IRQ_TIMEOUT
+            | self.IRQ_HEADER_ERR
+            | self.IRQ_CRC_ERR
+            | self.IRQ_PREAMBLE_DETECTED
+            | self.IRQ_SYNC_WORD_VALID
+            | self.IRQ_HEADER_VALID
         )
         # set status to RX wait or RX continuous wait
         self._statusWait = self.STATUS_RX_WAIT
@@ -1152,9 +1157,14 @@ class SX126x(BaseLoRa):
         # skip to enter RX mode when previous RX operation incomplete
         if self.getMode() == self.STATUS_MODE_RX:
             return False
-        # clear previous interrupt and set RX done, RX timeout, header error, and CRC error as interrupt source
         self._irqSetup(
-            self.IRQ_RX_DONE | self.IRQ_TIMEOUT | self.IRQ_HEADER_ERR | self.IRQ_CRC_ERR
+            self.IRQ_RX_DONE
+            | self.IRQ_TIMEOUT
+            | self.IRQ_HEADER_ERR
+            | self.IRQ_CRC_ERR
+            | self.IRQ_PREAMBLE_DETECTED
+            | self.IRQ_SYNC_WORD_VALID
+            | self.IRQ_HEADER_VALID
         )
         # set status to RX wait or RX continuous wait
         self._statusWait = self.STATUS_RX_WAIT

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1126,7 +1126,7 @@ class SX1262Radio(LoRaRadio):
         if existing_irq != 0:
             self.lora.clearIrqStatus(existing_irq)
 
-    async def _prepare_radio_for_tx(self) -> tuple[bool, list[float]]:
+    async def _prepare_radio_for_tx(self) -> tuple[bool, list[int]]:
         """Prepare radio hardware for transmission. Returns (success, lbt_backoff_delays_ms)."""
         self._tx_done_event.clear()
         self._rx_done_event.clear()
@@ -1139,7 +1139,7 @@ class SX1262Radio(LoRaRadio):
         # jittered retries run for the whole budget, keeping two nodes' checks
         # decorrelated and bounding the post-clear latency to one retry
         # interval. (MeshCore: 200 ms retry, getCADFailMaxDuration() 4 s cap.)
-        lbt_backoff_delays: list[float] = []
+        lbt_backoff_delays: list[int] = []
         lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
         lbt_started = time.monotonic()
         latch_defers = 0
@@ -1184,7 +1184,9 @@ class SX1262Radio(LoRaRadio):
             delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
             remaining_ms = (lbt_deadline - time.monotonic()) * 1000.0
             delay_ms = max(10.0, min(delay_ms, remaining_ms))
-            lbt_backoff_delays.append(float(delay_ms))
+            # Whole milliseconds: the list is reported and persisted as-is
+            # downstream, and sub-ms decimals are noise on a jittered wait.
+            lbt_backoff_delays.append(round(delay_ms))
             if scanned:
                 # Only a CAD scan leaves the radio in standby, so only then is
                 # there RX to re-arm before the wait. After the passive check

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1184,6 +1184,15 @@ class SX1262Radio(LoRaRadio):
             _trace(f"LBT: channel busy - retrying in {delay_ms:.0f}ms")
             await asyncio.sleep(delay_ms / 1000.0)
 
+        # Committing to TX aborts any reception still in progress, so its
+        # terminal IRQ will never arrive — clear the reception markers here,
+        # or the next send would defer on a ghost, without running a single
+        # CAD, until the staleness bound expired. (MeshCore is immune by
+        # construction: its isReceiving() re-reads the live chip flags, and
+        # a transmit clears them.)
+        self._rx_activity_at = 0.0
+        self._rx_header_at = 0.0
+
         # Stage the TX only now: dropping to standby before the LBT loop would
         # abort any reception in progress before even checking for one.
         self.lora.setStandby(self.lora.STANDBY_RC)

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1141,6 +1141,10 @@ class SX1262Radio(LoRaRadio):
         # interval. (MeshCore: 200 ms retry, getCADFailMaxDuration() 4 s cap.)
         lbt_backoff_delays: list[float] = []
         lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
+        lbt_started = time.monotonic()
+        latch_defers = 0
+        cad_checks = 0
+        outcome = "forced"
 
         while True:
             scanned = False
@@ -1151,14 +1155,18 @@ class SX1262Radio(LoRaRadio):
                 # which aborts the very reception it is probing for.
                 if self.is_receiving_packet():
                     channel_busy = True
+                    latch_defers += 1
                     _trace("LBT: reception in progress - deferring TX")
                 else:
                     scanned = True
+                    cad_checks += 1
                     channel_busy = await self.perform_cad(timeout=0.5, respect_tx_lock=False)
                 if not channel_busy:
+                    outcome = "clear"
                     _trace("LBT: channel clear")
                     break
             except Exception as e:
+                outcome = "exception"
                 logger.warning(f"LBT channel check failed: {e}, proceeding with transmission")
                 break
 
@@ -1195,6 +1203,12 @@ class SX1262Radio(LoRaRadio):
         # a transmit clears them.)
         self._rx_activity_at = 0.0
         self._rx_header_at = 0.0
+
+        logger.debug(
+            f"LBT summary: outcome={outcome} elapsed={(time.monotonic() - lbt_started) * 1000:.0f}ms "
+            f"latch_defers={latch_defers} cad_checks={cad_checks} "
+            f"backoff_total={sum(lbt_backoff_delays):.0f}ms"
+        )
 
         # Stage the TX only now: dropping to standby before the LBT loop would
         # abort any reception in progress before even checking for one.
@@ -1852,7 +1866,12 @@ class SX1262Radio(LoRaRadio):
             return False
         has_header = self._rx_header_at > 0
         bound = self._max_reception_seconds() if has_header else self._max_preamble_seconds()
-        if time.monotonic() - started > bound:
+        elapsed = time.monotonic() - started
+        if elapsed > bound:
+            logger.debug(
+                f"Reception latch expired ({'header' if has_header else 'preamble'} phase, "
+                f"{elapsed * 1000:.0f}ms > {bound * 1000:.0f}ms bound)"
+            )
             self._rx_activity_at = 0.0
             self._rx_header_at = 0.0
             return False

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -433,10 +433,13 @@ class SX1262Radio(LoRaRadio):
                 )
                 if irqStat & reception_markers:
                     now_mono = time.monotonic()
-                    if self._rx_activity_at <= 0:
-                        self._rx_activity_at = now_mono
                     if irqStat & self.lora.IRQ_HEADER_VALID:
+                        # Header valid restarts the clock onto the longer bound.
+                        if self._rx_header_at <= 0:
+                            self._rx_activity_at = now_mono
                         self._rx_header_at = now_mono
+                    elif self._rx_activity_at <= 0:
+                        self._rx_activity_at = now_mono
                 if irqStat & terminal_interrupts:
                     self._rx_activity_at = 0.0
                     self._rx_header_at = 0.0
@@ -1822,16 +1825,17 @@ class SX1262Radio(LoRaRadio):
         return symbol_map[cad_symbol_num]
 
     def _max_reception_seconds(self) -> float:
-        """Upper bound on how long one reception can plausibly last.
-
-        Worst-case airtime of a max-size packet at the current radio params,
-        padded by 50%. Bounds the reception-progress latch so a lost terminal
-        IRQ cannot report "receiving" forever and wedge TX — MeshCore bounds
-        its equivalent (_maxPayloadMillis) the same way.
-        """
+        """Worst-case max-size packet airtime + 50%, once a header is seen (MeshCore: _maxPayloadMillis)."""
         final_timeout_ms, _ = self._calculate_tx_timeout(255)
         # _calculate_tx_timeout returns airtime + 1000 ms margin.
         return max(0.5, (final_timeout_ms - 1000) * 1.5 / 1000.0)
+
+    def _max_preamble_seconds(self) -> float:
+        """Preamble-to-header-valid latency bound, recomputed live from SF/BW/CR (MeshCore: _preambleMillis)."""
+        preamble_only_ms = calculate_lora_airtime_ms(
+            0, self.spreading_factor, int(self.bandwidth), self.coding_rate, self.preamble_length
+        )
+        return max(0.05, preamble_only_ms * 1.5 / 1000.0)
 
     def is_receiving_packet(self) -> bool:
         """True while the chip reported an in-progress reception.
@@ -1846,9 +1850,9 @@ class SX1262Radio(LoRaRadio):
         started = self._rx_activity_at
         if started <= 0:
             return False
-        if time.monotonic() - started > self._max_reception_seconds():
-            # Stale marker: the chip moved on without a terminal IRQ reaching
-            # us (lost edge, cleared flags). Expire it rather than wedge TX.
+        has_header = self._rx_header_at > 0
+        bound = self._max_reception_seconds() if has_header else self._max_preamble_seconds()
+        if time.monotonic() - started > bound:
             self._rx_activity_at = 0.0
             self._rx_header_at = 0.0
             return False

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1013,9 +1013,9 @@ class SX1262Radio(LoRaRadio):
                         self.lora.CAD_EXIT_STDBY,  # exit to standby
                         0,  # no timeout
                     )
-                    logger.debug("Custom CAD thresholds written")
+                    logger.debug("[CAD] Custom thresholds written")
                 except Exception as e:
-                    logger.warning(f"Failed to write CAD thresholds: {e}")
+                    logger.warning(f"[CAD] Failed to write thresholds: {e}")
 
             self.lora.request(self.lora.RX_CONTINUOUS)
             time.sleep(self._RADIO_TIMING_DELAY)
@@ -1126,6 +1126,12 @@ class SX1262Radio(LoRaRadio):
         if existing_irq != 0:
             self.lora.clearIrqStatus(existing_irq)
 
+    # Log taxonomy, shared with the USB/TCP modem radios: [LBT] is the
+    # listen-before-talk retry loop, [CAD] a single channel-activity scan,
+    # [TX] the transmit path. A nominal TX logs two DEBUG lines — the
+    # "[LBT] Summary" and "[TX] Done" — contention adds bounded DEBUG
+    # retries, anomalies log at WARNING, and a send that did not happen at
+    # ERROR. TRACE carries the chip-level minutiae.
     async def _prepare_radio_for_tx(self) -> tuple[bool, list[int]]:
         """Prepare radio hardware for transmission. Returns (success, lbt_backoff_delays_ms)."""
         self._tx_done_event.clear()
@@ -1156,18 +1162,18 @@ class SX1262Radio(LoRaRadio):
                 if self.is_receiving_packet():
                     channel_busy = True
                     latch_defers += 1
-                    _trace("LBT: reception in progress - deferring TX")
+                    logger.debug("[LBT] Reception in progress - deferring TX")
                 else:
                     scanned = True
                     cad_checks += 1
                     channel_busy = await self.perform_cad(timeout=0.5, respect_tx_lock=False)
                 if not channel_busy:
                     outcome = "clear"
-                    _trace("LBT: channel clear")
+                    _trace("[LBT] Channel clear")
                     break
             except Exception as e:
                 outcome = "exception"
-                logger.warning(f"LBT channel check failed: {e}, proceeding with transmission")
+                logger.warning(f"[LBT] Channel check failed: {e}, proceeding with transmission")
                 break
 
             if time.monotonic() >= lbt_deadline:
@@ -1176,7 +1182,7 @@ class SX1262Radio(LoRaRadio):
                 # would stall the TX queue. Mirrors MeshCore forcing the send
                 # once getCADFailMaxDuration() elapses.
                 logger.warning(
-                    f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
+                    f"[LBT] Budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
                     "channel still busy, transmitting anyway"
                 )
                 break
@@ -1194,7 +1200,7 @@ class SX1262Radio(LoRaRadio):
                 # IRQ flags and drop to standby — aborting the very reception
                 # that set the latch, with no terminal IRQ left to clear it.
                 await self._restore_rx_for_cad_backoff()
-            _trace(f"LBT: channel busy - retrying in {delay_ms:.0f}ms")
+            logger.debug(f"[LBT] Channel busy - retrying in {delay_ms:.0f}ms")
             await asyncio.sleep(delay_ms / 1000.0)
 
         # Committing to TX aborts any reception still in progress, so its
@@ -1207,7 +1213,7 @@ class SX1262Radio(LoRaRadio):
         self._rx_header_at = 0.0
 
         logger.debug(
-            f"LBT summary: outcome={outcome} elapsed={(time.monotonic() - lbt_started) * 1000:.0f}ms "
+            f"[LBT] Summary: outcome={outcome} elapsed={(time.monotonic() - lbt_started) * 1000:.0f}ms "
             f"latch_defers={latch_defers} cad_checks={cad_checks} "
             f"backoff_total={sum(lbt_backoff_delays):.0f}ms"
         )
@@ -1225,14 +1231,14 @@ class SX1262Radio(LoRaRadio):
         self._control_tx_rx_pins(tx_mode=True)
 
         if self.lora.busyCheck():
-            logger.warning("Radio is busy before starting transmission")
+            logger.warning("[TX] Radio busy before start")
             # Wait for radio to become ready
             busy_timeout = 0
             while self.lora.busyCheck() and busy_timeout < 100:
                 await asyncio.sleep(self.RADIO_TIMING_DELAY)
                 busy_timeout += 1
             if self.lora.busyCheck():
-                logger.error("Radio stayed busy - cannot start transmission")
+                logger.error("[TX] Radio stayed busy - aborting")
                 return False, lbt_backoff_delays
 
         return True, lbt_backoff_delays
@@ -1291,7 +1297,7 @@ class SX1262Radio(LoRaRadio):
             busy_timeout += 1
 
         if self.lora.busyCheck():
-            logger.error("Radio stayed busy after TX command - transmission may not have started")
+            logger.error("[TX] Radio stayed busy after TX command - transmission may not have started")
             return False
 
         # Check initial interrupt status immediately after TX command
@@ -1341,7 +1347,7 @@ class SX1262Radio(LoRaRadio):
             elapsed = time.time() - start_time
             remaining = timeout_seconds - elapsed
             if remaining <= 0:
-                logger.error("[TX] TX completion timeout - no interrupt received!")
+                logger.error("[TX] Completion timeout - no interrupt received")
                 await self._handle_transmission_timeout(timeout_seconds, start_time)
                 return False
 
@@ -1387,17 +1393,17 @@ class SX1262Radio(LoRaRadio):
     async def _handle_transmission_timeout(self, timeout_seconds: float, start_time: float) -> None:
         """Handle transmission timeout and provide diagnostic information"""
         logger.error(
-            f"Transmission wait timed out after {timeout_seconds:.1f} seconds - "
+            f"[TX] Transmission wait timed out after {timeout_seconds:.1f}s - "
             f"radio may not be transmitting"
         )
 
         # Check interrupt status to see what happened
         irqStat = self.lora.getIrqStatus()
-        logger.error(f"Interrupt status at timeout: 0x{irqStat:04X}")
+        logger.error(f"[TX] Interrupt status at timeout: 0x{irqStat:04X}")
 
         # Check if this is a configuration issue
         if irqStat == 0x0200:  # Only timeout bit set
-            logger.error("Radio configuration issue: TX operation timed out without starting")
+            logger.error("[TX] Radio configuration issue - timed out without starting")
 
         self.lora.clearIrqStatus(irqStat)
 
@@ -1407,12 +1413,12 @@ class SX1262Radio(LoRaRadio):
         irqStat = self.lora.getIrqStatus()
 
         # Check what actually happened
-        _trace(f"Final interrupt status: 0x{irqStat:04X}")
+        _trace(f"[TX] Final interrupt status: 0x{irqStat:04X}")
 
         if irqStat & self.lora.IRQ_TX_DONE:
             pass  # Success
         elif irqStat & self.lora.IRQ_TIMEOUT:
-            logger.warning("TX_TIMEOUT interrupt received - transmission failed")
+            logger.warning("[TX] TX_TIMEOUT interrupt received - transmission failed")
         else:
             # No warning for 0x0000 - interrupt already cleared by handler
             pass
@@ -1422,9 +1428,9 @@ class SX1262Radio(LoRaRadio):
             tx_time = self.lora.transmitTime()
             if tx_time > 0:
                 data_rate = self.lora.dataRate()
-                logger.debug(f"Packet transmitted: {tx_time:.2f}ms, {data_rate:.2f} bytes/s")
+                _trace(f"[TX] Chip stats: {tx_time:.2f}ms, {data_rate:.2f} bytes/s")
         except Exception as e:
-            logger.debug(f"Transmission stats not available: {e}")
+            _trace(f"[TX] Chip stats not available: {e}")
 
         # Clear interrupt status
         self.lora.clearIrqStatus(irqStat)
@@ -1495,7 +1501,7 @@ class SX1262Radio(LoRaRadio):
                 airtime_ms = final_timeout_ms - 1000
 
                 _trace(
-                    f"Setting TX timeout: {final_timeout_ms}ms "
+                    f"[TX] Setting timeout: {final_timeout_ms}ms "
                     f"(tOut={driver_timeout}) for {length} bytes"
                 )
 
@@ -1523,6 +1529,8 @@ class SX1262Radio(LoRaRadio):
                 # Trigger TX LED
                 self._gpio_manager.blink_led(self.txled_pin)
 
+                logger.debug(f"[TX] Done {length}B airtime={airtime_ms:.0f}ms")
+
                 # Build and return transmission metadata
                 return {
                     "airtime_ms": airtime_ms,
@@ -1532,7 +1540,7 @@ class SX1262Radio(LoRaRadio):
                 }
 
             except Exception as e:
-                logger.error(f"Failed to send packet: {e}")
+                logger.error(f"[TX] Send failed: {e}")
                 raise
             finally:
                 # Always leave radio in RX continuous mode after TX
@@ -1792,20 +1800,20 @@ class SX1262Radio(LoRaRadio):
 
         self._custom_cad_peak = peak
         self._custom_cad_min = min_val
-        logger.info(f"Custom CAD thresholds set: peak={peak}, min={min_val}")
+        logger.info(f"[CAD] Custom thresholds set: peak={peak}, min={min_val}")
 
     def clear_custom_cad_thresholds(self) -> None:
         """Clear custom CAD thresholds and revert to defaults."""
         self._custom_cad_peak = None
         self._custom_cad_min = None
-        logger.info("Custom CAD thresholds cleared, reverting to defaults")
+        logger.info("[CAD] Custom thresholds cleared, reverting to defaults")
 
     def set_custom_cad_symbol_num(self, cad_symbol_num: int) -> None:
         """Set custom CAD symbol count that overrides the default runtime value."""
         if cad_symbol_num not in {1, 2, 4, 8, 16}:
             raise ValueError("cad_symbol_num must be one of: 1, 2, 4, 8, 16")
         self._custom_cad_symbol_num = int(cad_symbol_num)
-        logger.info("Custom CAD symbol count set: symbols=%s", self._custom_cad_symbol_num)
+        logger.info("[CAD] Custom symbol count set: symbols=%s", self._custom_cad_symbol_num)
 
     def _get_thresholds_for_current_settings(self) -> tuple[int, int]:
         """Fetch CAD thresholds for the current spreading factor.
@@ -2018,12 +2026,12 @@ class SX1262Radio(LoRaRadio):
                 detected = self._last_cad_detected
                 cad_done = bool(irq & self.lora.IRQ_CAD_DONE)
 
-                _trace(f"CAD operation completed - IRQ status: 0x{irq:04X}")
+                _trace(f"[CAD] Scan completed - IRQ status: 0x{irq:04X}")
 
                 if detected:
-                    _trace("CAD result: BUSY - channel activity detected")
+                    _trace("[CAD] BUSY - channel activity detected")
                 else:
-                    _trace("CAD result: CLEAR - no channel activity detected")
+                    _trace("[CAD] CLEAR - no channel activity detected")
 
                 # Clear hardware IRQ status
                 current_irq = self.lora.getIrqStatus()
@@ -2047,10 +2055,10 @@ class SX1262Radio(LoRaRadio):
                     return detected
 
             except asyncio.TimeoutError:
-                _trace("CAD operation timed out - assuming channel clear")
+                _trace("[CAD] Timed out - assuming clear")
                 irq = self.lora.getIrqStatus()
                 if irq != 0:
-                    _trace(f"CAD timeout but IRQ status: 0x{irq:04X}")
+                    _trace(f"[CAD] Timeout but IRQ status: 0x{irq:04X}")
                     self.lora.clearIrqStatus(irq)
 
                 if calibration:
@@ -2071,7 +2079,7 @@ class SX1262Radio(LoRaRadio):
                     return False
 
         except Exception as e:
-            logger.error(f"CAD operation failed: {e}")
+            logger.error(f"[CAD] Scan failed: {e}")
             if calibration:
                 return {
                     "frequency": self.frequency,
@@ -2121,7 +2129,7 @@ class SX1262Radio(LoRaRadio):
                     self._floor_sample_sum = 0.0
                     self._noise_floor_samples = []
             except Exception as e:
-                logger.warning(f"Failed to restore RX mode after CAD: {e}")
+                logger.warning(f"[CAD] Failed to restore RX mode: {e}")
             finally:
                 if acquired_tx_lock and self._tx_lock.locked():
                     self._tx_lock.release()

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -87,6 +87,8 @@ class SX1262Radio(LoRaRadio):
         use_dio3_tcxo: bool = False,
         dio3_tcxo_voltage: float = 1.8,
         use_dio2_rf: bool = False,
+        lbt_max_wait_seconds: float = 4.0,
+        lbt_retry_interval_ms: int = 200,
         radio_timing_delay: float = RADIO_TIMING_DELAY,
         spi_transport=None,
         gpio_manager=None,
@@ -219,6 +221,22 @@ class SX1262Radio(LoRaRadio):
 
         # Store CAD results from interrupt handler
         self._last_cad_detected = False
+
+        # Listen-Before-Talk budget, bounded in TIME rather than attempts, so
+        # an occupation longer than the budget cannot leave two neighbours
+        # forcing their TX in lockstep. Defaults match MeshCore (4 s cap,
+        # 200 ms retry); the jitter keeps two nodes' checks decorrelated.
+        self.lbt_max_wait_seconds = max(0.5, float(lbt_max_wait_seconds))
+        self.lbt_retry_interval_ms = max(20, int(lbt_retry_interval_ms))
+
+        # Reception-in-progress markers (parity with MeshCore
+        # CustomSX1262::isReceiving()). The interrupt handler clears the
+        # chip-side PREAMBLE/SYNC/HEADER flags, so these timestamps are the
+        # only place "a reception has started" survives. Terminal RX IRQs
+        # clear them; is_receiving_packet() expires them after a worst-case
+        # airtime so a lost terminal IRQ cannot wedge TX.
+        self._rx_activity_at: float = 0.0
+        self._rx_header_at: float = 0.0
         self._last_cad_irq_status = 0
 
         # Custom CAD thresholds (None means use defaults)
@@ -403,6 +421,25 @@ class SX1262Radio(LoRaRadio):
                     | self.lora.IRQ_TIMEOUT
                     | self.lora.IRQ_HEADER_ERR
                 )
+
+                # Latch reception-progress markers before the chip-side flags
+                # are cleared: the TX path reads them (is_receiving_packet)
+                # rather than dropping to standby for a CAD scan, which would
+                # abort the very reception it is checking for.
+                reception_markers = (
+                    self.lora.IRQ_PREAMBLE_DETECTED
+                    | self.lora.IRQ_SYNC_WORD_VALID
+                    | self.lora.IRQ_HEADER_VALID
+                )
+                if irqStat & reception_markers:
+                    now_mono = time.monotonic()
+                    if self._rx_activity_at <= 0:
+                        self._rx_activity_at = now_mono
+                    if irqStat & self.lora.IRQ_HEADER_VALID:
+                        self._rx_header_at = now_mono
+                if irqStat & terminal_interrupts:
+                    self._rx_activity_at = 0.0
+                    self._rx_header_at = 0.0
 
                 # Log all interrupt types for debugging
                 if irqStat & self.lora.IRQ_RX_DONE:
@@ -1095,6 +1132,60 @@ class SX1262Radio(LoRaRadio):
         # latched in software before we begin CAD/TX buffer reuse.
         await self._drain_pending_rx_irq_before_buffer_reuse()
 
+        # Listen Before Talk, bounded in TIME rather than attempts: short
+        # jittered retries run for the whole budget, keeping two nodes' checks
+        # decorrelated and bounding the post-clear latency to one retry
+        # interval. (MeshCore: 200 ms retry, getCADFailMaxDuration() 4 s cap.)
+        lbt_backoff_delays: list[float] = []
+        lbt_deadline = time.monotonic() + self.lbt_max_wait_seconds
+
+        while True:
+            scanned = False
+            try:
+                # Passive check first: a latched in-progress reception is
+                # authoritative and free — and it must be consulted BEFORE
+                # any standby(), because perform_cad() drops to standby,
+                # which aborts the very reception it is probing for.
+                if self.is_receiving_packet():
+                    channel_busy = True
+                    _trace("LBT: reception in progress - deferring TX")
+                else:
+                    scanned = True
+                    channel_busy = await self.perform_cad(timeout=0.5, respect_tx_lock=False)
+                if not channel_busy:
+                    _trace("LBT: channel clear")
+                    break
+            except Exception as e:
+                logger.warning(f"LBT channel check failed: {e}, proceeding with transmission")
+                break
+
+            if time.monotonic() >= lbt_deadline:
+                # Busy for the whole budget: past this point the likeliest
+                # cause is a radio wedged in a bad state, and refusing forever
+                # would stall the TX queue. Mirrors MeshCore forcing the send
+                # once getCADFailMaxDuration() elapses.
+                logger.warning(
+                    f"LBT budget exhausted ({self.lbt_max_wait_seconds:.1f}s) - "
+                    "channel still busy, transmitting anyway"
+                )
+                break
+
+            delay_ms = self.lbt_retry_interval_ms * random.uniform(0.5, 1.5)
+            remaining_ms = (lbt_deadline - time.monotonic()) * 1000.0
+            delay_ms = max(10.0, min(delay_ms, remaining_ms))
+            lbt_backoff_delays.append(float(delay_ms))
+            if scanned:
+                # Only a CAD scan leaves the radio in standby, so only then is
+                # there RX to re-arm before the wait. After the passive check
+                # the radio is still receiving, and re-arming would clear the
+                # IRQ flags and drop to standby — aborting the very reception
+                # that set the latch, with no terminal IRQ left to clear it.
+                await self._restore_rx_for_cad_backoff()
+            _trace(f"LBT: channel busy - retrying in {delay_ms:.0f}ms")
+            await asyncio.sleep(delay_ms / 1000.0)
+
+        # Stage the TX only now: dropping to standby before the LBT loop would
+        # abort any reception in progress before even checking for one.
         self.lora.setStandby(self.lora.STANDBY_RC)
         await asyncio.sleep(self.RADIO_TIMING_DELAY)  # Give hardware time to enter standby
         if self.lora.busyCheck():
@@ -1102,47 +1193,6 @@ class SX1262Radio(LoRaRadio):
             while self.lora.busyCheck() and busy_wait < 20:
                 await asyncio.sleep(self.RADIO_TIMING_DELAY)
                 busy_wait += 1
-
-        # Listen Before Talk (LBT) - Check for channel activity using CAD
-        lbt_backoff_delays = []  # Track each backoff delay in ms
-        lbt_attempts = 0
-        max_lbt_attempts = 5
-
-        while lbt_attempts < max_lbt_attempts:
-            try:
-                channel_busy = await self.perform_cad(timeout=0.5, respect_tx_lock=False)
-                if not channel_busy:
-                    _trace(f"CAD check clear - channel available after {lbt_attempts + 1} attempts")
-                    break
-
-                _trace("CAD check still busy - channel activity detected")
-                lbt_attempts += 1
-                if lbt_attempts < max_lbt_attempts:
-                    # Jitter (50-200ms)
-                    base_delay = random.randint(50, 200)
-                    # Exponential backoff: base * 2^attempts
-                    backoff_ms = base_delay * (2 ** (lbt_attempts - 1))
-                    # Cap at 5 seconds maximum
-                    backoff_ms = min(backoff_ms, 5000)
-
-                    lbt_backoff_delays.append(float(backoff_ms))
-                    # Keep TX lock held for thread safety while this send() owns TX sequencing,
-                    # but restore RX during backoff so standby time is limited to CAD windows.
-                    await self._restore_rx_for_cad_backoff()
-
-                    _trace(
-                        f"CAD backoff - waiting {backoff_ms}ms before retry "
-                        f"(attempt {lbt_attempts}/{max_lbt_attempts})"
-                    )
-                    await asyncio.sleep(backoff_ms / 1000.0)
-                else:
-                    logger.warning(
-                        f"CAD max attempts reached - channel still busy after "
-                        f"{max_lbt_attempts} attempts, transmitting anyway"
-                    )
-            except Exception as e:
-                logger.warning(f"CAD check failed: {e}, proceeding with transmission")
-                break
 
         self._control_tx_rx_pins(tx_mode=True)
 
@@ -1761,6 +1811,39 @@ class SX1262Radio(LoRaRadio):
         if cad_symbol_num not in symbol_map:
             raise ValueError("cad_symbol_num must be one of: 1, 2, 4, 8, 16")
         return symbol_map[cad_symbol_num]
+
+    def _max_reception_seconds(self) -> float:
+        """Upper bound on how long one reception can plausibly last.
+
+        Worst-case airtime of a max-size packet at the current radio params,
+        padded by 50%. Bounds the reception-progress latch so a lost terminal
+        IRQ cannot report "receiving" forever and wedge TX — MeshCore bounds
+        its equivalent (_maxPayloadMillis) the same way.
+        """
+        final_timeout_ms, _ = self._calculate_tx_timeout(255)
+        # _calculate_tx_timeout returns airtime + 1000 ms margin.
+        return max(0.5, (final_timeout_ms - 1000) * 1.5 / 1000.0)
+
+    def is_receiving_packet(self) -> bool:
+        """True while the chip reported an in-progress reception.
+
+        Passive and free: reads the software latch fed by the interrupt
+        handler (preamble / sync word / header IRQs), so the TX path can
+        detect a busy channel without touching the radio — a CAD scan drops
+        to standby first, which aborts the reception it is probing for, and
+        CAD's 2-symbol scan is unreliable mid-payload anyway. Parity with
+        MeshCore CustomSX1262::isReceiving().
+        """
+        started = self._rx_activity_at
+        if started <= 0:
+            return False
+        if time.monotonic() - started > self._max_reception_seconds():
+            # Stale marker: the chip moved on without a terminal IRQ reaching
+            # us (lost edge, cleared flags). Expire it rather than wedge TX.
+            self._rx_activity_at = 0.0
+            self._rx_header_at = 0.0
+            return False
+        return True
 
     async def perform_cad(
         self,

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -284,6 +284,40 @@ async def test_send_after_forced_tx_probes_the_channel_again(radio):
     assert radio.perform_cad.await_count == 1  # the channel was actually probed
 
 
+# ─── LBT/CAD decision logging ─────────────────────────────────────────
+
+
+async def test_lbt_summary_reports_cad_clear(radio, caplog):
+    radio.perform_cad = AsyncMock(return_value=False)
+
+    with caplog.at_level("DEBUG", logger="SX1262_wrapper"):
+        await radio._prepare_radio_for_tx()
+
+    (summary,) = [r.message for r in caplog.records if "LBT summary" in r.message]
+    assert "outcome=clear" in summary
+    assert "latch_defers=0" in summary
+    assert "cad_checks=1" in summary
+
+
+async def test_lbt_summary_counts_latch_defers_separately_from_cad(radio, caplog):
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio.perform_cad = AsyncMock(return_value=False)
+    radio._restore_rx_for_cad_backoff = AsyncMock()
+
+    async def _finish_reception():
+        await asyncio.sleep(0.05)
+        _inject_irq(radio, IRQ_RX_DONE)
+
+    finisher = asyncio.create_task(_finish_reception())
+    with caplog.at_level("DEBUG", logger="SX1262_wrapper"):
+        await radio._prepare_radio_for_tx()
+    await finisher
+
+    (summary,) = [r.message for r in caplog.records if "LBT summary" in r.message]
+    assert "latch_defers=0" not in summary  # the reception was polled at least once
+    assert "cad_checks=1" in summary  # the single scan after the latch cleared
+
+
 # ─── Constructor knobs ───────────────────────────────────────────────
 
 

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -117,6 +117,38 @@ async def test_max_reception_seconds_tracks_radio_params(radio):
     assert slow > fast
 
 
+# ─── two-stage expiry: preamble-only vs header-seen ───────────────────
+
+
+async def test_max_preamble_seconds_is_much_shorter_than_max_reception(radio):
+    """A preamble that never reaches a header should time out fast, not wait
+    out a full packet's worth of airtime."""
+    assert radio._max_preamble_seconds() < radio._max_reception_seconds() / 4
+
+
+async def test_preamble_only_latch_expires_on_the_short_bound(radio):
+    """No header ever arrived: expiry uses _max_preamble_seconds(), not the
+    much longer _max_reception_seconds() — a false preamble trigger (noise)
+    must not defer TX for a full packet's worth of time."""
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio._rx_activity_at = time.monotonic() - (radio._max_preamble_seconds() + 0.01)
+
+    assert radio.is_receiving_packet() is False
+    assert radio._rx_activity_at == 0.0
+
+
+async def test_header_valid_restarts_the_clock(radio):
+    """A preamble latch about to expire must not expire once a header
+    arrives: the clock restarts and the longer bound applies from here."""
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio._rx_activity_at = time.monotonic() - (radio._max_preamble_seconds() - 0.005)
+
+    _inject_irq(radio, IRQ_HEADER_VALID)
+
+    assert radio.is_receiving_packet() is True
+    assert time.monotonic() - radio._rx_activity_at < 0.005
+
+
 # ─── LBT: passive check first, no standby/CAD during a reception ─────
 
 

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -215,6 +215,43 @@ async def test_lbt_clear_channel_transmits_without_waiting(radio):
     assert delays == []
 
 
+# ─── TX commit clears the reception latch ────────────────────────────
+
+
+async def test_forced_tx_clears_the_reception_latch(radio):
+    """Transmitting kills the reception the latch is tracking, so its
+    terminal IRQ never arrives. The TX commit must clear the markers itself:
+    left armed, they would make the next send defer on a reception that no
+    longer exists — without a single CAD — until the staleness bound expired.
+    """
+    radio._max_reception_seconds = lambda: 10.0  # keep expiry out of the picture
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)  # a reception that never finishes
+    radio.perform_cad = AsyncMock(return_value=False)
+
+    success, delays = await radio._prepare_radio_for_tx()  # deadline -> forced TX
+
+    assert success is True
+    assert delays  # it did defer on the latch until the budget ran out
+    assert radio._rx_activity_at == 0.0 and radio._rx_header_at == 0.0
+    assert radio.is_receiving_packet() is False
+
+
+async def test_send_after_forced_tx_probes_the_channel_again(radio):
+    """The send following a forced TX must sense the channel, not sit out a
+    ghost of the reception that TX destroyed."""
+    radio._max_reception_seconds = lambda: 10.0
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio.perform_cad = AsyncMock(return_value=False)
+    await radio._prepare_radio_for_tx()  # forced TX; must clear the latch
+
+    radio.perform_cad.reset_mock()
+    success, delays = await radio._prepare_radio_for_tx()
+
+    assert success is True
+    assert delays == []  # no ghost deferral
+    assert radio.perform_cad.await_count == 1  # the channel was actually probed
+
+
 # ─── Constructor knobs ───────────────────────────────────────────────
 
 

--- a/tests/test_sx1262_lbt.py
+++ b/tests/test_sx1262_lbt.py
@@ -1,0 +1,253 @@
+"""Tests for the SX1262 Listen-Before-Talk path.
+
+Two properties are under test:
+
+* LBT is bounded in TIME, not in attempts: short jittered retries run for the
+  whole budget, so an occupation longer than it cannot leave two co-located
+  repeaters forcing their TX together (MeshCore parity: 200 ms retry, time
+  cap);
+* a reception in progress defers TX without being aborted. Each check
+  consults a passive software latch (is_receiving_packet, fed by the
+  preamble / sync word / header IRQs) BEFORE any standby/CAD, and the radio
+  is staged for TX only once the channel is deemed clear.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openhop_core.hardware.sx1262_wrapper import SX1262Radio
+
+from .test_sx1262_wrapper_concurrency import (
+    IRQ_HEADER_VALID,
+    IRQ_PREAMBLE_DETECTED,
+    IRQ_RX_DONE,
+    _make_mock_gpio,
+    _make_mock_lora,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    SX1262Radio._active_instance = None
+    SX1262Radio._active_instances = set()
+    yield
+    SX1262Radio._active_instance = None
+    SX1262Radio._active_instances = set()
+
+
+@pytest.fixture
+async def radio():
+    """SX1262Radio with all hardware mocked, fast LBT timings for tests."""
+    mock_gpio = _make_mock_gpio()
+    with (
+        patch(
+            "openhop_core.hardware.sx1262_wrapper.GPIOPinManager",
+            return_value=mock_gpio,
+        ),
+        patch("openhop_core.hardware.sx1262_wrapper.set_gpio_manager"),
+    ):
+        r = SX1262Radio(
+            radio_timing_delay=0.0,
+            lbt_max_wait_seconds=0.5,
+            lbt_retry_interval_ms=20,
+        )
+
+    r.lora = _make_mock_lora()
+    r._initialized = True
+    r._interrupt_setup = True
+    r._gpio_manager = mock_gpio
+    r._event_loop = asyncio.get_running_loop()
+    yield r
+
+
+def _inject_irq(radio, irq_flags: int) -> None:
+    radio.lora.getIrqStatus.return_value = irq_flags
+    radio._last_irq_status = irq_flags
+    radio._handle_interrupt()
+
+
+# ─── is_receiving_packet: software latch lifecycle ───────────────────
+
+
+async def test_preamble_irq_latches_reception_in_progress(radio):
+    assert radio.is_receiving_packet() is False
+
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+
+    assert radio.is_receiving_packet() is True
+
+
+async def test_header_valid_irq_latches_too(radio):
+    _inject_irq(radio, IRQ_HEADER_VALID)
+
+    assert radio.is_receiving_packet() is True
+    assert radio._rx_header_at > 0
+
+
+async def test_terminal_irq_clears_the_latch(radio):
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    assert radio.is_receiving_packet() is True
+
+    _inject_irq(radio, IRQ_RX_DONE)
+
+    assert radio.is_receiving_packet() is False
+    assert radio._rx_activity_at == 0.0
+
+
+async def test_stale_latch_expires_instead_of_wedging_tx(radio):
+    """A lost terminal IRQ must not report "receiving" forever: the latch
+    expires after a worst-case packet airtime (MeshCore bounds its equivalent
+    the same way)."""
+    radio._rx_activity_at = time.monotonic() - (radio._max_reception_seconds() + 1.0)
+
+    assert radio.is_receiving_packet() is False
+    assert radio._rx_activity_at == 0.0  # expired latch is cleared
+
+
+async def test_max_reception_seconds_tracks_radio_params(radio):
+    """Slower params → longer worst-case packet → longer expiry bound."""
+    fast = radio._max_reception_seconds()
+    radio.spreading_factor = 11
+    radio.bandwidth = 62500
+    slow = radio._max_reception_seconds()
+
+    assert slow > fast
+
+
+# ─── LBT: passive check first, no standby/CAD during a reception ─────
+
+
+async def test_lbt_defers_to_in_progress_reception_without_cad(radio):
+    """While a reception is latched, the LBT loop must wait on the passive
+    check alone: running CAD would drop to standby and abort the reception it
+    is probing for. The CAD scan happens only once the latch clears."""
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio.perform_cad = AsyncMock(return_value=False)
+    radio._restore_rx_for_cad_backoff = AsyncMock()
+
+    async def _finish_reception():
+        await asyncio.sleep(0.05)
+        _inject_irq(radio, IRQ_RX_DONE)
+
+    finisher = asyncio.create_task(_finish_reception())
+    success, delays = await radio._prepare_radio_for_tx()
+    await finisher
+
+    assert success is True
+    assert len(delays) >= 1  # waited at least one retry interval
+    # No CAD (hence no standby) while the reception was in progress: the
+    # single scan ran after the terminal IRQ cleared the latch.
+    assert radio.perform_cad.await_count == 1
+
+
+async def test_lbt_does_not_touch_the_radio_while_a_reception_is_latched(radio):
+    """Deferring on the passive latch must leave the radio alone.
+
+    Re-arming RX between retries clears the IRQ flags and drops to standby,
+    which aborts the reception the latch is protecting — and with no terminal
+    IRQ left to clear it, the latch would then block TX until it goes stale.
+    Only a CAD scan leaves standby behind, so only a scan needs the re-arm.
+    """
+    _inject_irq(radio, IRQ_PREAMBLE_DETECTED)
+    radio.perform_cad = AsyncMock(return_value=False)
+    radio._restore_rx_for_cad_backoff = AsyncMock()
+
+    async def _finish_reception():
+        await asyncio.sleep(0.05)
+        _inject_irq(radio, IRQ_RX_DONE)
+
+    finisher = asyncio.create_task(_finish_reception())
+    success, delays = await radio._prepare_radio_for_tx()
+    await finisher
+
+    assert success is True
+    assert delays  # at least one deferral happened on the latch alone
+    radio._restore_rx_for_cad_backoff.assert_not_awaited()
+    # The only standby is the post-LBT TX staging: none during the deferral.
+    assert radio.lora.setStandby.call_count == 1
+
+
+async def test_lbt_standby_only_after_channel_clear(radio):
+    """The staging standby must happen only once the channel is deemed
+    clear, never before the first channel check."""
+    radio.perform_cad = AsyncMock(return_value=False)
+
+    await radio._prepare_radio_for_tx()
+
+    # perform_cad is mocked (no internal standby) and no busy wait occurred,
+    # so every setStandby call is the post-LBT TX staging.
+    assert radio.lora.setStandby.called
+    assert radio.perform_cad.await_count == 1
+
+
+# ─── LBT: time budget, not attempt count ─────────────────────────────
+
+
+async def test_lbt_budget_is_time_bounded_with_short_retries(radio):
+    """A busy channel is re-checked on short jittered intervals for the
+    whole TIME budget, however long the occupation lasts."""
+    radio.perform_cad = AsyncMock(return_value=True)
+    radio._restore_rx_for_cad_backoff = AsyncMock()
+
+    started = time.monotonic()
+    success, delays = await radio._prepare_radio_for_tx()
+    elapsed = time.monotonic() - started
+
+    assert success is True  # forced TX at budget exhaustion, loudly logged
+    # Many checks across the window; the exact count is timing-dependent.
+    assert radio.perform_cad.await_count > 5
+    # The loop honored the budget: it neither gave up early nor overshot much.
+    assert 0.4 <= elapsed <= 2.0
+    assert sum(delays) <= radio.lbt_max_wait_seconds * 1000.0 + 100.0
+    # Every retry is short and jittered around lbt_retry_interval_ms.
+    assert all(10.0 <= d <= radio.lbt_retry_interval_ms * 1.5 for d in delays)
+
+
+async def test_lbt_clear_channel_transmits_without_waiting(radio):
+    radio.perform_cad = AsyncMock(return_value=False)
+
+    success, delays = await radio._prepare_radio_for_tx()
+
+    assert success is True
+    assert delays == []
+
+
+# ─── Constructor knobs ───────────────────────────────────────────────
+
+
+async def test_lbt_knob_clamps():
+    mock_gpio = _make_mock_gpio()
+    with (
+        patch(
+            "openhop_core.hardware.sx1262_wrapper.GPIOPinManager",
+            return_value=mock_gpio,
+        ),
+        patch("openhop_core.hardware.sx1262_wrapper.set_gpio_manager"),
+    ):
+        r = SX1262Radio(
+            radio_timing_delay=0.0,
+            lbt_max_wait_seconds=0.0,
+            lbt_retry_interval_ms=5,
+        )
+
+    assert r.lbt_max_wait_seconds == 0.5
+    assert r.lbt_retry_interval_ms == 20
+
+
+async def test_lbt_defaults():
+    mock_gpio = _make_mock_gpio()
+    with (
+        patch(
+            "openhop_core.hardware.sx1262_wrapper.GPIOPinManager",
+            return_value=mock_gpio,
+        ),
+        patch("openhop_core.hardware.sx1262_wrapper.set_gpio_manager"),
+    ):
+        r = SX1262Radio(radio_timing_delay=0.0)
+
+    # Matches MeshCore: getCADFailMaxDuration() 4 s, 200 ms retry.
+    assert r.lbt_max_wait_seconds == 4.0
+    assert r.lbt_retry_interval_ms == 200

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -800,17 +800,25 @@ class TestCADAndLBT:
         assert len(result["lbt_backoff_delays_ms"]) == 2
         assert result["lbt_channel_busy"] is True
 
-    async def test_lbt_max_retries_still_transmits(self, radio, mock_lora):
-        """After 5 consecutive busy checks the TX proceeds unconditionally."""
+    async def test_lbt_budget_exhaustion_still_transmits(self, radio, mock_lora):
+        """Once the LBT TIME budget runs out the TX proceeds unconditionally.
+
+        LBT is bounded in time, not attempts: with a channel that never
+        clears, the loop keeps re-checking on short jittered intervals until
+        the budget is exhausted, then transmits (a channel busy that long is
+        likelier a wedged radio than a real occupation)."""
         radio.perform_cad = AsyncMock(return_value=True)  # always busy
+        radio.lbt_max_wait_seconds = 0.5
+        radio.lbt_retry_interval_ms = 20
         mock_lora.getIrqStatus.return_value = IRQ_TX_DONE
         radio._wait_for_transmission_complete = AsyncMock(return_value=True)
         radio._finalize_transmission = MagicMock()
 
         result = await radio.send(b"forced")
-        # lbt_attempts in result is len(lbt_backoff_delays); the last (5th) attempt
-        # doesn't append a delay before breaking, so the count is 4.
-        assert result["lbt_attempts"] == 4
+        # Many short retries; the exact count is timing-dependent, the
+        # invariant is the time bound.
+        assert result["lbt_attempts"] > 5
+        assert sum(result["lbt_backoff_delays_ms"]) <= 600.0
         mock_lora.setTx.assert_called_once()
 
     async def test_lbt_cad_exception_proceeds_with_tx(self, radio, mock_lora):

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -2619,7 +2619,7 @@ class TestBeginBranchCoverage:
             assert radio.begin() is True
 
         assert any(
-            "Failed to write CAD thresholds" in r.getMessage() for r in caplog.records
+            "[CAD] Failed to write thresholds" in r.getMessage() for r in caplog.records
         )
 
     def test_begin_custom_cad_threshold_write_success(self, mock_lora, mock_gpio):


### PR DESCRIPTION
## Related PRs

- USB/TCP modem paths + `ERR_CHANNEL_BUSY` host handling: #117 (independent — disjoint files, the two merge in any order).
- Modem firmware counterpart (reception guard + CAD before `standby()` in `CMD_TX_REQUEST`): openhop-dev/openhop_modem#58.

## Problem

Two nearby repeaters that both defer to the same channel occupation regularly collide when it ends. Two structural defects in the SPI TX path cause that:

**1. LBT bounded in attempts, not time.** `_prepare_radio_for_tx` ran 5 exponential backoffs (random 50–200 ms base × 2ⁿ) — **≈1.9 s total budget on average** — then executed a *blind forced TX* (`"transmitting anyway"`). Any occupation longer than the budget (one long frame, or back-to-back traffic) exhausted **both** neighbours' attempts while the channel was still busy, and both transmitted blindly together — colliding with each other *and* with the ongoing frame. The exponential tail (up to 1.6 s between the last checks) also left the channel idle for seconds after it cleared, and made the post-clear checks of two nodes land far from any preamble window.

**2. Reception-in-progress was invisible — and actively destroyed.** The chip's `PREAMBLE_DETECTED` / `SYNC_WORD_VALID` / `HEADER_VALID` IRQs were routed to the interrupt handler and then discarded (debug log only), so nothing could answer "is a reception in progress?". Worse, the TX path dropped to **standby before its first channel check**, aborting the very reception it was about to probe for — and CAD's 2-symbol scan is unreliable mid-payload anyway.

## Change (MeshCore parity)

This ports the channel-access semantics of the MeshCore firmware (`Dispatcher::checkSend` + `CustomSX1262::isReceiving`), which does not exhibit the problem:

- **Time-bounded LBT**: short jittered retries (`lbt_retry_interval_ms`, default 200 ms ± 50 %) until `lbt_max_wait_seconds`, **default 4 s to match MeshCore's `getCADFailMaxDuration()`** (its retry is a fixed 200 ms; the jitter here keeps two nodes' checks decorrelated). Where the old scheme ran out of budget mid-occupation and forced a blind TX, the loop now keeps polling for the whole budget.
- **Passive check first**: each LBT iteration consults `is_receiving_packet()` — a software latch fed by the preamble/sync/header IRQs the handler already receives, cleared by terminal RX IRQs, and expired after a worst-case packet airtime so a lost terminal IRQ can never wedge TX (MeshCore's `_maxPayloadMillis` bound). No standby, no radio access: an in-progress reception defers TX without being aborted.
- **Standby only after clear**: the radio is staged for TX once the channel is deemed clear, instead of before the first check.
- **RX re-armed only after a CAD scan**, since that is what leaves the radio in standby. Doing it on the passive-latch path as well would clear the IRQ flags and drop to standby — aborting the reception the latch exists to protect, and leaving no terminal IRQ to clear the latch, which would then hold TX off until it went stale.
- **The reception latch is cleared at the TX commit point** (separate commit, cherry-pickable): transmitting kills any reception still in progress, so its terminal IRQ never arrives — a marker left armed would make the *next* send defer on a ghost, without a single CAD, until the staleness bound expired (3.5 s at SF8/62.5 kHz; beyond the whole 4 s budget from SF9/62.5 kHz up). MeshCore is immune by construction: its `isReceiving()` re-reads the live chip flags, and a transmit clears them.
- The `send()` metadata shape is unchanged (`lbt_attempts` / `lbt_backoff_delays_ms` still describe the waits) so LBT diagnostics keep working. New constructor knobs default sensibly; repeater-side config wiring can follow separately.

## Field evidence

Captured on the deployment that motivated this PR: repeaters **A** and **B** co-located on the same building (directional antennas covering two different sectors), plus an **observer** node that hears both clearly. SF8 / 62.5 kHz; the repeaters' TX delay was lowered to make the issue reproducible on demand.

### Before — unpatched

Both repeaters receive the same 165 B flood packet and queue their retransmissions (airtime 1590.3 ms) while the channel stays busy — CAD keeps reporting activity for the next ~2.8 s, consistent with other nodes relaying the same flood back-to-back:

| time (02:55:…) | event |
|---|---|
| 22.12x | A and B both receive the flood packet |
| 22.434 / 22.671 | A / B start LBT — CAD busy |
| 22.4 → 25.2 | both burn their whole 5-attempt budget against the ongoing traffic (A's backoffs: 66+344+524+880 ms; B's: 171+320+780+816 ms) |
| 24.733 | **A**: `CAD max attempts reached — transmitting anyway` |
| 24.763 | A starts its 1590 ms TX |
| 25.224 | **B**: `CAD max attempts reached — transmitting anyway`, 491 ms after A — **while A is on air** |
| 25.252 | B starts TX → **≈1.1 s of overlap** between the two frames |
| 26.325 | observer: `CRC error — RSSI=-5dBm, SNR=-1.2dB, Length=167` |

This is exactly the failure mode described above: the attempt-counted budget (≈1.8–2.1 s here) is shorter than the occupation, both neighbours exhaust it mid-occupation, and the blind forced TX fires on both — B never sees A's preamble because nothing checks the channel past the last attempt. Under this PR, both nodes are still polling every ~200 ms when the channel frees, so A wins the first slot and B's next check catches A's transmission — preamble latch or CAD — and defers.

<details>
<summary>Repeater A — TRACE log</summary>

```
2026-08-17 02:55:22,125 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-17 02:55:22,128 - SX1262_wrapper - TRACE - [RX] Terminal interrupt 0x0002 - waking background task
2026-08-17 02:55:22,131 - SX1262_wrapper - TRACE - [RX] RX_DONE event triggered!
2026-08-17 02:55:22,133 - SX1262_wrapper - DEBUG - [RX] Packet received: length=165, RSSI=-53dBm, SNR=11.75dB
2026-08-17 02:55:22,136 - SX1262_wrapper - TRACE - [RX] Packet data: 15406ae945b377224517a772a97850d3... (165 bytes)
2026-08-17 02:55:22,151 - SX1262_wrapper - TRACE - [RX] Restored RX continuous mode after IRQ 0x0002
2026-08-17 02:55:22,154 - Dispatcher - INFO - RX GRP_TXT (5) len=163 payload=6ae945b377224517a772
2026-08-17 02:55:22,156 - Dispatcher - DEBUG - Received packet type GRP_TXT, payload length: 163
2026-08-17 02:55:22,158 - Dispatcher - DEBUG - Payload preview: 6ae945b377224517a772
2026-08-17 02:55:22,161 - RepeaterHandler - DEBUG - RX packet: header=0x15, payload_len=163, path_len=0, rssi=-53, snr=11.75, mode=forward
2026-08-17 02:55:22,165 - RepeaterHandler - DEBUG - Route=FLOOD, len=167B, airtime=1590.3ms, delay=0.204s
2026-08-17 02:55:22,372 - SX1262_wrapper - TRACE - TX timing SF8/62.5kHz CR4/8 167B: air_time=1590.3ms, timeout=2591ms, driver_timeout=165824
2026-08-17 02:55:22,373 - SX1262_wrapper - TRACE - Setting TX timeout: 2591ms (tOut=165824) for 167 bytes
2026-08-17 02:55:22,398 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:22,434 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:22,445 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:22,447 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:22,448 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:22,467 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:22,498 - SX1262_wrapper - TRACE - CAD backoff - waiting 66ms before retry (attempt 1/5)
2026-08-17 02:55:22,578 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:22,614 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:22,621 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:22,623 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:22,624 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:22,642 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:22,673 - SX1262_wrapper - TRACE - CAD backoff - waiting 344ms before retry (attempt 2/5)
2026-08-17 02:55:23,032 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:23,070 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:23,077 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:23,079 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:23,080 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:23,100 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:23,131 - SX1262_wrapper - TRACE - CAD backoff - waiting 524ms before retry (attempt 3/5)
2026-08-17 02:55:23,669 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:23,706 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:23,716 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:23,718 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:23,720 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:23,738 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:23,771 - SX1262_wrapper - TRACE - CAD backoff - waiting 880ms before retry (attempt 4/5)
2026-08-17 02:55:24,665 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:24,703 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:24,709 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:24,712 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:24,713 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:24,732 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:24,733 - SX1262_wrapper - WARNING - CAD max attempts reached - channel still busy after 5 attempts, transmitting anyway
2026-08-17 02:55:24,750 - SX126x - DEBUG - SX1262 TX power: requested=19dBm, duty=3, hpMax=6, paVal=22
2026-08-17 02:55:24,763 - SX1262_wrapper - TRACE - [TX] Waiting for TX completion (timeout: 3.091s)
2026-08-17 02:55:26,354 - SX1262_wrapper - TRACE - [TX] TX_DONE interrupt (0x0001)
2026-08-17 02:55:26,357 - SX1262_wrapper - TRACE - [TX] TX completion interrupt received!
2026-08-17 02:55:26,360 - SX1262_wrapper - TRACE - Final interrupt status: 0x0000
2026-08-17 02:55:26,362 - SX1262_wrapper - TRACE - [TX->RX] Starting RX mode restoration after transmission
2026-08-17 02:55:26,393 - SX1262_wrapper - TRACE - [TX->RX] RX mode restoration completed
2026-08-17 02:55:26,395 - Dispatcher - INFO - TX 167 bytes (type=GRP_TXT, route=FLOOD)
2026-08-17 02:55:26,396 - AirtimeManager - DEBUG - TX recorded:  1590.3ms (total:  57705ms)
2026-08-17 02:55:26,397 - RepeaterHandler - INFO - Retransmitted packet (167 bytes, 1590.3ms airtime)
2026-08-17 02:55:26,399 - RepeaterHandler - INFO - LBT: 4 attempts, 1814ms delay, backoffs=[66.0, 344.0, 524.0, 880.0]
2026-08-17 02:55:26,400 - RepeaterHandler - DEBUG - Packet header=0x15, type=5, route=1
2026-08-17 02:55:26,402 - StorageCollector - DEBUG - Recording packet: type=5, transmitted=True
```

</details>

<details>
<summary>Repeater B — TRACE log</summary>

```
2026-08-17 02:55:22,120 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-17 02:55:22,121 - SX1262_wrapper - TRACE - [RX] Terminal interrupt 0x0002 - waking background task
2026-08-17 02:55:22,123 - SX1262_wrapper - TRACE - [RX] RX_DONE event triggered!
2026-08-17 02:55:22,125 - SX1262_wrapper - DEBUG - [RX] Packet received: length=165, RSSI=-22dBm, SNR=12.25dB
2026-08-17 02:55:22,127 - SX1262_wrapper - TRACE - [RX] Packet data: 15406ae945b377224517a772a97850d3... (165 bytes)
2026-08-17 02:55:22,140 - SX1262_wrapper - TRACE - [RX] Restored RX continuous mode after IRQ 0x0002
2026-08-17 02:55:22,146 - Dispatcher - INFO - RX GRP_TXT (5) len=163 payload=6ae945b377224517a772
2026-08-17 02:55:22,147 - Dispatcher - DEBUG - Received packet type GRP_TXT, payload length: 163
2026-08-17 02:55:22,148 - Dispatcher - DEBUG - Payload preview: 6ae945b377224517a772
2026-08-17 02:55:22,158 - RepeaterHandler - DEBUG - RX packet: header=0x15, payload_len=163, path_len=0, rssi=-22, snr=12.25, mode=forward
2026-08-17 02:55:22,160 - RepeaterHandler - DEBUG - Route=FLOOD, len=167B, airtime=1590.3ms, delay=0.444s
2026-08-17 02:55:22,608 - SX1262_wrapper - TRACE - TX timing SF8/62.5kHz CR4/8 167B: air_time=1590.3ms, timeout=2591ms, driver_timeout=165824
2026-08-17 02:55:22,609 - SX1262_wrapper - TRACE - Setting TX timeout: 2591ms (tOut=165824) for 167 bytes
2026-08-17 02:55:22,634 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:22,671 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:22,677 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:22,679 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:22,680 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:22,698 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:22,727 - SX1262_wrapper - TRACE - CAD backoff - waiting 171ms before retry (attempt 1/5)
2026-08-17 02:55:22,911 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:22,949 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:22,949 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:22,959 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:22,961 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:22,962 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:22,983 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:23,012 - SX1262_wrapper - TRACE - CAD backoff - waiting 320ms before retry (attempt 2/5)
2026-08-17 02:55:23,346 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:23,383 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:23,390 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:23,391 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:23,392 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:23,413 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:23,442 - SX1262_wrapper - TRACE - CAD backoff - waiting 780ms before retry (attempt 3/5)
2026-08-17 02:55:24,237 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:24,276 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:24,282 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:24,284 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:24,285 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:24,301 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:24,331 - SX1262_wrapper - TRACE - CAD backoff - waiting 816ms before retry (attempt 4/5)
2026-08-17 02:55:25,161 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-17 02:55:25,196 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-17 02:55:25,203 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-17 02:55:25,205 - SX1262_wrapper - TRACE - CAD operation completed - IRQ status: 0x0180
2026-08-17 02:55:25,206 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-17 02:55:25,223 - SX1262_wrapper - TRACE - CAD check still busy - channel activity detected
2026-08-17 02:55:25,224 - SX1262_wrapper - WARNING - CAD max attempts reached - channel still busy after 5 attempts, transmitting anyway
2026-08-17 02:55:25,239 - SX126x - DEBUG - SX1262 TX power: requested=19dBm, duty=3, hpMax=6, paVal=22
2026-08-17 02:55:25,252 - SX1262_wrapper - TRACE - [TX] Waiting for TX completion (timeout: 3.091s)
2026-08-17 02:55:26,843 - SX1262_wrapper - TRACE - [TX] TX_DONE interrupt (0x0001)
2026-08-17 02:55:26,845 - SX1262_wrapper - TRACE - [TX] TX completion interrupt received!
2026-08-17 02:55:26,847 - SX1262_wrapper - TRACE - Final interrupt status: 0x0000
2026-08-17 02:55:26,849 - SX1262_wrapper - TRACE - [TX->RX] Starting RX mode restoration after transmission
2026-08-17 02:55:26,880 - SX1262_wrapper - TRACE - [TX->RX] RX mode restoration completed
2026-08-17 02:55:26,881 - Dispatcher - INFO - TX 167 bytes (type=GRP_TXT, route=FLOOD)
2026-08-17 02:55:26,883 - AirtimeManager - DEBUG - TX recorded:  1590.3ms (total:  64888ms)
2026-08-17 02:55:26,884 - RepeaterHandler - INFO - Retransmitted packet (167 bytes, 1590.3ms airtime)
2026-08-17 02:55:26,886 - RepeaterHandler - INFO - LBT: 4 attempts, 2087ms delay, backoffs=[171.0, 320.0, 780.0, 816.0]
2026-08-17 02:55:26,888 - RepeaterHandler - DEBUG - Packet header=0x15, type=5, route=1
2026-08-17 02:55:26,890 - StorageCollector - DEBUG - Recording packet: type=5, transmitted=True
```

</details>

<details>
<summary>Observer — the collision on the air</summary>

```
2026-08-17 02:55:26,325 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-17 02:55:26,325 - SX1262_wrapper - DEBUG - [RX] CRC_ERR interrupt (0x0040)
2026-08-17 02:55:26,325 - SX1262_wrapper - TRACE - [RX] Terminal interrupt 0x0042 - waking background task
2026-08-17 02:55:26,325 - SX1262_wrapper - TRACE - [RX] RX_DONE event triggered!
2026-08-17 02:55:26,327 - SX1262_wrapper - WARNING - [RX] CRC error #11 - RSSI=-5dBm, SNR=-1.2dB, SignalRSSI=-9dBm, Length=167, NoiseFloor=-74.0dBm, DeviceErrors=0x0000, IRQ=0x0042, RawData=1541882f6ae945b377224517a772a97850d33333938066211242528e3a2adf3ee0>
2026-08-17 02:55:26,337 - SX1262_wrapper - TRACE - [RX] Restored RX continuous mode after IRQ 0x0042
```

</details>

### After — patched, same setup (4 s cap)

Same two repeaters, same radio settings (SF8 / 62.5 kHz / CR4/8), running this branch with the MeshCore-parity 4 s cap. Both receive the same 41 B GRP_TXT flood two milliseconds apart and both decide to relay it — the exact race from *Before*:

| time (02:10:…) | event |
|---|---|
| 02.24 → 02.77 | A and B receive the flood (A −33 dBm / 13.25 dB, B −21 dBm / 12.5 dB) and draw their random TX delays: A 268 ms, B 360 ms |
| 03.15 | **A**: first CAD — clear → transmits (`LBT summary: outcome=clear elapsed=75ms latch_defers=0 cad_checks=1`) |
| 03.24 | **B**: first CAD **catches A's transmission** → busy → jittered retry — the reconvergence window that used to collide |
| 03.30 → 03.39 | B, back in RX during its backoff, **starts receiving A's relay**: PREAMBLE_DETECTED, then HEADER_VALID |
| 03.54, 03.66 | B's next two checks defer on the **passive reception latch** — `LBT: reception in progress - deferring TX` — no CAD scan, no standby, the reception left untouched |
| 03.79 | A's TX_DONE; B's RX_DONE lands while the TX lock is held and is latched in software |
| 03.95 | B **drains the pending frame before its next CAD**: A's relayed copy, fully decoded (43 B, A's hash now on the path), correctly dropped as a duplicate |
| 04.03 | B: CAD — clear → `LBT summary: outcome=clear elapsed=881ms latch_defers=2 cad_checks=2 backoff_total=649ms` |
| 04.11 → 04.69 | B transmits. Sequential transmissions, no collision |

What this capture proves, beyond the collision not reproducing:

- **The reception guard is doing its half of the work**: two of B's three deferrals came from the passive latch, not from CAD — and the latch path left the radio alone, so the frame it was protecting kept demodulating.
- **The deferred-to frame survived and was delivered.** B decoded A's relay in full — correct CRC, A's hash on the path — and deduplicated it. Before this change, the standby issued ahead of the first channel check destroyed that reception unconditionally.
- **No third observer is needed.** The *Before* evidence required a bystander node to catch the collision as a CRC error; here the waiting repeater is itself the witness that the other's frame arrived intact.
- The whole wait cost **881 ms** of the 4 s budget, and B transmitted ~50 ms after the channel cleared.

An earlier capture, taken during the 8 s trial of this branch, recorded a **7.2 s continuous channel occupation** on this same site — the reason `lbt_max_wait_seconds` stays a constructor knob rather than a constant.

<details>
<summary>Repeater A — TRACE log (wins the race)</summary>

```
2026-08-20 02:10:02,243 - SX1262_wrapper - DEBUG - [RX] PREAMBLE_DETECTED interrupt (0x0004)
2026-08-20 02:10:02,244 - SX1262_wrapper - DEBUG - [RX] Progress interrupt 0x0004 - packet still incoming
2026-08-20 02:10:02,413 - SX1262_wrapper - DEBUG - [RX] HEADER_VALID interrupt (0x0010)
2026-08-20 02:10:02,414 - SX1262_wrapper - DEBUG - [RX] Progress interrupt 0x0010 - packet still incoming
2026-08-20 02:10:02,774 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-20 02:10:02,775 - SX1262_wrapper - TRACE - [RX] Terminal interrupt 0x0002 - waking background task
2026-08-20 02:10:02,777 - SX1262_wrapper - TRACE - [RX] RX_DONE event triggered!
2026-08-20 02:10:02,778 - SX1262_wrapper - DEBUG - [RX] Packet received: length=41, RSSI=-33dBm, SNR=13.25dB
2026-08-20 02:10:02,780 - SX1262_wrapper - TRACE - [RX] Packet data: 14db9e0000406ae9a1734cb70d88e671... (41 bytes)
2026-08-20 02:10:02,793 - SX1262_wrapper - TRACE - [RX] Restored RX continuous mode after IRQ 0x0002
2026-08-20 02:10:02,796 - Dispatcher - INFO - RX GRP_TXT (5) len=35 payload=6ae9a1734cb70d88e671
2026-08-20 02:10:02,808 - RepeaterHandler - DEBUG - RX packet: header=0x14, payload_len=35, path_len=0, rssi=-33, snr=13.25, mode=forward
2026-08-20 02:10:02,821 - RepeaterHandler - DEBUG - Route=FLOOD, len=43B, airtime=574.5ms, delay=0.268s
2026-08-20 02:10:03,092 - SX1262_wrapper - TRACE - TX timing SF8/62.5kHz CR4/8 43B: air_time=574.5ms, timeout=1575ms, driver_timeout=100800
2026-08-20 02:10:03,107 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-20 02:10:03,143 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-20 02:10:03,150 - SX1262_wrapper - TRACE - [CAD] Channel clear detected (0x0080)
2026-08-20 02:10:03,152 - SX1262_wrapper - TRACE - CAD result: CLEAR - no channel activity detected
2026-08-20 02:10:03,170 - SX1262_wrapper - TRACE - LBT: channel clear
2026-08-20 02:10:03,171 - SX1262_wrapper - DEBUG - LBT summary: outcome=clear elapsed=75ms latch_defers=0 cad_checks=1 backoff_total=0ms
2026-08-20 02:10:03,208 - SX1262_wrapper - TRACE - [TX] Waiting for TX completion (timeout: 2.075s)
2026-08-20 02:10:03,783 - SX1262_wrapper - TRACE - [TX] TX_DONE interrupt (0x0001)
2026-08-20 02:10:03,791 - SX1262_wrapper - TRACE - [TX->RX] Starting RX mode restoration after transmission
2026-08-20 02:10:03,823 - Dispatcher - INFO - TX 43 bytes (type=GRP_TXT, route=TRANSPORT_FLOOD)
2026-08-20 02:10:03,827 - RepeaterHandler - INFO - Retransmitted packet (43 bytes, 574.5ms airtime)
```

</details>

<details>
<summary>Repeater B — TRACE log (defers, receives A's relay intact, then transmits)</summary>

```
2026-08-20 02:10:02,243 - SX1262_wrapper - DEBUG - [RX] PREAMBLE_DETECTED interrupt (0x0004)
2026-08-20 02:10:02,413 - SX1262_wrapper - DEBUG - [RX] HEADER_VALID interrupt (0x0010)
2026-08-20 02:10:02,773 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-20 02:10:02,779 - SX1262_wrapper - DEBUG - [RX] Packet received: length=41, RSSI=-21dBm, SNR=12.5dB
2026-08-20 02:10:02,781 - SX1262_wrapper - TRACE - [RX] Packet data: 14db9e0000406ae9a1734cb70d88e671... (41 bytes)
2026-08-20 02:10:02,799 - Dispatcher - INFO - RX GRP_TXT (5) len=35 payload=6ae9a1734cb70d88e671
2026-08-20 02:10:02,810 - RepeaterHandler - DEBUG - RX packet: header=0x14, payload_len=35, path_len=0, rssi=-21, snr=12.5, mode=forward
2026-08-20 02:10:02,819 - RepeaterHandler - DEBUG - Route=FLOOD, len=43B, airtime=574.5ms, delay=0.360s
2026-08-20 02:10:03,182 - SX1262_wrapper - TRACE - TX timing SF8/62.5kHz CR4/8 43B: air_time=574.5ms, timeout=1575ms, driver_timeout=100800
2026-08-20 02:10:03,196 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-20 02:10:03,233 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-20 02:10:03,240 - SX1262_wrapper - TRACE - [CAD] Channel activity detected (0x0180)
2026-08-20 02:10:03,243 - SX1262_wrapper - TRACE - CAD result: BUSY - channel activity detected
2026-08-20 02:10:03,289 - SX1262_wrapper - TRACE - LBT: channel busy - retrying in 246ms
2026-08-20 02:10:03,303 - SX1262_wrapper - DEBUG - [RX] PREAMBLE_DETECTED interrupt (0x0004)
2026-08-20 02:10:03,304 - SX1262_wrapper - DEBUG - [RX] Progress interrupt 0x0004 - packet still incoming
2026-08-20 02:10:03,393 - SX1262_wrapper - DEBUG - [RX] HEADER_VALID interrupt (0x0010)
2026-08-20 02:10:03,394 - SX1262_wrapper - DEBUG - [RX] Progress interrupt 0x0010 - packet still incoming
2026-08-20 02:10:03,540 - SX1262_wrapper - TRACE - LBT: reception in progress - deferring TX
2026-08-20 02:10:03,543 - SX1262_wrapper - TRACE - LBT: channel busy - retrying in 118ms
2026-08-20 02:10:03,664 - SX1262_wrapper - TRACE - LBT: reception in progress - deferring TX
2026-08-20 02:10:03,665 - SX1262_wrapper - TRACE - LBT: channel busy - retrying in 286ms
2026-08-20 02:10:03,786 - SX1262_wrapper - TRACE - [RX] RX_DONE interrupt (0x0002)
2026-08-20 02:10:03,787 - SX1262_wrapper - DEBUG - [RX] Ignoring terminal interrupt 0x0002 during TX operation
2026-08-20 02:10:03,953 - SX1262_wrapper - TRACE - [RX] Drained pending RX packet before TX/CAD: 14db9e000041882f6ae9a1734cb70d88... (43 bytes)
2026-08-20 02:10:03,959 - Dispatcher - INFO - RX GRP_TXT (5) len=35 payload=6ae9a1734cb70d88e671
2026-08-20 02:10:03,972 - RepeaterHandler - DEBUG - RX packet: header=0x14, payload_len=35, path_len=2, rssi=-21, snr=12.5, mode=forward
2026-08-20 02:10:03,982 - RepeaterHandler - DEBUG - Packet not forwarded: Duplicate
2026-08-20 02:10:03,989 - SX1262_wrapper - TRACE - [CAD] IRQ pin is LOW after clear (retry 0)
2026-08-20 02:10:04,026 - SX1262_wrapper - TRACE - [CAD] Operation started - checking channel with peak=22, min=10
2026-08-20 02:10:04,033 - SX1262_wrapper - TRACE - [CAD] Channel clear detected (0x0080)
2026-08-20 02:10:04,036 - SX1262_wrapper - TRACE - CAD result: CLEAR - no channel activity detected
2026-08-20 02:10:04,062 - SX1262_wrapper - TRACE - LBT: channel clear
2026-08-20 02:10:04,065 - SX1262_wrapper - DEBUG - LBT summary: outcome=clear elapsed=881ms latch_defers=2 cad_checks=2 backoff_total=649ms
2026-08-20 02:10:04,111 - SX1262_wrapper - TRACE - [TX] Waiting for TX completion (timeout: 2.075s)
2026-08-20 02:10:04,687 - SX1262_wrapper - TRACE - [TX] TX_DONE interrupt (0x0001)
2026-08-20 02:10:04,693 - SX1262_wrapper - TRACE - [TX->RX] Starting RX mode restoration after transmission
```

</details>

## Out of scope (follow-ups planned)

- Post-clear contention window (slotted defer + re-check) as an improvement on top.

## Test plan

- [x] `pytest tests/test_sx1262_lbt.py` — 14 new tests: IRQ latch lifecycle (preamble/header set, terminal clears, stale expiry, params-dependent bound), LBT defers on latched reception **without CAD/standby**, staging standby only after clear, time-budget honored with short jittered retries, clear channel transmits immediately, knob clamps/defaults, the passive-latch path leaving the radio untouched (no RX re-arm, no standby), and the TX commit clearing the latch (a forced TX leaves no ghost; the following send probes the channel again)
- [x] `pytest tests/test_sx1262_wrapper.py tests/test_sx1262_wrapper_concurrency.py` — 189 passed; one legacy test asserting the old 5-attempt scheme updated to assert the time-bound invariant instead
- [x] `ruff check` — strict parity with dev (72 = 72 pre-existing findings, none added)
- [x] On-air validation of the time-budget rework (earlier revision of this branch, 8 s cap): the collision could no longer be reproduced
- [x] On-air validation at the 4 s cap with the passive-latch path active: the waiting repeater deferred to the other's transmission and received that frame intact — no collision, no third observer needed (see *Field evidence → After*)
- [x] Multi-day field trial on two sites, three repeaters.