### PR TITLE
fix(dispatcher): release the tracked hash when the transmit never happens

### DIFF
--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -1169,27 +1169,37 @@ class Dispatcher:
         tx_metadata = None
         # Resolve which fabric/radio endpoint will TX for log clarity (multi-radio).
         tx_radio_id = self._resolve_tx_radio_id_for_log(raw, radio_id)
+        # The hash above was tracked on the assumption this send reaches the
+        # air. Release it from a finally if it does not, so every exit from the
+        # send below — including one added later — keeps the seen-table honest:
+        # a hash left behind suppresses copies of a packet we never sent.
+        transmitted = False
         try:
-            # Prefer fabric/radio multi-radio send(data, radio_id=...) when
-            # available; fall back to the legacy single-arg send(raw).
-            send_fn = self.radio.send
-            if radio_id is not None:
-                try:
-                    tx_metadata = await send_fn(raw, radio_id=radio_id)
-                except TypeError:
+            try:
+                # Prefer fabric/radio multi-radio send(data, radio_id=...) when
+                # available; fall back to the legacy single-arg send(raw).
+                send_fn = self.radio.send
+                if radio_id is not None:
+                    try:
+                        tx_metadata = await send_fn(raw, radio_id=radio_id)
+                    except TypeError:
+                        tx_metadata = await send_fn(raw)
+                else:
                     tx_metadata = await send_fn(raw)
-            else:
-                tx_metadata = await send_fn(raw)
-        except Exception as e:
-            radio_label = f" radio={tx_radio_id}" if tx_radio_id else ""
-            self._log(f"Radio transmit error{radio_label}: {e}")
-            self.state = DispatcherState.IDLE
-            return (False, None, None)
-        if tx_metadata is None:
-            radio_label = f" radio={tx_radio_id}" if tx_radio_id else ""
-            self._log(f"Radio transmit returned no confirmation metadata{radio_label}")
-            self.state = DispatcherState.IDLE
-            return (False, None, None)
+            except Exception as e:
+                radio_label = f" radio={tx_radio_id}" if tx_radio_id else ""
+                self._log(f"Radio transmit error{radio_label}: {e}")
+                self.state = DispatcherState.IDLE
+                return (False, None, None)
+            if tx_metadata is None:
+                radio_label = f" radio={tx_radio_id}" if tx_radio_id else ""
+                self._log(f"Radio transmit returned no confirmation metadata{radio_label}")
+                self.state = DispatcherState.IDLE
+                return (False, None, None)
+            transmitted = True
+        finally:
+            if not transmitted:
+                self.packet_filter.untrack_packet(packet_hash)
         # Spend the airtime budget on the completed transmit (client-repeat only).
         if self._client_repeat_enabled:
             self._debit_tx_budget(packet)

--- a/src/openhop_core/protocol/packet_filter.py
+++ b/src/openhop_core/protocol/packet_filter.py
@@ -45,6 +45,15 @@ class PacketFilter:
         """Track a packet hash with current timestamp."""
         self._packet_hashes[packet_hash] = time.time()
 
+    def untrack_packet(self, packet_hash: str) -> None:
+        """Drop a tracked hash.
+
+        Counterpart to :meth:`track_packet` for a transmission that was
+        tracked before it started and then never reached the air: keeping the
+        hash would suppress the copies that are still worth processing.
+        """
+        self._packet_hashes.pop(packet_hash, None)
+
     def blacklist(self, packet_hash: str) -> None:
         """Add a packet hash to the blacklist.
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1329,3 +1329,69 @@ class TestDispatcherSendMarksSeen:
         await dispatcher._process_received_packet(pkt.write_to())
 
         assert mock_handler.call_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "break_the_radio",
+        [
+            lambda radio: setattr(radio, "send", AsyncMock(side_effect=RuntimeError("radio gone"))),
+            lambda radio: setattr(radio, "send", AsyncMock(return_value=None)),
+        ],
+        ids=["send_raises", "send_returns_none"],
+    )
+    async def test_send_that_never_reached_the_air_does_not_suppress_later_copies(
+        self, dispatcher, break_the_radio
+    ):
+        """The mark is a bet that the send happens; a failed send must take it back.
+
+        Otherwise this node drops every later copy of a packet it never put on
+        the air — for the whole dedup window — which is exactly the case where
+        another node's copy is still worth processing.
+        """
+        mock_handler = MockHandler(PAYLOAD_TYPE_TXT_MSG)
+        dispatcher.register_handler(PAYLOAD_TYPE_TXT_MSG, mock_handler)
+
+        pkt = Packet()
+        pkt.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD  # version 0
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"never made it out")
+        pkt.payload_len = len(pkt.payload)
+
+        break_the_radio(dispatcher.radio)
+        assert await dispatcher.send_packet(pkt, wait_for_ack=False) is False
+
+        await dispatcher._process_received_packet(pkt.write_to())
+
+        assert mock_handler.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_send_does_not_lift_the_suppression_of_a_sent_packet(self, dispatcher):
+        """Releasing must be keyed on the failed packet, not on recent state.
+
+        A release that is not keyed would let the earlier packet's own echo
+        back through, which is the loopback the mark exists to stop.
+        """
+        mock_handler = MockHandler(PAYLOAD_TYPE_TXT_MSG)
+        dispatcher.register_handler(PAYLOAD_TYPE_TXT_MSG, mock_handler)
+
+        sent = Packet()
+        sent.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD  # version 0
+        sent.path_len = 0
+        sent.path = bytearray()
+        sent.payload = bytearray(b"this one really went out")
+        sent.payload_len = len(sent.payload)
+        assert await dispatcher.send_packet(sent, wait_for_ack=False) is True
+
+        failed = Packet()
+        failed.header = (PAYLOAD_TYPE_TXT_MSG << 2) | ROUTE_TYPE_FLOOD  # version 0
+        failed.path_len = 0
+        failed.path = bytearray()
+        failed.payload = bytearray(b"this one did not")
+        failed.payload_len = len(failed.payload)
+        dispatcher.radio.send = AsyncMock(return_value=None)
+        assert await dispatcher.send_packet(failed, wait_for_ack=False) is False
+
+        await dispatcher._process_received_packet(sent.write_to())
+
+        assert mock_handler.call_count == 0


### PR DESCRIPTION
## Problem

`_transmit_locked` marks the packet in the seen-table **before** handing it to the radio, so a neighbour rebroadcasting it back is dropped rather than processed. The comment there states the intent and its firmware anchor:

> *Mark this packet seen before transmitting, matching firmware's `hasSeen()` call right before `sendPacket()` in `Mesh::sendFlood`/`sendDirect`/`sendZeroHop`.*

That mark is a bet that the send reaches the air — and **the bet was never taken back**. Both failure exits return without touching the seen-table:

- a radio error caught by `except Exception` → `return (False, None, None)`;
- `tx_metadata is None`, which is how the USB/TCP modem drivers report a channel they refused for the whole LBT budget (`usb_radio.py` / `tcp_radio.py` deliberately fail instead of forcing) → `return (False, None, None)`.

Every later copy of a packet this node never transmitted was then suppressed for the rest of the dedup window (`PacketFilter.window_seconds`, 30 s) — including the copy another node was still offering, which is the one case where reprocessing is exactly what you want. There is no retry at this layer, so the packet is simply gone.

## Change

- `PacketFilter.untrack_packet()` — the counterpart to `track_packet()`.
- `_transmit_locked` releases the hash from a `finally` covering the send, so **any exit — including one added later — leaves the seen-table consistent with what actually went on air**. The flag flips to "transmitted" only after the metadata check, so a failure in the success path that follows (callbacks, ACK registration) keeps the entry, which is correct: the packet is already out.
- The release is keyed on the packet that failed. Entries left by transmissions that did happen are untouched, so loopback suppression is unaffected.

## Tests

Added to `TestDispatcherSendMarksSeen`, the class that already covers the send-time mark, so both directions of the invariant sit together.

- **`test_send_that_never_reached_the_air_does_not_suppress_later_copies`**, parametrised over the two failure shapes (`send` raises, `send` returns `None`): after the failed send, the same packet arriving from the mesh must reach its handler.
- **`test_failed_send_does_not_lift_the_suppression_of_a_sent_packet`**: a failed send of packet B must not release packet A's entry. This is the over-correction guard — an unkeyed release would let A's own loopback back through, which is the very thing the mark exists to stop. It passes both before and after the fix, on purpose.

The existing `test_sent_group_packet_dropped_on_loopback` and `test_distinct_inbound_packet_not_suppressed_after_send` already pin the successful-send side, so that behaviour is covered without duplicating it here.

Verified in both directions: the two failure tests **fail on `dev`** and pass here.

## Test plan

- [x] `pytest tests/test_dispatcher.py -k TestDispatcherSendMarksSeen` — 7 passed
- [x] Full suite — 38 failures, identical to `dev` (all pre-existing and unrelated)
- [x] `black --check` clean on both changed sources; `ruff check` parity with `dev` (identical findings)

## Related

The repeater carries the same defect one layer up, with a much longer blast radius (`cache_ttl` defaults to 3600 s) and a second-order effect on the duplicate statistics: openhop-dev/openhop_repeater#400. The two are independent — this one stands alone.
