### PR TITLE
Add PR checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,E231,W503
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+    dist,
+    *.egg-info,
+    examples/,
+    src/openhop_core/hardware/lora/,
+    scripts/test_modem_crypto.py

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,78 @@
+name: PR Checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: pr-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .pre-commit-config.yaml
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+          python -m pip install -e .[dev]
+
+      # The pytest hook is skipped here because the `tests` job below already
+      # runs the suite across every supported Python, not just 3.12.
+      - name: Run pre-commit
+        env:
+          SKIP: pytest
+        run: pre-commit run --all-files
+
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: python -m pytest --tb=short

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,10 +69,12 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
+      # .[test] rather than .[dev]: the dev extra pulls in black, which
+      # requires Python 3.10+ and would fail to resolve on the 3.9 entry.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install -e .[test]
 
       - name: Run tests
         run: python -m pytest --tb=short

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e .[test]
 
       - name: Run tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,31 +29,17 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
-        # Strict but reasonable settings
-        args: [
-          "--max-line-length=100",
-          "--extend-ignore=E203,E231,W503"
-        ]
+        # Settings live in .flake8 so a bare `flake8` run matches this hook.
         # Exclude third-party code but check our core code
         exclude: '^(src/openhop_core/hardware/lora/|examples/|scripts/test_modem_crypto\.py$)'
 
-  # Run pytest to ensure all tests pass
-  # - repo: local
-  #   hooks:
-  #     - id: pytest
-  #       name: pytest
-  #       entry: pytest
-  #       language: system
-  #       pass_filenames: false
-  #       # Only run if Python files in src/ or tests/ have changed
-  #       files: ^(src/|tests/|pyproject\.toml|setup\.py).*$
-  #       args: ["-v", "--tb=short"]
-  #     - id: pytest-fast
-  #       name: pytest-fast (quick smoke test)
-  #       entry: pytest
-  #       language: system
-  #       pass_filenames: false
-  #       # Run a quick subset of tests for faster feedback
-  #       files: ^(src/|tests/).*\.py$
-  #       args: ["-v", "--tb=short", "-x", "--maxfail=3", "tests/test_basic.py", "tests/test_crypto.py"]
-  #       stages: [manual]
+  # Test suite gate
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: ./scripts/precommit-pytest.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,19 @@ gpiod = ["gpiod>=2.4.0"]
 websocket = [
     "websockets>=11.0.0",
 ]
-dev = [
+# Everything the test suite needs, and nothing that constrains the Python
+# version -- this must stay installable on every version in requires-python
+# so CI can run the suite across the whole matrix.
+test = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
     "pyserial>=3.5",
+]
+# The full local toolchain. Note this pulls in black, which requires Python
+# 3.10+, so [dev] is not installable on 3.9 -- use [test] there.
+dev = [
+    "openhop_core[test]",
     "black>=26.5.1",
     "isort>=5.12.0",
     "flake8>=7.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,18 +81,9 @@ target-version = ['py38']
 profile = "black"
 line_length = 100
 
-[tool.flake8]
-max-line-length = 100
-extend-ignore = ["E203", "W503"]
-exclude = [
-    "src/openhop_core/hardware/lora/",
-    "examples/",
-    "__pycache__",
-    ".git",
-    ".tox",
-    "dist",
-    "*.egg-info"
-]
+# flake8 does not read pyproject.toml without a plugin, so its configuration
+# lives in .flake8 at the repo root -- the one place both a bare `flake8` run
+# and the pre-commit hook will pick it up.
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/scripts/precommit-pytest.sh
+++ b/scripts/precommit-pytest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prefer the currently activated venv, then repo-local .venv, then python3/python.
+if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/python" ]; then
+  PYTHON_BIN="${VIRTUAL_ENV}/bin/python"
+elif [ -x ".venv/bin/python" ]; then
+  PYTHON_BIN=".venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "No Python interpreter found for pytest hook." >&2
+  exit 1
+fi
+
+exec "${PYTHON_BIN}" -m pytest -q

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -679,26 +679,31 @@ class TestTransmissionLifecycle:
 class TestCADAndLBT:
     """Channel Activity Detection and Listen-Before-Talk backoff."""
 
-    async def _fire_cad_event(self, radio, detected: bool, delay: float = 0):
-        """Async helper: fire the CAD event from a background task."""
-        await asyncio.sleep(delay)
-        radio._last_cad_irq_status = (
-            IRQ_CAD_DONE | IRQ_CAD_DETECTED if detected else IRQ_CAD_DONE
-        )
-        radio._last_cad_detected = detected
-        radio._cad_event.set()
+    def _arm_cad_event(self, radio, detected: bool):
+        """Arm the CAD completion IRQ to fire once the driver starts CAD.
+
+        perform_cad() clears _cad_event during setup, so a result armed on a
+        timer can be wiped before the driver ever waits on it. Firing from
+        setCad() mirrors the hardware -- the IRQ cannot arrive before CAD is
+        running -- and keeps these tests independent of machine speed.
+        """
+
+        def _fire(*_args, **_kwargs):
+            radio._last_cad_irq_status = (
+                IRQ_CAD_DONE | IRQ_CAD_DETECTED if detected else IRQ_CAD_DONE
+            )
+            radio._last_cad_detected = detected
+            radio._cad_event.set()
+
+        radio.lora.setCad.side_effect = _fire
 
     async def test_perform_cad_channel_clear_returns_false(self, radio):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=False, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=False)
         result = await radio.perform_cad(timeout=1.0)
         assert result is False
 
     async def test_perform_cad_channel_busy_returns_true(self, radio):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=True, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=True)
         result = await radio.perform_cad(timeout=1.0)
         assert result is True
 
@@ -714,9 +719,7 @@ class TestCADAndLBT:
         mock_lora.request.assert_called_with(mock_lora.RX_CONTINUOUS)
 
     async def test_perform_cad_calibration_mode_returns_dict(self, radio):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=False, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=False)
         result = await radio.perform_cad(timeout=1.0, calibration=True)
         assert isinstance(result, dict)
         assert "detected" in result
@@ -726,17 +729,13 @@ class TestCADAndLBT:
         assert "timestamp" in result
 
     async def test_perform_cad_calibration_reports_done_without_detected(self, radio):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=False, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=False)
         result = await radio.perform_cad(timeout=1.0, calibration=True)
         assert result["cad_done"] is True
         assert result["detected"] is False
 
     async def test_perform_cad_calibration_reports_done_and_detected(self, radio):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=True, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=True)
         result = await radio.perform_cad(timeout=1.0, calibration=True)
         assert result["cad_done"] is True
         assert result["detected"] is True
@@ -753,9 +752,7 @@ class TestCADAndLBT:
     async def test_perform_cad_symbol_mapping_uses_requested_symbol_count(
         self, radio, mock_lora
     ):
-        asyncio.get_running_loop().create_task(
-            self._fire_cad_event(radio, detected=False, delay=0.01)
-        )
+        self._arm_cad_event(radio, detected=False)
         await radio.perform_cad(timeout=1.0, calibration=True, cad_symbol_num=8)
         mock_lora.setCadParams.assert_called()
         cad_symbol_arg = mock_lora.setCadParams.call_args[0][0]
@@ -2471,15 +2468,16 @@ class TestCoverageGapBranches:
     async def test_perform_cad_success_clears_nonzero_current_irq(
         self, radio, mock_lora
     ):
-        async def _fire_event():
-            await asyncio.sleep(0.01)
+        def _fire(*_args, **_kwargs):
+            # Fire from setCad() so the result survives perform_cad()'s
+            # setup-time _cad_event.clear(); see _arm_cad_event above.
             radio._last_cad_irq_status = IRQ_CAD_DONE
             radio._last_cad_detected = True
             radio._cad_event.set()
 
         # existing_irq=0, current_irq(after completion)=0x0020
         mock_lora.getIrqStatus.side_effect = [0, 0x0020]
-        asyncio.get_running_loop().create_task(_fire_event())
+        mock_lora.setCad.side_effect = _fire
         assert await radio.perform_cad(timeout=1.0) is True
         assert any(c.args == (0x0020,) for c in mock_lora.clearIrqStatus.call_args_list)
 

--- a/tests/test_sx1262_wrapper_concurrency.py
+++ b/tests/test_sx1262_wrapper_concurrency.py
@@ -67,6 +67,33 @@ ALL_IRQ_FLAGS = [
 
 
 # ---------------------------------------------------------------------------
+# CAD test helpers
+# ---------------------------------------------------------------------------
+def arm_cad_completion(radio, detected: bool, irq_status=None):
+    """Arm the CAD completion IRQ to fire once the driver starts CAD.
+
+    perform_cad() clears _cad_event during setup, so completion armed on a
+    timer can be wiped before the driver ever waits on it -- the operation
+    then falls through to its timeout, which returns False and is therefore
+    indistinguishable from a genuine channel-clear result. Firing from
+    setCad() mirrors the hardware, since the IRQ cannot arrive before CAD is
+    running, and keeps these tests independent of machine speed.
+    """
+
+    def _fire(*_args, **_kwargs):
+        if irq_status is None:
+            radio._last_cad_irq_status = (
+                IRQ_CAD_DONE | IRQ_CAD_DETECTED if detected else IRQ_CAD_DONE
+            )
+        else:
+            radio._last_cad_irq_status = irq_status
+        radio._last_cad_detected = detected
+        radio._cad_event.set()
+
+    radio.lora.setCad.side_effect = _fire
+
+
+# ---------------------------------------------------------------------------
 # Mock builders
 # ---------------------------------------------------------------------------
 
@@ -680,22 +707,7 @@ class TestCADAndLBT:
     """Channel Activity Detection and Listen-Before-Talk backoff."""
 
     def _arm_cad_event(self, radio, detected: bool):
-        """Arm the CAD completion IRQ to fire once the driver starts CAD.
-
-        perform_cad() clears _cad_event during setup, so a result armed on a
-        timer can be wiped before the driver ever waits on it. Firing from
-        setCad() mirrors the hardware -- the IRQ cannot arrive before CAD is
-        running -- and keeps these tests independent of machine speed.
-        """
-
-        def _fire(*_args, **_kwargs):
-            radio._last_cad_irq_status = (
-                IRQ_CAD_DONE | IRQ_CAD_DETECTED if detected else IRQ_CAD_DONE
-            )
-            radio._last_cad_detected = detected
-            radio._cad_event.set()
-
-        radio.lora.setCad.side_effect = _fire
+        arm_cad_completion(radio, detected=detected)
 
     async def test_perform_cad_channel_clear_returns_false(self, radio):
         self._arm_cad_event(radio, detected=False)
@@ -1415,16 +1427,16 @@ class TestEventOrdering:
         radio._cad_event.set()
         radio._last_cad_detected = True
 
-        # New CAD fires with detected=False
-        async def _new_cad():
-            await asyncio.sleep(0.01)
-            radio._last_cad_irq_status = IRQ_CAD_DONE
-            radio._last_cad_detected = False
-            radio._cad_event.set()
-
-        asyncio.get_running_loop().create_task(_new_cad())
+        # New CAD completes with detected=False
+        arm_cad_completion(radio, detected=False)
+        started = time.monotonic()
         result = await radio.perform_cad(timeout=1.0)
+        elapsed = time.monotonic() - started
         assert result is False, "Stale 'detected' state must not leak"
+        assert elapsed < 0.5, (
+            "perform_cad() fell through to its timeout instead of consuming "
+            "the CAD completion, so the stale-state path went untested"
+        )
 
     async def test_cad_event_cleared_at_start_of_cad_operation(self, radio, mock_lora):
         """Verify CAD operation clears the event before starting."""
@@ -2220,16 +2232,10 @@ class TestFIFOCorruptionRace:
                     "perform_cad() restored RX_CONTINUOUS before setTx()"
                 )
 
-        async def _complete_cad_clear(delay: float = 0.02):
-            await asyncio.sleep(delay)
-            radio._last_cad_irq_status = IRQ_CAD_DONE
-            radio._last_cad_detected = False
-            radio._cad_event.set()
-
         mock_lora.setTx.side_effect = _track_setTx
         mock_lora.request.side_effect = _track_request
 
-        asyncio.get_running_loop().create_task(_complete_cad_clear())
+        arm_cad_completion(radio, detected=False)
 
         radio._wait_for_transmission_complete = AsyncMock(return_value=True)
         radio._finalize_transmission = MagicMock()
@@ -2442,16 +2448,16 @@ class TestCoverageGapBranches:
     async def test_perform_cad_clears_existing_irq_before_operation(
         self, radio, mock_lora
     ):
-        async def _fire_event():
-            await asyncio.sleep(0.01)
-            radio._last_cad_irq_status = IRQ_CAD_DONE
-            radio._last_cad_detected = False
-            radio._cad_event.set()
-
         mock_lora.getIrqStatus.side_effect = [0x0010, 0x0000]
-        asyncio.get_running_loop().create_task(_fire_event())
+        arm_cad_completion(radio, detected=False)
+        started = time.monotonic()
         result = await radio.perform_cad(timeout=1.0)
+        elapsed = time.monotonic() - started
         assert result is False
+        assert elapsed < 0.5, (
+            "perform_cad() timed out instead of completing, so the existing-IRQ "
+            "clear was not verified against a real CAD operation"
+        )
         assert any(c.args == (0x0010,) for c in mock_lora.clearIrqStatus.call_args_list)
 
     async def test_perform_cad_warns_when_irq_pin_stays_high(
@@ -2468,16 +2474,9 @@ class TestCoverageGapBranches:
     async def test_perform_cad_success_clears_nonzero_current_irq(
         self, radio, mock_lora
     ):
-        def _fire(*_args, **_kwargs):
-            # Fire from setCad() so the result survives perform_cad()'s
-            # setup-time _cad_event.clear(); see _arm_cad_event above.
-            radio._last_cad_irq_status = IRQ_CAD_DONE
-            radio._last_cad_detected = True
-            radio._cad_event.set()
-
         # existing_irq=0, current_irq(after completion)=0x0020
         mock_lora.getIrqStatus.side_effect = [0, 0x0020]
-        mock_lora.setCad.side_effect = _fire
+        arm_cad_completion(radio, detected=True, irq_status=IRQ_CAD_DONE)
         assert await radio.perform_cad(timeout=1.0) is True
         assert any(c.args == (0x0020,) for c in mock_lora.clearIrqStatus.call_args_list)
 


### PR DESCRIPTION
Nothing checks pull requests right now — the publish workflow only runs the tests on release.

This adds a PR Checks workflow following the one in openhop_repeater, with one difference: the tests run on 3.9 through 3.12, since core supports all four.

Three things had to be fixed to get it green:

- Four CAD tests were already failing on dev. They set the CAD event on a timer, but `perform_cad` clears that event while it sets up, so the result got wiped and the call fell through to its timeout. They now fire from `setCad`, which is when the real interrupt would arrive. Three more tests had the same problem and were passing without actually testing anything.
- The test jobs installed `.[dev]`, which pins black, and black no longer supports 3.9 — so that job could never have installed. There is now a `[test]` extra with just what the tests need. The publish workflow had the same problem, so that is fixed here too.
- The flake8 settings in `pyproject.toml` were never being read, and had drifted from the ones actually in use. Moved to `.flake8`.

Also switched on the pytest pre-commit hook that was commented out.

1605 tests pass locally and pre-commit is clean. The 3.9 job has only been checked by resolving its dependencies, not on a real runner yet.