### PR TITLE
fix: restore Python 3.9 and repository test gates

### DIFF
--- a/src/openhop_core/async_primitives.py
+++ b/src/openhop_core/async_primitives.py
@@ -1,0 +1,105 @@
+"""Async primitives that can be constructed before an event loop exists.
+
+Python 3.9 binds ``asyncio`` locks and events during construction. Core objects
+are often assembled synchronously and used later by an application event loop,
+so these wrappers defer creation of the real primitive until first async use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Optional, Type
+
+
+class LazyAsyncLock:
+    """An ``asyncio.Lock`` compatible wrapper with deferred loop binding."""
+
+    def __init__(self) -> None:
+        self._lock: Optional[asyncio.Lock] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._guard = threading.Lock()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        with self._guard:
+            if self._lock is None:
+                self._lock = asyncio.Lock()
+                self._loop = loop
+            elif self._loop is not loop:
+                if self._lock.locked():
+                    raise RuntimeError("async lock is active on a different event loop")
+                self._lock = asyncio.Lock()
+                self._loop = loop
+            return self._lock
+
+    async def acquire(self) -> bool:
+        return await self._get_lock().acquire()
+
+    def release(self) -> None:
+        with self._guard:
+            lock = self._lock
+        if lock is None:
+            raise RuntimeError("Lock is not acquired")
+        lock.release()
+
+    def locked(self) -> bool:
+        with self._guard:
+            return self._lock is not None and self._lock.locked()
+
+    async def __aenter__(self) -> "LazyAsyncLock":
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.release()
+
+
+class LazyAsyncEvent:
+    """An ``asyncio.Event`` compatible wrapper with deferred loop binding."""
+
+    def __init__(self) -> None:
+        self._event: Optional[asyncio.Event] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._flag = False
+        self._guard = threading.Lock()
+
+    def _get_event(self) -> asyncio.Event:
+        loop = asyncio.get_running_loop()
+        with self._guard:
+            if self._event is None or self._loop is not loop:
+                self._event = asyncio.Event()
+                self._loop = loop
+            if self._flag:
+                self._event.set()
+            else:
+                self._event.clear()
+            return self._event
+
+    def set(self) -> None:
+        with self._guard:
+            self._flag = True
+            event = self._event
+        if event is not None:
+            event.set()
+
+    def clear(self) -> None:
+        with self._guard:
+            self._flag = False
+            event = self._event
+        if event is not None:
+            event.clear()
+
+    def is_set(self) -> bool:
+        with self._guard:
+            return self._flag
+
+    async def wait(self) -> bool:
+        await self._get_event().wait()
+        return True

--- a/src/openhop_core/companion/base_support.py
+++ b/src/openhop_core/companion/base_support.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict
 from typing import Any, Optional
 
+from ..async_primitives import LazyAsyncEvent
 from ..protocol.constants import (
     ADVERT_FLAG_IS_CHAT_NODE,
     ADVERT_FLAG_IS_REPEATER,
@@ -91,7 +92,7 @@ class ResponseWaiter:
     """Helper for awaiting async protocol/login responses."""
 
     def __init__(self) -> None:
-        self.event = asyncio.Event()
+        self.event = LazyAsyncEvent()
         self.data: dict = {"success": False, "text": None, "parsed": {}}
 
     def callback(

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -1213,8 +1213,9 @@ class SX1262Radio(LoRaRadio):
         self._rx_activity_at = 0.0
         self._rx_header_at = 0.0
 
+        lbt_elapsed_ms = (time.monotonic() - lbt_started) * 1000
         logger.debug(
-            f"[LBT] Summary: outcome={outcome} elapsed={(time.monotonic() - lbt_started) * 1000:.0f}ms "
+            f"[LBT] Summary: outcome={outcome} elapsed={lbt_elapsed_ms:.0f}ms "
             f"latch_defers={latch_defers} cad_checks={cad_checks} "
             f"backoff_total={sum(lbt_backoff_delays):.0f}ms"
         )
@@ -1298,7 +1299,9 @@ class SX1262Radio(LoRaRadio):
             busy_timeout += 1
 
         if self.lora.busyCheck():
-            logger.error("[TX] Radio stayed busy after TX command - transmission may not have started")
+            logger.error(
+                "[TX] Radio stayed busy after TX command - transmission may not have started"
+            )
             return False
 
         # Check initial interrupt status immediately after TX command
@@ -1850,13 +1853,19 @@ class SX1262Radio(LoRaRadio):
         return symbol_map[cad_symbol_num]
 
     def _max_reception_seconds(self) -> float:
-        """Worst-case max-size packet airtime + 50%, once a header is seen (MeshCore: _maxPayloadMillis)."""
+        """Return max packet airtime plus 50% after header detection.
+
+        This mirrors MeshCore's ``_maxPayloadMillis`` reception bound.
+        """
         final_timeout_ms, _ = self._calculate_tx_timeout(255)
         # _calculate_tx_timeout returns airtime + 1000 ms margin.
         return max(0.5, (final_timeout_ms - 1000) * 1.5 / 1000.0)
 
     def _max_preamble_seconds(self) -> float:
-        """Preamble-to-header-valid latency bound, recomputed live from SF/BW/CR (MeshCore: _preambleMillis)."""
+        """Return the live SF/BW/CR preamble-to-header latency bound.
+
+        This mirrors MeshCore's ``_preambleMillis`` reception bound.
+        """
         preamble_only_ms = calculate_lora_airtime_ms(
             0, self.spreading_factor, int(self.bandwidth), self.coding_rate, self.preamble_length
         )

--- a/src/openhop_core/hardware/sx1262_wrapper.py
+++ b/src/openhop_core/hardware/sx1262_wrapper.py
@@ -10,6 +10,7 @@ import random
 import time
 from typing import Optional, Union
 
+from ..async_primitives import LazyAsyncEvent, LazyAsyncLock
 from ..protocol.packet_utils import calculate_lora_airtime_ms, coding_rate_denominator
 from .base import LoRaRadio
 from .gpio_manager import GPIOPinManager
@@ -166,8 +167,8 @@ class SX1262Radio(LoRaRadio):
         self.last_snr: float = 0.0
         self.last_signal_rssi: int = -99
         self._initialized = False
-        self._rx_lock = asyncio.Lock()
-        self._tx_lock = asyncio.Lock()
+        self._rx_lock = LazyAsyncLock()
+        self._tx_lock = LazyAsyncLock()
 
         # GPIO management: prefer an explicitly provided manager (multi-CH341),
         # else a process-default external adapter manager, else a private
@@ -207,9 +208,9 @@ class SX1262Radio(LoRaRadio):
         self._rxled_pin_setup = False
         self._en_pins_setup = False
 
-        self._tx_done_event = asyncio.Event()
-        self._rx_done_event = asyncio.Event()
-        self._cad_event = asyncio.Event()
+        self._tx_done_event = LazyAsyncEvent()
+        self._rx_done_event = LazyAsyncEvent()
+        self._cad_event = LazyAsyncEvent()
         self._pending_rx_irq_status = 0
 
         # Store last IRQ status for background task

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -39,6 +39,7 @@ import threading
 import time
 from typing import Callable, Optional
 
+from ..async_primitives import LazyAsyncLock
 from .protocol_constants import (
     CMD_AUTH,
     CMD_AUTH_OK,
@@ -171,7 +172,7 @@ class TCPLoRaRadio(_RadioBase):
         self._response_lock = threading.Lock()
 
         # TX lock
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock = LazyAsyncLock()
 
         # Stats
         self._tx_count = 0

--- a/src/openhop_core/hardware/tcp_radio.py
+++ b/src/openhop_core/hardware/tcp_radio.py
@@ -147,7 +147,7 @@ class TCPLoRaRadio(_RadioBase):
         # Serialize command/response transactions. Multiple callers can wait
         # for the same response command (notably consecutive CAD updates), and
         # the response-event map supports only one waiter per command byte.
-        self._command_lock = asyncio.Lock()
+        self._command_lock = LazyAsyncLock()
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); read by _reopen_socket

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -40,6 +40,7 @@ from typing import Callable, Optional
 import serial
 from serial.tools import list_ports
 
+from ..async_primitives import LazyAsyncLock
 from .protocol_constants import (
     CMD_CAD_PARAMS_RESP,
     CMD_CAD_REQUEST,
@@ -178,7 +179,7 @@ class USBLoRaRadio(_RadioBase):
         self._custom_cad_symbol_num: Optional[int] = None
 
         # TX lock to serialize transmissions (matches SX1262Radio)
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock = LazyAsyncLock()
 
         # Stats
         self._tx_count = 0

--- a/src/openhop_core/hardware/usb_radio.py
+++ b/src/openhop_core/hardware/usb_radio.py
@@ -168,7 +168,7 @@ class USBLoRaRadio(_RadioBase):
         # CAD thresholds and symbol count back-to-back, and both commands wait
         # for CMD_CAD_PARAMS_RESP. Without serialization the second waiter
         # replaces the first entry in _response_events and one update times out.
-        self._command_lock = asyncio.Lock()
+        self._command_lock = LazyAsyncLock()
 
         # Custom CAD thresholds. Set lazily by set_custom_cad_thresholds()
         # or perform_cad(det_peak=..., det_min=...); kept in attributes from

--- a/src/openhop_core/hardware/wsradio.py
+++ b/src/openhop_core/hardware/wsradio.py
@@ -6,6 +6,7 @@ import time
 import websockets
 from websockets.exceptions import ConnectionClosed
 
+from ..async_primitives import LazyAsyncLock
 from .base import LoRaRadio
 
 logger = logging.getLogger("WsRadio")
@@ -20,8 +21,8 @@ class WsRadio(LoRaRadio):
         self._connected = False
         self._last_tx_data = None  # Stores last transmitted packet
         self._last_tx_time = 0.0
-        self._connection_lock = asyncio.Lock()  # Prevent concurrent connection attempts
-        self._recv_lock = asyncio.Lock()  # Prevent concurrent recv calls
+        self._connection_lock = LazyAsyncLock()  # Prevent concurrent connection attempts
+        self._recv_lock = LazyAsyncLock()  # Prevent concurrent recv calls
         self._reconnect_delay = 1.0  # Start with 1 second
         self._max_reconnect_delay = 30.0  # Max 30 seconds
         self._timeout = timeout

--- a/src/openhop_core/node/dispatcher.py
+++ b/src/openhop_core/node/dispatcher.py
@@ -8,6 +8,7 @@ import random
 import time
 from typing import Any, Awaitable, Callable, List, Optional
 
+from ..async_primitives import LazyAsyncLock
 from ..protocol import Packet
 from ..protocol.constants import (  # Payload types
     MAX_PATH_SIZE,
@@ -193,7 +194,7 @@ class Dispatcher:
         self.dedupe_enabled = dedupe_enabled
 
         # Simple TX lock to prevent concurrent transmissions
-        self._tx_lock = asyncio.Lock()
+        self._tx_lock = LazyAsyncLock()
 
         # Use provided packet filter or create default
         if packet_filter is not None:

--- a/tests/test_async_primitives.py
+++ b/tests/test_async_primitives.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+
+from openhop_core.async_primitives import LazyAsyncEvent, LazyAsyncLock
+
+
+def test_lazy_async_primitives_construct_without_current_event_loop():
+    lock = LazyAsyncLock()
+    event = LazyAsyncEvent()
+
+    assert lock.locked() is False
+    assert event.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_lazy_async_lock_serializes_waiters():
+    lock = LazyAsyncLock()
+    entered = []
+
+    async def worker(value):
+        async with lock:
+            entered.append(value)
+            await asyncio.sleep(0)
+
+    await asyncio.gather(worker(1), worker(2))
+
+    assert entered == [1, 2]
+    assert lock.locked() is False
+
+
+@pytest.mark.asyncio
+async def test_lazy_async_event_preserves_pre_loop_state_and_wakes_waiter():
+    event = LazyAsyncEvent()
+    event.set()
+
+    assert await asyncio.wait_for(event.wait(), timeout=0.1) is True
+
+    event.clear()
+    waiter = asyncio.create_task(event.wait())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    event.set()
+
+    assert await asyncio.wait_for(waiter, timeout=0.1) is True


### PR DESCRIPTION
## Summary

Fix two failures exposed by the PR checks added in `2270cb8` (`ci(github): gate pull requests on pre-commit and the test matrix`):

- defer event-loop binding for async locks/events constructed before an application loop exists;
- apply the lazy primitives to Dispatcher, SX1262, TCP/USB modem, WebSocket radio, and Companion pending-response state;
- include the command-serialization locks now present in the modem transports;
- preserve normal `async with`, `locked()`, `set()`, `clear()`, `is_set()`, and `wait()` behavior;
- add focused lazy lock/event regression coverage;
- format the current SX1262 LBT code so Black and flake8 pass repository-wide.

## Actual cause

This was not caused by #112. #112 is only part of the current `dev` base.

The Python 3.9 incompatibility is older:

- `abb64590` added the constructor-time Dispatcher TX lock;
- `94ec988e` already contained constructor-time SX1262 async locks/events;
- similar constructor-time locks were subsequently used by other radio and Companion objects.

Python 3.9 binds these primitives during construction and raises when no current event loop exists. Commit `2270cb8` did not introduce that runtime bug; it exposed it by adding the Python 3.9 PR test matrix. The modem command locks now on `dev` use the same existing pattern and are included here so the complete current tree passes.

The pre-commit formatting failure came from SX1262 LBT changes merged through PR #116 in `4002c44`, specifically overlong lines introduced by `fb7d0ed` and `be75950`.

## Base

This branch is based on current `dev` at `5bdea19`. That commit includes #112, but #112 is not identified as the cause of these failures.

## Verification

- Full Python 3.9 test suite passed.
- Full Python 3.12 pre-commit gate passed, including pytest.
- GitHub tests passed on Python 3.9, 3.10, 3.11, and 3.12.
- GitHub pre-commit passed.
- Black, isort, and flake8 passed.
- `git diff --check` passed.
