### PR TITLE
fix(dispatcher): apply default path hash mode to direct origins too

### DIFF
--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -718,9 +718,13 @@ class Dispatcher:
         """Apply dispatcher default path hash mode if set and packet is eligible."""
         if self.path_hash_mode is None:
             return
-        route_type = pkt.get_route_type()
-        if route_type not in (ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD):
-            return
+        # Route type deliberately does not gate the default: locally
+        # originated DIRECT sends (companion DMs, zero-hop server replies)
+        # need the node width just like flood origins, otherwise they leave
+        # with a 1-byte path hash and analyzers attribute the node as
+        # 1-byte. Forwarded packets carry hops (path_hash_count != 0) and
+        # pre-widthed packets carry the _path_hash_mode_applied marker, so
+        # both stay untouched.
         if pkt.get_path_hash_count() != 0:
             return
         if getattr(pkt, "_path_hash_mode_applied", False):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -562,6 +562,34 @@ class TestDispatcherSendPacket:
         assert path_len_byte == 0x40
 
     @pytest.mark.asyncio
+    async def test_default_path_hash_mode_applied_to_direct_origin(self, dispatcher):
+        """Zero-hop DIRECT origins get the node default width too, not only floods.
+
+        A locally originated direct send (companion DM, a server reply built
+        without a request width to mirror) used to leave with a 1-byte path
+        hash regardless of the configured default. Analyzers attribute hash
+        width from observed origin packets, so a node configured for 2-byte
+        hashes was flagged as 1-byte on the map. The zero-hop guard and the
+        ``_path_hash_mode_applied`` marker already protect forwarded and
+        pre-widthed packets, so route type must not gate the default.
+        """
+        from openhop_core.protocol.constants import PH_TYPE_SHIFT
+
+        dispatcher.set_default_path_hash_mode(1)  # 2-byte hashes
+        pkt = Packet()
+        pkt.header = (1 << 6) | (PAYLOAD_TYPE_TXT_MSG << PH_TYPE_SHIFT) | ROUTE_TYPE_DIRECT
+        pkt.path_len = 0
+        pkt.path = bytearray()
+        pkt.payload = bytearray(b"direct_payload")
+        pkt.payload_len = len(pkt.payload)
+
+        await dispatcher.send_packet(pkt)
+
+        raw = dispatcher.radio.tx_data
+        assert raw is not None
+        assert raw[1] == 0x40
+
+    @pytest.mark.asyncio
     async def test_path_hash_mode_not_overwritten_when_companion_applied(self, dispatcher):
         """Packet with _path_hash_mode_applied is not overwritten by dispatcher default."""
         from openhop_core.protocol.constants import PH_TYPE_SHIFT


### PR DESCRIPTION
## Summary

`_apply_default_path_hash_mode` only applied the configured default width to flood routes. Locally originated **DIRECT** sends — companion DMs, zero-hop server replies built without a request width to mirror — left with a 1-byte path hash regardless of `set_default_path_hash_mode(...)`.

The practical impact is on attribution: community analyzers derive a node's hash width from observed origin packets, so a node configured for 2-byte hashes gets flagged as 1-byte on the map whenever its direct traffic is what observers see.

## Change

Drop the route-type gate. The two existing protections already cover everything that must stay untouched:
- forwarded packets carry hops → `path_hash_count() != 0` guard,
- pre-widthed packets (companion-applied, or server replies mirroring a request width) carry the `_path_hash_mode_applied` marker — the existing `test_server_reply_width_survives_to_the_wire` still passes unchanged.

## Evidence

Reproduced and verified on a live mesh (Czech community mesh, 869.432 MHz): with default mode 1, DIRECT origins left with `path_len` byte `0x00`; after this change the same sends leave as `0x40`, and analyzer attribution for the node flipped from 1-byte to 2-byte. We have been running this patch in production on two observer/repeater nodes since 2026-08-23.

## Tests

- new: `test_default_path_hash_mode_applied_to_direct_origin` (mirrors the flood test)
- `python -m pytest -q tests/test_dispatcher.py` — 65 passed
- black / isort / flake8 per `.pre-commit-config.yaml` — clean on changed files