### PR TITLE
fix(login): align ACL roles with MeshCore ClientACL.h

### DIFF
--- a/examples/login_server.py
+++ b/examples/login_server.py
@@ -25,7 +25,14 @@ from common import RADIO_TYPES, create_mesh_node
 
 from openhop_core.node.handlers.login_server import LoginServerHandler
 from openhop_core.protocol import Identity, LocalIdentity
-from openhop_core.protocol.constants import PUB_KEY_SIZE
+from openhop_core.protocol.constants import (
+    PERM_ACL_ADMIN,
+    PERM_ACL_GUEST,
+    PERM_ACL_ROLE_MASK,
+    PUB_KEY_SIZE,
+    acl_is_admin,
+    acl_role,
+)
 
 
 def create_mesh_node_with_identity(
@@ -100,10 +107,11 @@ EXAMPLE_ADMIN_PASSWORD = "admin123"
 EXAMPLE_GUEST_PASSWORD = "guest123"
 # =============================================================================
 
-# Permission levels
-PERM_ACL_GUEST = 0x01
-PERM_ACL_ADMIN = 0x02
-PERM_ACL_ROLE_MASK = 0x03
+# Permission levels come from openhop_core.protocol.constants, which mirrors
+# firmware ClientACL.h: the role is the low two bits of the permissions byte
+# (GUEST=0, READ_ONLY=1, READ_WRITE=2, ADMIN=3). Do not redefine them here —
+# a local copy on different numbering is exactly what made OpenHop admins
+# decode as read-write in stock MeshCore clients.
 
 
 class ClientInfo:
@@ -121,11 +129,11 @@ class ClientInfo:
 
     def is_admin(self) -> bool:
         """Check if client has admin permissions."""
-        return (self.permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_ADMIN
+        return acl_is_admin(self.permissions)
 
     def is_guest(self) -> bool:
         """Check if client has guest permissions."""
-        return (self.permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST
+        return acl_role(self.permissions) == PERM_ACL_GUEST
 
 
 class ClientACL:

--- a/src/openhop_core/companion/base_send.py
+++ b/src/openhop_core/companion/base_send.py
@@ -928,6 +928,9 @@ class _SendOpsMixin:
             "success": success,
             "repeater": contact_name,
             "is_admin": data.get("is_admin", False),
+            # Raw login-reply byte 6. Firmware's companion forwards it verbatim
+            # (0/1/2), so a room server's "plain guest" 2 survives to the app.
+            "admin_code": data.get("admin_code"),
             "keep_alive_interval": data.get("keep_alive_interval", 0),
             "tag": data.get("timestamp", 0),
             "acl_permissions": data.get("reserved", data.get("permissions", 0)),

--- a/src/openhop_core/companion/frame_server/commands_messaging.py
+++ b/src/openhop_core/companion/frame_server/commands_messaging.py
@@ -452,11 +452,18 @@ class _MessagingCommandsMixin:
                 fw_level = result.get("firmware_ver_level")
                 if fw_level is None:
                     fw_level = FIRMWARE_VER_CODE  # fallback so app sees >= 2 for owner info
+                # Byte 1 is the server's raw reply byte 6, forwarded verbatim
+                # the way companion_radio does (`out_frame[i++] = data[6]`): a
+                # room server distinguishes admin (1) from a plain guest (2),
+                # and collapsing it to a boolean would drop that.
+                admin_code = result.get("admin_code")
+                if admin_code is None:
+                    admin_code = 1 if result.get("is_admin") else 0
                 self._write_frame(
                     bytes(
                         [
                             PUSH_CODE_LOGIN_SUCCESS,
-                            1 if result.get("is_admin") else 0,
+                            min(255, max(0, int(admin_code))),
                         ]
                     )
                     + pubkey[:6]

--- a/src/openhop_core/node/handlers/login_response.py
+++ b/src/openhop_core/node/handlers/login_response.py
@@ -2,7 +2,12 @@ import struct
 from typing import Callable, Optional
 
 from ...protocol import CryptoUtils, Identity, Packet
-from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_PATH, PAYLOAD_TYPE_RESPONSE
+from ...protocol.constants import (
+    PAYLOAD_TYPE_ANON_REQ,
+    PAYLOAD_TYPE_PATH,
+    PAYLOAD_TYPE_RESPONSE,
+    acl_role,
+)
 from ...protocol.packet_utils import PathUtils
 from ...util.callbacks import invoke_maybe_awaitable
 from .base import BaseHandler
@@ -10,6 +15,16 @@ from .result import HandlerResult
 from .return_path import ReturnPathTeacher
 
 # Response codes from C++ server
+# Login reply byte 6, the legacy admin flag. Firmware's room server overloads
+# it into three states (simple_room_server/MyMesh.cpp):
+#     reply_data[6] = isAdmin() ? 1 : (permissions == 0 ? 2 : 0)
+# so 2 means "plain guest", NOT admin. Repeaters and sensors only ever send
+# 0 or 1. Treating this byte as a boolean makes a stock room server's guests
+# look like admins.
+LOGIN_ADMIN_CODE_NOT_ADMIN = 0
+LOGIN_ADMIN_CODE_ADMIN = 1
+LOGIN_ADMIN_CODE_GUEST = 2
+
 RESP_SERVER_LOGIN_OK = 0x80
 # Alternative success code observed in practice
 RESP_SERVER_LOGIN_SUCCESS_ALT = 0x00
@@ -23,8 +38,9 @@ class LoginResponseHandler(BaseHandler):
     - timestamp (4 bytes): Server response timestamp
     - response_code (1 byte): RESP_SERVER_LOGIN_OK (0x80) for success
     - keep_alive_interval (1 byte): Recommended keep-alive interval (secs / 16)
-    - is_admin (1 byte): 1 if admin, 0 if guest
-    - reserved (1 byte): Reserved for future use
+    - admin_code (1 byte): legacy admin flag; 1 = admin, 2 = plain guest on a
+      room server, 0 otherwise. Only 1 means admin.
+    - permissions (1 byte): ACL byte; role in the low two bits (v7+ servers)
     - random_blob (4 bytes): Random data for packet uniqueness
 
     """
@@ -325,9 +341,9 @@ class LoginResponseHandler(BaseHandler):
                 return True, None
 
             # Parse the C++ response format (handleLoginReq reply_data):
-            # timestamp(4) + response_code(1) + keep_alive(1) + is_admin(1) +
+            # timestamp(4) + response_code(1) + keep_alive(1) + admin_code(1) +
             # permissions(1) + random(4) + [firmware_ver_level(1) at index 12]
-            timestamp, response_code, keep_alive, is_admin, reserved = struct.unpack(
+            timestamp, response_code, keep_alive, admin_code, permissions = struct.unpack(
                 "<IBBBB", plaintext[:8]
             )
             random_blob = plaintext[8:12]
@@ -337,8 +353,13 @@ class LoginResponseHandler(BaseHandler):
                 "timestamp": timestamp,
                 "response_code": response_code,
                 "keep_alive_interval": keep_alive,
-                "is_admin": bool(is_admin),
-                "reserved": reserved,
+                # Only 1 is admin: a room server sends 2 for a plain guest,
+                # and bool(2) would promote that guest to admin.
+                "is_admin": admin_code == LOGIN_ADMIN_CODE_ADMIN,
+                "admin_code": admin_code,
+                "reserved": permissions,  # legacy key, kept for callers
+                "permissions": permissions,
+                "acl_role": acl_role(permissions),
                 "random_blob": random_blob,
                 "firmware_ver_level": firmware_ver_level,
                 "contact": contact,

--- a/src/openhop_core/node/handlers/login_server.py
+++ b/src/openhop_core/node/handlers/login_server.py
@@ -16,7 +16,7 @@ import time
 from typing import Callable, Optional
 
 from ...protocol import CryptoUtils, Identity, Packet, PacketBuilder, PathUtils
-from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE
+from ...protocol.constants import PAYLOAD_TYPE_ANON_REQ, PAYLOAD_TYPE_RESPONSE, acl_is_admin
 from ...protocol.region_map import apply_reply_scope
 from .base import BaseHandler
 from .result import HandlerResult
@@ -49,8 +49,9 @@ class LoginServerHandler(BaseHandler):
     - timestamp (4 bytes): Server response timestamp
     - response_code (1 byte): RESP_SERVER_LOGIN_OK (0x00) for success
     - keep_alive_interval (1 byte): Legacy field, set to 0
-    - is_admin (1 byte): 1 if admin, 0 if guest
-    - permissions (1 byte): Full permission bits
+    - is_admin (1 byte): 1 when the ACL role is ADMIN, else 0
+    - permissions (1 byte): Full ACL byte; role in the low two bits
+      (PERM_ACL_GUEST=0, READ_ONLY=1, READ_WRITE=2, ADMIN=3)
     - random_blob (4 bytes): Random data for packet uniqueness
     - firmware_version (1 byte): Firmware version level
     """
@@ -73,7 +74,10 @@ class LoginServerHandler(BaseHandler):
             local_identity: Server's local identity
             log_fn: Logging function
             authenticate_callback: Function(client_identity, shared_secret, password, timestamp)
-                                   Returns: (success: bool, permissions: int)
+                                   Returns: (success: bool, permissions: int).
+                                   ``permissions`` must carry the role in its low
+                                   two bits using the firmware ClientACL values
+                                   (see PERM_ACL_* in protocol.constants).
             is_room_server: True if this identity is a room server (expects sync_since field),
                            False if repeater (no sync_since field)
         """
@@ -262,8 +266,10 @@ class LoginServerHandler(BaseHandler):
             struct.pack_into("<I", reply_data, 0, current_time)  # timestamp
             reply_data[4] = response_code  # response code
             reply_data[5] = 0  # legacy keep-alive interval
-            # is_admin: check if permission bits include admin bit (0x02)
-            reply_data[6] = 1 if (permissions & 0x02) else 0
+            # is_admin mirrors firmware ClientInfo::isAdmin(): the role is the
+            # low two bits and ADMIN is 3, so this is an equality test, not a
+            # bit test. Testing 0x02 would also flag READ_WRITE (2) as admin.
+            reply_data[6] = 1 if acl_is_admin(permissions) else 0
             reply_data[7] = permissions  # full permissions byte
             struct.pack_into("<I", reply_data, 8, random.randint(0, 0xFFFFFFFF))  # random blob
             reply_data[12] = FIRMWARE_VER_LEVEL  # firmware version

--- a/src/openhop_core/protocol/__init__.py
+++ b/src/openhop_core/protocol/__init__.py
@@ -36,6 +36,11 @@ from .constants import (
     PAYLOAD_TYPE_TRACE,
     PAYLOAD_TYPE_TXT_MSG,
     PAYLOAD_VER_1,
+    PERM_ACL_ADMIN,
+    PERM_ACL_GUEST,
+    PERM_ACL_READ_ONLY,
+    PERM_ACL_READ_WRITE,
+    PERM_ACL_ROLE_MASK,
     PH_ROUTE_MASK,
     PH_TYPE_MASK,
     PH_TYPE_SHIFT,
@@ -54,6 +59,8 @@ from .constants import (
     TELEM_PERM_ENVIRONMENT,
     TELEM_PERM_LOCATION,
     TIMESTAMP_SIZE,
+    acl_is_admin,
+    acl_role,
     describe_advert_flags,
 )
 from .crypto import CryptoUtils
@@ -176,4 +183,12 @@ __all__ = [
     "TELEM_PERM_BASE",
     "TELEM_PERM_LOCATION",
     "TELEM_PERM_ENVIRONMENT",
+    # ClientACL roles (low 2 bits of the permissions byte)
+    "PERM_ACL_ROLE_MASK",
+    "PERM_ACL_GUEST",
+    "PERM_ACL_READ_ONLY",
+    "PERM_ACL_READ_WRITE",
+    "PERM_ACL_ADMIN",
+    "acl_role",
+    "acl_is_admin",
 ]

--- a/src/openhop_core/protocol/acl_conformance.py
+++ b/src/openhop_core/protocol/acl_conformance.py
@@ -1,0 +1,79 @@
+"""Literal conformance vectors for the login reply's ACL bytes.
+
+Pure data with no imports, so downstream projects (openhop_repeater and any
+other server built on core) can assert against exactly the same numbers this
+package is tested with.
+
+The 13-byte login reply built by firmware ``handleLoginReq`` is::
+
+    timestamp(4) response_code(1) keep_alive(1) admin_code(1) permissions(1)
+    random(4) firmware_ver_level(1)
+
+``admin_code`` is byte 6 (the legacy admin flag) and ``permissions`` is byte 7
+(the ACL byte modern clients decode). Transcribed from MeshCore firmware at
+commit 915ccdb1:
+
+* ``src/helpers/ClientACL.h`` — role numbering and ``isAdmin()``
+* ``examples/simple_repeater/MyMesh.cpp`` — ``reply_data[6] = isAdmin() ? 1 : 0``
+* ``examples/simple_room_server/MyMesh.cpp`` —
+  ``reply_data[6] = isAdmin() ? 1 : (permissions == 0 ? 2 : 0)``
+
+Every value here is a literal on purpose. Asserting against ``PERM_ACL_*``
+would follow those constants wherever they drift, which is precisely the
+failure these vectors exist to catch (openhop-dev/openhop_repeater#388: the
+constants and the code agreed with each other and disagreed with the mesh).
+"""
+
+# Role occupying the low two bits of the permissions byte.
+ROLE_VALUES = {
+    "guest": 0x00,
+    "read_only": 0x01,
+    "read_write": 0x02,
+    "admin": 0x03,
+}
+
+ROLE_MASK = 0x03
+
+# Byte 6 states. A room server overloads this byte; everything else sends 0/1.
+ADMIN_CODE_NOT_ADMIN = 0x00
+ADMIN_CODE_ADMIN = 0x01
+ADMIN_CODE_ROOM_GUEST = 0x02
+
+# What a server must put on the wire, by server type and credential.
+# (server_type, credential, admin_code, permissions)
+OUTBOUND = (
+    ("repeater", "admin_password", 0x01, 0x03),
+    # A repeater's guest password grants GUEST: base telemetry, no settings.
+    ("repeater", "guest_password", 0x00, 0x00),
+    ("repeater", "blank_read_only", 0x00, 0x00),
+    ("room_server", "admin_password", 0x01, 0x03),
+    # A room server's guest password grants READ_WRITE: post and read posts.
+    # permissions is non-zero, so byte 6 is 0 rather than the room guest code.
+    #
+    # REGRESSION SENTINEL. This is the only outbound row that a `permissions &
+    # 0x02` admin test gets wrong (2 & 2 is truthy, so it would claim admin);
+    # the other four pass on the buggy code. Do not drop it.
+    ("room_server", "guest_password", 0x00, 0x02),
+)
+
+# What a client must make of bytes it receives, including shapes we never
+# emit ourselves but must decode from stock firmware.
+# (admin_code, permissions, is_admin, role)
+INBOUND = (
+    (0x01, 0x03, True, 0x03),
+    (0x00, 0x02, False, 0x02),
+    (0x00, 0x01, False, 0x01),
+    (0x00, 0x00, False, 0x00),
+    # REGRESSION SENTINEL. A stock room server's plain guest: byte 6 is 2, and
+    # bool(2) is True, so a boolean decode promoted every such guest to admin.
+    # This is the only inbound row that discriminates against that decode.
+    (0x02, 0x00, False, 0x00),
+    # Bits above the role mask are reserved flags and must not change the role.
+    (0x01, 0xF3, True, 0x03),
+    (0x00, 0xF2, False, 0x02),
+)
+
+# Known divergence, deliberately not in OUTBOUND: firmware's room server sends
+# admin_code 2 for a blank-password read-only login (permissions == 0), where
+# we send 0. Both mean "not admin", so no client is misled about privilege; we
+# simply do not reproduce the extra "plain guest" signal on that one path.

--- a/src/openhop_core/protocol/constants.py
+++ b/src/openhop_core/protocol/constants.py
@@ -125,6 +125,34 @@ TELEM_PERM_LOCATION = 0x02
 TELEM_PERM_ENVIRONMENT = 0x04
 
 # ---------------------------------------------------------------------------
+# ClientACL roles (firmware src/helpers/ClientACL.h). The role lives in the low
+# two bits of the permissions byte; the upper bits are reserved for future
+# per-feature flags. These are the *wire* values every stock-firmware client
+# decodes, so servers must publish roles using exactly this numbering — note
+# that ADMIN is 3, not "the 0x02 bit".
+# ---------------------------------------------------------------------------
+PERM_ACL_ROLE_MASK = 0x03
+PERM_ACL_GUEST = 0
+PERM_ACL_READ_ONLY = 1
+PERM_ACL_READ_WRITE = 2
+PERM_ACL_ADMIN = 3
+
+
+def acl_role(permissions: int) -> int:
+    """Return the ACL role in ``permissions`` (firmware ``perms & PERM_ACL_ROLE_MASK``)."""
+    return permissions & PERM_ACL_ROLE_MASK
+
+
+def acl_is_admin(permissions: int) -> bool:
+    """Mirror of firmware ``ClientInfo::isAdmin()`` — role must equal ADMIN (3).
+
+    Testing the 0x02 bit instead would also match READ_WRITE (2) and would let a
+    read-write client be announced as an admin.
+    """
+    return acl_role(permissions) == PERM_ACL_ADMIN
+
+
+# ---------------------------------------------------------------------------
 # Anonymous request sub-types (first byte of an ANON_REQ payload, after the
 # 4-byte timestamp). Wire values shared by the anon-request handler (node) and
 # the companion protocol; see firmware simple_repeater/MyMesh.cpp.

--- a/tests/test_companion_radio.py
+++ b/tests/test_companion_radio.py
@@ -14,21 +14,19 @@ from openhop_core.node.events import MeshEvents
 from openhop_core.node.handlers.login_response import (
     LOGIN_ADMIN_CODE_ADMIN,
     LOGIN_ADMIN_CODE_GUEST,
-    LOGIN_ADMIN_CODE_NOT_ADMIN,
 )
 from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, PacketBuilder
+from openhop_core.protocol.acl_conformance import INBOUND
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_RESPONSE,
     PERM_ACL_ADMIN,
     PERM_ACL_GUEST,
-    PERM_ACL_READ_WRITE,
     ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
     TXT_TYPE_CLI_DATA,
     TXT_TYPE_PLAIN,
-    acl_role,
 )
 
 
@@ -921,37 +919,32 @@ class TestLoginAdminCodeDecoding:
     byte with bool() promoted those guests to admin.
     """
 
-    def _decode(self, admin_code, permissions):
+    @pytest.mark.parametrize("admin_code, permissions, is_admin, role", INBOUND)
+    def test_inbound_conformance_vectors(self, admin_code, permissions, is_admin, role):
+        """Decode exactly what acl_conformance.INBOUND says, from literal bytes.
+
+        Includes shapes we never emit but must read from stock firmware, such
+        as a room server's plain guest (admin_code 2, which bool() called
+        admin).
+        """
         server_identity = LocalIdentity()
         comp_identity = LocalIdentity()
-        pkt = _build_login_response_packet(
-            server_identity,
-            comp_identity,
-            is_admin=admin_code,
-            permissions=permissions,
-        )
-        shared_secret = Identity(comp_identity.get_public_key()).calc_shared_secret(
-            server_identity.get_private_key()
-        )
-        plaintext = CryptoUtils.mac_then_decrypt(
-            shared_secret[:16], shared_secret, bytes(pkt.payload[2:])
-        )
-        timestamp, response_code, keep_alive, code, perms = struct.unpack("<IBBBB", plaintext[:8])
-        return code, perms
+        comp = CompanionRadio(MockRadio(), comp_identity)
+        handler = comp._get_login_response_handler()
 
-    @pytest.mark.parametrize(
-        "admin_code, permissions, expect_admin",
-        [
-            (LOGIN_ADMIN_CODE_ADMIN, PERM_ACL_ADMIN, True),
-            (LOGIN_ADMIN_CODE_NOT_ADMIN, PERM_ACL_READ_WRITE, False),
-            # A stock room server's plain guest. bool(2) said admin.
-            (LOGIN_ADMIN_CODE_GUEST, PERM_ACL_GUEST, False),
-        ],
-    )
-    def test_only_code_1_means_admin(self, admin_code, permissions, expect_admin):
-        code, perms = self._decode(admin_code, permissions)
-        assert (code == LOGIN_ADMIN_CODE_ADMIN) is expect_admin
-        assert acl_role(perms) == acl_role(permissions)
+        pkt = _build_login_response_packet(
+            server_identity, comp_identity, is_admin=admin_code, permissions=permissions
+        )
+        contact = SimpleNamespace(
+            name="srv", public_key=server_identity.get_public_key(), is_admin=None
+        )
+        ok, data = asyncio.run(handler._decrypt_response(pkt, contact))
+
+        assert ok is True
+        assert data["admin_code"] == admin_code
+        assert data["is_admin"] is is_admin
+        assert data["permissions"] == permissions
+        assert data["acl_role"] == role
 
     def test_room_server_guest_code_is_not_admin_end_to_end(self):
         """The parsed dict must not report admin for a room server's guest."""

--- a/tests/test_companion_radio.py
+++ b/tests/test_companion_radio.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import struct
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,15 +11,24 @@ from openhop_core.companion.constants import ADV_TYPE_CHAT
 from openhop_core.companion.models import Contact
 from openhop_core.companion.timing import estimate_airtime_ms
 from openhop_core.node.events import MeshEvents
+from openhop_core.node.handlers.login_response import (
+    LOGIN_ADMIN_CODE_ADMIN,
+    LOGIN_ADMIN_CODE_GUEST,
+    LOGIN_ADMIN_CODE_NOT_ADMIN,
+)
 from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, PacketBuilder
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
     PAYLOAD_TYPE_RESPONSE,
+    PERM_ACL_ADMIN,
+    PERM_ACL_GUEST,
+    PERM_ACL_READ_WRITE,
     ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
     TXT_TYPE_CLI_DATA,
     TXT_TYPE_PLAIN,
+    acl_role,
 )
 
 
@@ -901,6 +911,89 @@ def _build_login_response_packet(
     pkt.payload = bytearray(payload)
     pkt.payload_len = len(payload)
     return pkt
+
+
+class TestLoginAdminCodeDecoding:
+    """Login reply byte 6 is a tri-state, not a boolean.
+
+    Firmware's room server sends ``isAdmin() ? 1 : (permissions == 0 ? 2 : 0)``
+    (simple_room_server/MyMesh.cpp), so 2 means "plain guest". Decoding the
+    byte with bool() promoted those guests to admin.
+    """
+
+    def _decode(self, admin_code, permissions):
+        server_identity = LocalIdentity()
+        comp_identity = LocalIdentity()
+        pkt = _build_login_response_packet(
+            server_identity,
+            comp_identity,
+            is_admin=admin_code,
+            permissions=permissions,
+        )
+        shared_secret = Identity(comp_identity.get_public_key()).calc_shared_secret(
+            server_identity.get_private_key()
+        )
+        plaintext = CryptoUtils.mac_then_decrypt(
+            shared_secret[:16], shared_secret, bytes(pkt.payload[2:])
+        )
+        timestamp, response_code, keep_alive, code, perms = struct.unpack("<IBBBB", plaintext[:8])
+        return code, perms
+
+    @pytest.mark.parametrize(
+        "admin_code, permissions, expect_admin",
+        [
+            (LOGIN_ADMIN_CODE_ADMIN, PERM_ACL_ADMIN, True),
+            (LOGIN_ADMIN_CODE_NOT_ADMIN, PERM_ACL_READ_WRITE, False),
+            # A stock room server's plain guest. bool(2) said admin.
+            (LOGIN_ADMIN_CODE_GUEST, PERM_ACL_GUEST, False),
+        ],
+    )
+    def test_only_code_1_means_admin(self, admin_code, permissions, expect_admin):
+        code, perms = self._decode(admin_code, permissions)
+        assert (code == LOGIN_ADMIN_CODE_ADMIN) is expect_admin
+        assert acl_role(perms) == acl_role(permissions)
+
+    def test_room_server_guest_code_is_not_admin_end_to_end(self):
+        """The parsed dict must not report admin for a room server's guest."""
+        server_identity = LocalIdentity()
+        comp_identity = LocalIdentity()
+        comp = CompanionRadio(MockRadio(), comp_identity)
+        handler = comp._get_login_response_handler()
+
+        pkt = _build_login_response_packet(
+            server_identity,
+            comp_identity,
+            is_admin=LOGIN_ADMIN_CODE_GUEST,
+            permissions=PERM_ACL_GUEST,
+        )
+        contact = SimpleNamespace(
+            name="room", public_key=server_identity.get_public_key(), is_admin=None
+        )
+        ok, data = asyncio.run(handler._decrypt_response(pkt, contact))
+        assert ok is True
+        assert data["admin_code"] == LOGIN_ADMIN_CODE_GUEST
+        assert data["is_admin"] is False
+        assert data["acl_role"] == PERM_ACL_GUEST
+
+    def test_admin_login_still_reports_admin(self):
+        server_identity = LocalIdentity()
+        comp_identity = LocalIdentity()
+        comp = CompanionRadio(MockRadio(), comp_identity)
+        handler = comp._get_login_response_handler()
+
+        pkt = _build_login_response_packet(
+            server_identity,
+            comp_identity,
+            is_admin=LOGIN_ADMIN_CODE_ADMIN,
+            permissions=PERM_ACL_ADMIN,
+        )
+        contact = SimpleNamespace(
+            name="rpt", public_key=server_identity.get_public_key(), is_admin=None
+        )
+        ok, data = asyncio.run(handler._decrypt_response(pkt, contact))
+        assert ok is True
+        assert data["is_admin"] is True
+        assert data["acl_role"] == PERM_ACL_ADMIN
 
 
 @pytest.mark.asyncio

--- a/tests/test_frame_server.py
+++ b/tests/test_frame_server.py
@@ -1015,6 +1015,54 @@ async def test_cmd_send_login_retry_has_one_completion_writer():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result_extra, expected_byte",
+    [
+        # Admin: byte 1 is 1, as before.
+        ({"is_admin": True, "admin_code": 1, "acl_permissions": 3}, 1),
+        # Room server "plain guest": firmware sends 2 on this byte and our
+        # companion forwards it verbatim rather than collapsing it to 0/1.
+        ({"is_admin": False, "admin_code": 2, "acl_permissions": 0}, 2),
+        ({"is_admin": False, "admin_code": 0, "acl_permissions": 2}, 0),
+        # No admin_code (older bridge result): fall back to the boolean.
+        ({"is_admin": True, "acl_permissions": 3}, 1),
+    ],
+)
+async def test_login_success_push_forwards_the_raw_admin_byte(result_extra, expected_byte):
+    """PUSH_CODE_LOGIN_SUCCESS byte 1 mirrors the server's reply byte 6.
+
+    companion_radio does `out_frame[i++] = data[6]`, and a room server uses
+    that byte as a tri-state (admin=1, plain guest=2, other=0).
+    """
+    from openhop_core.companion.constants import PUSH_CODE_LOGIN_SUCCESS
+
+    pubkey = bytes(range(32))
+    result = {"success": True, "tag": 123, "firmware_ver_level": 2, **result_extra}
+    sent = SentResult(success=True, is_flood=True, expected_ack=0x1122, timeout_ms=9000)
+    bridge = Mock()
+    bridge._start_frame_login_request = AsyncMock(
+        return_value={
+            "success": True,
+            "sent": sent,
+            "task": asyncio.create_task(_return_result(result)),
+            "session_owner": True,
+        }
+    )
+    server = CompanionFrameServer(bridge, "hash", port=0)
+    frames: list[bytes] = []
+    server._write_frame = lambda f: frames.append(f)
+
+    await server._cmd_send_login(pubkey + b"pw")
+    await asyncio.sleep(0)
+
+    pushes = [f for f in frames if f[0] == PUSH_CODE_LOGIN_SUCCESS]
+    assert len(pushes) == 1
+    assert pushes[0][1] == expected_byte
+    # Byte 7 of the reply still rides along as the authoritative ACL byte.
+    assert pushes[0][12] == result["acl_permissions"]
+
+
+@pytest.mark.asyncio
 async def test_cmd_send_status_req_failure_no_empty_push():
     """A failed status send returns an error and no SENT frame."""
     from openhop_core.companion.constants import PUSH_CODE_STATUS_RESPONSE

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -22,6 +22,7 @@ from openhop_core.node.handlers import (
 from openhop_core.node.handlers.login_server import FIRMWARE_VER_LEVEL
 from openhop_core.node.handlers.result import HandlerResult
 from openhop_core.protocol import CryptoUtils, Identity, LocalIdentity, Packet, PacketBuilder
+from openhop_core.protocol.acl_conformance import OUTBOUND
 from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_ACK,
     PAYLOAD_TYPE_ADVERT,
@@ -33,10 +34,7 @@ from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_RESPONSE,
     PAYLOAD_TYPE_TRACE,
     PAYLOAD_TYPE_TXT_MSG,
-    PERM_ACL_ADMIN,
     PERM_ACL_GUEST,
-    PERM_ACL_READ_ONLY,
-    PERM_ACL_READ_WRITE,
     PUB_KEY_SIZE,
     ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
@@ -2300,37 +2298,32 @@ class TestLoginServerHandler:
         assert login_reply[7] == PERM_ACL_GUEST
 
     @pytest.mark.asyncio
-    async def test_acl_roles_match_firmware_numbering(self):
-        """reply_data[6] is (perms & 3) == ADMIN, and reply_data[7] is the raw ACL byte.
+    async def test_outbound_conformance_vectors(self):
+        """Emit exactly the bytes in acl_conformance.OUTBOUND.
 
-        Firmware ClientACL.h puts the role in the low two bits with ADMIN == 3.
-        A bit test on 0x02 would wrongly announce READ_WRITE (2) as an admin,
-        which is what stock clients (and the KiekR app) decode as non-admin
-        while our own legacy is_admin byte said otherwise.
+        Literal expectations on purpose: keying this off PERM_ACL_* would make
+        the test follow the constants wherever they drift, and constants that
+        drifted away from the mesh are the whole of #388.
         """
-        expected = {
-            PERM_ACL_GUEST: 0,
-            PERM_ACL_READ_ONLY: 0,
-            PERM_ACL_READ_WRITE: 0,
-            PERM_ACL_ADMIN: 1,
-        }
-        for perms, want_admin in expected.items():
-            login_reply = await self._login_reply_for(perms)
-            assert login_reply[6] == want_admin, f"role {perms} → is_admin {want_admin}"
-            assert login_reply[7] == perms
+        for server_type, credential, admin_code, permissions in OUTBOUND:
+            login_reply = await self._login_reply_for(permissions)
+            label = f"{server_type}/{credential}"
+            assert login_reply[6] == admin_code, f"{label}: admin_code"
+            assert login_reply[7] == permissions, f"{label}: permissions"
 
     @pytest.mark.asyncio
-    async def test_reserved_permission_bits_do_not_affect_role(self):
-        """Upper bits are reserved flags; only the low two bits pick the role."""
-        admin_with_flags = PERM_ACL_ADMIN | 0xF0
-        login_reply = await self._login_reply_for(admin_with_flags)
-        assert login_reply[6] == 1
-        assert login_reply[7] == admin_with_flags
+    async def test_admin_code_is_an_equality_test_over_the_whole_byte(self):
+        """Only role 3 is admin, for every value of the reserved upper bits.
 
-        rw_with_flags = PERM_ACL_READ_WRITE | 0xF0
-        login_reply = await self._login_reply_for(rw_with_flags)
-        assert login_reply[6] == 0
-        assert login_reply[7] == rw_with_flags
+        A bit test on 0x02 also matches READ_WRITE (2), which is what stock
+        clients decode as non-admin while our byte 6 claimed admin.
+        """
+        for reserved in (0x00, 0x04, 0x40, 0xFC):
+            for role in (0x00, 0x01, 0x02, 0x03):
+                login_reply = await self._login_reply_for(role | reserved)
+                expected = 1 if role == 0x03 else 0
+                assert login_reply[6] == expected, f"role {role} reserved {reserved:#04x}"
+                assert login_reply[7] == role | reserved
 
     @pytest.mark.asyncio
     async def test_no_send_callback_logs_error(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -33,6 +33,10 @@ from openhop_core.protocol.constants import (
     PAYLOAD_TYPE_RESPONSE,
     PAYLOAD_TYPE_TRACE,
     PAYLOAD_TYPE_TXT_MSG,
+    PERM_ACL_ADMIN,
+    PERM_ACL_GUEST,
+    PERM_ACL_READ_ONLY,
+    PERM_ACL_READ_WRITE,
     PUB_KEY_SIZE,
     ROUTE_TYPE_DIRECT,
     ROUTE_TYPE_FLOOD,
@@ -2227,7 +2231,7 @@ class TestLoginServerHandler:
         assert keepalive == 0  # Legacy, always 0
 
         is_admin = login_reply[6]
-        assert is_admin == 1  # permissions 0x03 has admin bit 0x02
+        assert is_admin == 1  # role 0x03 == PERM_ACL_ADMIN
 
         perms = login_reply[7]
         assert perms == 0x03
@@ -2270,30 +2274,63 @@ class TestLoginServerHandler:
 
         assert len(self.sent_packets) == 0
 
-    @pytest.mark.asyncio
-    async def test_guest_permissions_is_admin_zero(self):
-        """Guest login (no admin bit) → is_admin = 0 in response (matches C++ check)."""
-        # Permission 0x01 = guest only, no admin bit (0x02)
-        self.auth_callback.return_value = (True, 0x01)
+    async def _login_reply_for(self, permissions: int) -> bytes:
+        """Run a flood login returning ``permissions`` and decrypt the 13-byte reply."""
+        self.auth_callback.return_value = (True, permissions)
+        self.sent_packets.clear()
 
-        pkt = self._build_login_packet(password="guest", route_type="flood")
+        pkt = self._build_login_packet(password="pw", route_type="flood")
         await self.handler(pkt)
 
         response_pkt, _ = self.sent_packets[0]
-
-        # Decrypt and verify is_admin field
         client_id = Identity(self.client_identity_local.get_public_key())
         shared_secret = client_id.calc_shared_secret(self.server_identity.get_private_key())
         aes_key = shared_secret[:16]
         encrypted_part = bytes(response_pkt.payload[2:])
         plaintext = CryptoUtils.mac_then_decrypt(aes_key, shared_secret, encrypted_part)
+        # skip path_len(1) + extra_type(1), take 13
+        return plaintext[2:15]
 
-        login_reply = plaintext[2:15]  # skip path_len(1) + extra_type(1), take 13
-        is_admin = login_reply[6]
-        assert is_admin == 0  # No admin bit → is_admin = 0
+    @pytest.mark.asyncio
+    async def test_guest_permissions_is_admin_zero(self):
+        """Guest login (role 0) → is_admin = 0 in response (matches C++ isAdmin())."""
+        login_reply = await self._login_reply_for(PERM_ACL_GUEST)
 
-        perms = login_reply[7]
-        assert perms == 0x01
+        assert login_reply[6] == 0
+        assert login_reply[7] == PERM_ACL_GUEST
+
+    @pytest.mark.asyncio
+    async def test_acl_roles_match_firmware_numbering(self):
+        """reply_data[6] is (perms & 3) == ADMIN, and reply_data[7] is the raw ACL byte.
+
+        Firmware ClientACL.h puts the role in the low two bits with ADMIN == 3.
+        A bit test on 0x02 would wrongly announce READ_WRITE (2) as an admin,
+        which is what stock clients (and the KiekR app) decode as non-admin
+        while our own legacy is_admin byte said otherwise.
+        """
+        expected = {
+            PERM_ACL_GUEST: 0,
+            PERM_ACL_READ_ONLY: 0,
+            PERM_ACL_READ_WRITE: 0,
+            PERM_ACL_ADMIN: 1,
+        }
+        for perms, want_admin in expected.items():
+            login_reply = await self._login_reply_for(perms)
+            assert login_reply[6] == want_admin, f"role {perms} → is_admin {want_admin}"
+            assert login_reply[7] == perms
+
+    @pytest.mark.asyncio
+    async def test_reserved_permission_bits_do_not_affect_role(self):
+        """Upper bits are reserved flags; only the low two bits pick the role."""
+        admin_with_flags = PERM_ACL_ADMIN | 0xF0
+        login_reply = await self._login_reply_for(admin_with_flags)
+        assert login_reply[6] == 1
+        assert login_reply[7] == admin_with_flags
+
+        rw_with_flags = PERM_ACL_READ_WRITE | 0xF0
+        login_reply = await self._login_reply_for(rw_with_flags)
+        assert login_reply[6] == 0
+        assert login_reply[7] == rw_with_flags
 
     @pytest.mark.asyncio
     async def test_no_send_callback_logs_error(self):


### PR DESCRIPTION
`ClientACL.h` puts the ACL role in the low two bits of the permissions byte — GUEST=0, READ_ONLY=1, READ_WRITE=2, ADMIN=3 — and derives admin with `(perms & 3) == 3`. We were testing the `0x02` bit, which also matches READ_WRITE, so a read-write client got announced as an admin.

Adds the canonical `PERM_ACL_*` values plus `acl_role()` / `acl_is_admin()` to `protocol.constants`, and uses them for the login reply's admin byte.

Two related things turned up while reviewing it:

- `examples/login_server.py` kept its own copy of the constants on the old numbering, so the reference server started encoding role 2 for admin. It imports the shared ones now.
- We parsed the reply's admin byte with `bool()`, but a room server overloads it: `isAdmin() ? 1 : (permissions == 0 ? 2 : 0)`. A `2` means plain guest, so every guest on a stock room server decoded as admin. Only `1` counts now, and the companion forwards the raw byte into `PUSH_CODE_LOGIN_SUCCESS` the way `companion_radio` does rather than flattening it.

Heads up on that last one: it changes a wire-visible byte for companion clients. It matches firmware, but a client reading it as a strict boolean will see `2` where it used to see `1`.

Tests are driven off a new `protocol/acl_conformance.py` — literal bytes for what we must emit per role and what we must decode, including shapes only stock firmware sends. It has no imports, so openhop_repeater asserts against the same table instead of a second copy. Checked out against this branch's parent with the vectors copied in, the two rows marked as regression sentinels fail and the rest pass.

Needs to land alongside openhop_repeater's `fix/login-perms` — that branch imports these symbols and won't start without them.

Refs openhop-dev/openhop_repeater#388
